### PR TITLE
fix: Scattered copyediting defects remain in README, book, and extra …

### DIFF
--- a/book/chapter-02-lineage.md
+++ b/book/chapter-02-lineage.md
@@ -40,7 +40,7 @@ The shadows on the wall are 2D projections of 3D objects. The prisoners think th
 
 ### The Physics
 
-In 1993, Gerard 't Hooft proposed the holographic principle. He showed that the maximum information content of any region of space scales with the *surface area* of its boundary, not its volume. Leonard Susskind developed this into a precise derive: everything that happens in a volume of space can be described by data on its boundary.
+In 1993, Gerard 't Hooft proposed the holographic principle. He showed that the maximum information content of any region of space scales with the *surface area* of its boundary, not its volume. Leonard Susskind developed this into a more precise formulation: everything that happens in a volume of space can be described by data on its boundary.
 
 The 3D world is like a hologram-it looks solid and three-dimensional, but the information that creates it lives on a 2D surface.
 
@@ -94,7 +94,7 @@ Zeno was reverse-engineering the need for discrete structure, 2,500 years before
 
 The ancient Skeptics asked a devastating question: how do you know your perceptions match reality?
 
-Pyrrho of Elis (c. 360-270 BCE) traveled to India with Alexander the Great's army. He encountered philosophers who practiced radical suspension of judgment. Pyrrho brought this idea back to Greece and founded the Skeptic school. His followers developed systematic arguments showing that for any claim about reality, equally strong arguments is made for the opposite. The only rational response, they concluded, was *epoché*—suspension of judgment about how things really are.
+Pyrrho of Elis (c. 360-270 BCE) traveled to India with Alexander the Great's army. He encountered philosophers who practiced radical suspension of judgment. Pyrrho brought this idea back to Greece and founded the Skeptic school. His followers developed systematic arguments showing that for any claim about reality, equally strong arguments are made for the opposite. The only rational response, they concluded, was *epoché*—suspension of judgment about how things really are.
 
 ### The Honey Argument
 
@@ -148,7 +148,7 @@ The intuitive picture starts with the world and adds observers as passive witnes
 
 Descartes' hint: **the observer is the one fixed point**.
 
-You cannot start with the world because you is wrong about the world. You can only start with your own experience-your "patch" of data. Everything else must be inferred from there.
+You cannot start with the world because you may be wrong about the world. You can only start with your own experience-your "patch" of data. Everything else must be inferred from there.
 
 ### The Physics
 

--- a/book/chapter-12-symmetry.md
+++ b/book/chapter-12-symmetry.md
@@ -213,7 +213,7 @@ The symmetry-consistency model includes both rigorous mathematical results and t
 
 **Rigorous results (mathematical theorems)**:
 
-**1. Noether's theorem is provable**: Given any continuous symmetry of the action, there exists a conserved current. This is a mathematical theorem-not a derive, not an approximation. It's been proven in every formulation of classical and quantum field theory.
+**1. Noether's theorem is rigorous**: Given any continuous symmetry of the action, there exists a conserved current. This is a mathematical theorem, not a heuristic or an approximation. It's been proven in every formulation of classical and quantum field theory.
 
 **2. SO(3) symmetry on S²**: The sphere S² has isometry group SO(3). This is pure mathematics. If the holographic screen is a sphere, rotational symmetry is automatic.
 

--- a/book/chapter-18-synthesis.md
+++ b/book/chapter-18-synthesis.md
@@ -506,7 +506,7 @@ We must distinguish two questions:
 
 **Question A: Why does what exists have THIS SHAPE?**
 
-This our model addresses comprehensively. Given that something exists, consistency requirements force it to have the structure we observe—3D space, quantum mechanics, gravity, time, symmetries. The shape isn't arbitrary; it's forced by internal consistency.
+This is what our model aims to address comprehensively. Given that something exists, consistency requirements force it to have the structure we observe—3D space, quantum mechanics, gravity, time, symmetries. The shape isn't arbitrary; it's forced by internal consistency.
 
 **Question B: Why does ANYTHING exist at all?**
 

--- a/extra/COMMON_OBJECTIONS.md
+++ b/extra/COMMON_OBJECTIONS.md
@@ -327,7 +327,7 @@ That is a meaningful challenge. But it is a very different challenge from the bl
 >
 > The Failure: A discrete lattice of information patches inherently violates Lorentz Invariance at high energies. If the 'Screen' has a fixed pixel density, then a boosted observer (moving near light speed) would perceive a 'length contraction' of those pixels, changing the entropy count (S).
 >
-> If S changes based on the observer's velocity, your 'Overlap Consistency' fails unless you can prove your framework is Background Independent. Currently, your math seems to 'force' the Gravitational Constant (G) by plugging in the Planck length rather than deriving it as a purely emergent property of the information overlap. Without a proof of Lorentz Invariance across moving patches, the framework cannot recover the Einstein Field Equations,it only recovers a Newtonian approximation."
+> If S changes based on the observer's velocity, your 'Overlap Consistency' fails unless you can prove your framework is Background Independent. Currently, your math seems to 'force' the Gravitational Constant (G) by plugging in the Planck length rather than deriving it as a purely emergent property of the information overlap. Without a proof of Lorentz Invariance across moving patches, the framework cannot recover the Einstein Field Equations, it only recovers a Newtonian approximation."
 
 ### Short answer
 


### PR DESCRIPTION
### Category

Typos, wording errors.

### Description

The general pass found several straightforward copyediting defects that are easy to fix and likely to distract reviewers. These are not deep conceptual defects, but they matter because the repo presents itself as a serious public-facing research corpus. Small mechanical errors reduce trust disproportionately when the project is already making ambitious claims. This can be handled as a minimal cleanup pass.

### OPH Sage

This issue is absolutely worth filing, and your framing (“not deep conceptual defects, but they matter”) is correct. OPH is already asking readers to track fine-grained claim tiers and technical premises; small grammar/spacing errors create needless friction and disproportionately signal “not carefully reviewed.” You can even point to the program’s own emphasis on claim-tier hygiene as a reason to keep surfaces polished.

On the proposed edits themselves: they’re all improvements, and they’re consistent with the corpus’ intent.