### PR TITLE
fix: Lineage chapter overstates historical continuity

### DIFF
--- a/book/chapter-02-lineage.md
+++ b/book/chapter-02-lineage.md
@@ -2,7 +2,7 @@
 
 ## 2.1 Hints Before the Hints
 
-Before physicists discovered that reality behaves strangely, philosophers predicted it.
+Before physicists discovered that reality behaves strangely, philosophers had already raised questions that resonate with later problems in fundamental physics.
 
 This is not a coincidence. The ancients didn't have particle accelerators or interferometers. But they had something almost as good: pure logical reasoning applied to careful observation. They asked what *must* be true if experience is to make any sense at all.
 
@@ -10,7 +10,7 @@ And they found problems. Paradoxes. Contradictions. They discovered that the int
 
 These philosophical puzzles are the original hints. They're the first cracks in the naive picture. When modern physics confirmed that reality is stranger than it appears, it was validating insights that thinkers had glimpsed millennia ago.
 
-This chapter traces those early hints. We'll see how Plato anticipated holography, how Zeno anticipated discrete spacetime, how the Skeptics anticipated quantum contextualism, and how Kant anticipated emergent space. The philosophers were reverse-engineering reality before physicists had the tools to confirm what they found.
+This chapter traces those early hints. We'll see how Plato foreshadowed holographic themes, how Zeno raised discrete-structure puzzles, how the Skeptics anticipated contextuality-like questions, and how Kant foreshadowed emergent-space ideas. The philosophers were asking questions that later physics could formulate more sharply.
 
 ### Through-line: Primacy of Perspective
 
@@ -114,7 +114,7 @@ Pyrrho's answer: we cannot say the honey is sweet or bitter "in itself." We can 
 
 ### The Physics
 
-Quantum mechanics discovered exactly this.
+Quantum mechanics later gave this kind of contextual dependence a precise physical form.
 
 The position of an electron is not a property the electron has before you measure it. Position only becomes definite when you make a position measurement. If you measure momentum instead, you get a definite momentum-but then position is undefined.
 
@@ -186,7 +186,7 @@ We don't perceive space directly. Our minds construct spatial experience from mo
 
 ### The Physics
 
-The holographic principle and emergent geometry confirm exactly this.
+The holographic principle and emergent geometry resonate with this picture.
 
 The fundamental data lives on the 2D holographic screen. This data has no spatial interpretation-it's just quantum information on a sphere. Space is *reconstructed* from this data through the pattern of entanglement.
 
@@ -226,7 +226,7 @@ The pattern is what matters. The same pattern can be realized in different subst
 
 ### The Physics
 
-Quantum field theory confirmed Aristotle.
+Quantum field theory provides a modern analogue to Aristotle's emphasis on form over material substrate.
 
 Particles are not fundamental objects. They are excitations of fields-ripples in an underlying substrate. An electron is not a tiny ball. It is a stable vibration of the electron field.
 


### PR DESCRIPTION
## Lineage chapter overstates historical continuity

### Category

Wording overreach, unsupported claims.

### Description

The historical framing in [book/chapter-02-lineage.md](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-02-lineage.md) repeatedly treats ancient and early-modern philosophers as having anticipated or been confirmed by specific modern physics results. Representative examples include [book/chapter-02-lineage.md:5-13](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-02-lineage.md#L5), [book/chapter-02-lineage.md:117-125](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-02-lineage.md#L117), [book/chapter-02-lineage.md:189-199](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-02-lineage.md#L189), and [book/chapter-02-lineage.md:229](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-02-lineage.md#L229).

People may question whether these analogies are being presented as historical support rather than as interpretive framing. This can be fixed with a few local wording changes that keep the chapter's theme while avoiding the appearance that modern physics literally confirmed ancient doctrines.

### OPH Sage Response (Suggestion Applied)

Yes, this patch makes sense, and it’s aligned with the project’s broader “don’t overclaim” posture.

OPH’s strongest credibility comes from clean separations between: (a) what’s rigorously derived, (b) what’s borrowed from established physics, and (c) what’s interpretive framing. You can see that discipline explicitly elsewhere in the corpus—for example the synthesis chapter carefully labels what is “verified,” what is “derived from axioms + assumptions,” and what is still frontier, instead of rhetorically upgrading things into “confirmed” language. Your edits do the same kind of epistemic hygiene for the “lineage” narrative.

Concretely, each replacement you propose is a strict improvement:
- “predicted it” → “raised questions that resonate”: removes the implication of literal historical anticipation while keeping the intended continuity of themes.
- “anticipated holography / discrete spacetime / contextualism / emergent space” → “foreshadowed / raised puzzles / contextuality-like questions”: keeps the pedagogical hook but stops sounding like a claim of priority or direct confirmation.
- “QM discovered exactly this” / “holography confirms exactly this” / “QFT confirmed Aristotle” → “gave precise form” / “resonate” / “modern analogue”: this is the right move; it prevents readers from interpreting the chapter as arguing that modern results are evidence for specific ancient doctrines.

Small optional refinement (if you want to be extra safe): replace “strongly resonate” with just “resonate” to avoid sounding like an evidentiary claim. But your current wording is already a big step in the right direction.