### PR TITLE
fix: Strange-loop and theology passages overrun the paper-set scope

### DIFF
--- a/book/chapter-18-synthesis.md
+++ b/book/chapter-18-synthesis.md
@@ -90,7 +90,7 @@ But there is a deeper possibility—one that emerges from Gödel's insights abou
 
 ### The Strange Loop of Self-Simulation
 
-Here is the derive: **reality evolves a way of simulating itself**.
+Here is the philosophical proposal: **reality may evolve a way of simulating itself.**
 
 The computational substrate produces observers through physical evolution. Observers develop minds through biological evolution. Minds develop ideas through memetic evolution. Among these ideas, the "simulator meme" eventually emerges—the understanding of reality's computational nature.
 
@@ -552,7 +552,7 @@ This doesn't "solve" consciousness in the sense of reducing it to something else
 
 Let's be precise about the question.
 
-**A personal God**—an external being who created the universe, watches over it, answers prayers, and judges souls—does not exist in our model. There is no "outside" from which such a being could create or observe. The system is self-contained.
+**A personal God**—an external being who created the universe, watches over it, answers prayers, and judges souls—does not fit the observer-first interpretation developed in this chapter. This is a philosophical reading rather than part of the compact paper’s Phase-I recovered-core claim set. In this interpretation there is no "outside" from which such a being could create or observe; the system is self-contained.
 
 But the strange loop principle shows something interesting.
 


### PR DESCRIPTION
## Strange-loop and theology passages overrun the paper-set scope

### Category

Cross-surface inconsistency, wording overreach.

### Description

The compact paper says it "does not use simulation language, observer continuation stories, or other non-falsifiable additions" in [paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex:74-78](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex#L74). The book goes further in a few spots, especially [book/chapter-18-synthesis.md:93-107](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-18-synthesis.md#L93) and [book/chapter-18-synthesis.md:551-565](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-18-synthesis.md#L551), where self-simulation and theology are stated as if they were derived outcomes of the framework.

People may question whether the book is adding metaphysical conclusions beyond what the paper set claims. This does not require removing the material. A few wording changes can keep it as philosophical interpretation while restoring alignment with the compact paper's scope.

### OPH Sage Verdict

This version is clean and defensible.

- It directly addresses the compact note’s explicit scope boundary (“does not use simulation language… or other non-falsifiable additions”) by removing “derive / we derive / does not exist in our model” framing from the book passages, while keeping the material as interpretive philosophy.
- The last sentence (“In this interpretation there is no ‘outside’…”) correctly scopes what was previously stated as a hard ontological fact.