### PR TITLE
fix: README status wording diverges from the compact-paper ledger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Observer Patch Holography: An Observer-Centric Approach to Fundamental Physics
 
-> > OPH is an observer-centric framework for fundamental physics. In the current quantitative implementation it uses two external continuous inputs (pixel area and screen capacity) together with structural axioms and explicit scaling/regularity premises. OPH develops a conditional scaling-limit gravity branch, conditional compact gauge reconstruction with Standard Model closure under extended MAR, and a quantitative program whose outputs are separated into calibration checks, a supplement-backed Higgs/top branch that adds no further continuous fit once the gauge trajectory is fixed, and weaker phenomenological continuations. The Standard Model and general relativity emerge as effective sectors of the underlying structure, while the string-theoretic worldsheet bridge remains continuation-level in the current program.
+> OPH is an observer-centric framework for fundamental physics. In the current quantitative implementation it uses two external continuous inputs (pixel area and screen capacity) together with structural axioms and explicit scaling/regularity premises. OPH develops a conditional scaling-limit gravity branch, conditional compact gauge reconstruction with Standard Model closure under extended MAR, and a quantitative program whose outputs are separated into calibration checks, a supplement-backed Higgs/top branch that adds no further continuous fit once the gauge trajectory is fixed, and weaker phenomenological continuations. The Standard Model and general relativity emerge as effective sectors of the underlying structure, while the string-theoretic worldsheet bridge remains continuation-level in the current program.
 
 > **Status disclaimer:** OPH is an active research program and not yet fully proven. Several derivations remain incomplete, some proofs currently exist only as sketches, and certain auxiliary assumptions still need to be removed. The framework should therefore be regarded as under active development.
 
@@ -185,7 +185,7 @@ The following infographic summarizes the current OPH reconstruction program from
 
 ## The Fundamental Parameters
 
-Our universe is currently described in the quantitative implementation by exactly **two externally fixed fundamental inputs**:
+Our universe is characterized by exactly **two externally fixed fundamental parameters**:
 
 ### 1. Pixel Area: $a_{\text{cell}} \approx 1.63 \, \ell_P^2$
 


### PR DESCRIPTION
## README status wording diverges from the compact-paper ledger

### Category

Inconsistent status labels, reproducibility overclaim.

### Description

The README currently compresses several claim tiers into stronger wording than the repo's own authoritative ledger supports. In [README.md](https://github.com/muellerberndt/observer-patch-holography/blob/main/README.md#L3), string/worldsheet material is presented alongside the main effective sectors, but the compact paper classifies that material as deferred continuation-level work in [the main paper](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex#L58) and the README matrix says the same in [L255](https://github.com/muellerberndt/observer-patch-holography/blob/main/README.md#L255). The section beginning at [L186](https://github.com/muellerberndt/observer-patch-holography/blob/main/README.md#L186) also calls `P` and `N_scr` "exactly two fundamental parameters," while the compact paper frames them as two external continuous inputs of the current quantitative implementation in [the main paper](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex#L42). Finally, [README.md:184](https://github.com/muellerberndt/observer-patch-holography/blob/main/README.md#L184) promises "a full audit of every constant," while the compact paper notes that a fully reproducible numerical audit still depends on supplement conventions in [the main paper:L1718](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex#L1718).

People will question whether the repo agrees with itself about what is recovered core, what is continuation-level, and what is already fully reproducible. This is a positioning problem, not a request to weaken the theory. The fix should be minimal: keep the current framing, but patch the few phrases that overrun the compact-paper ledger.
