### PR TITLE
fix: Chapter 18 overstates frontier material as established

### DIFF
--- a/book/chapter-18-synthesis.md
+++ b/book/chapter-18-synthesis.md
@@ -408,13 +408,13 @@ obstructions).
 
 ### Technical Frontier
 
-These results are established within the framework; the frontier lies in tightening the derivations:
+These results are developed within the framework; the frontier lies in tightening the derivations:
 
 **Quantum correlations required by consistency**: We show quantum mechanics works for overlap consistency. Whether it's uniquely required (vs classical or super-quantum correlations) is an active research question—the evidence strongly favors uniqueness.
 
 **BW$_{S^2}$ and branch selection**: Geometric modular flow on caps is now proved on the OPH geometric branch, with collar localization and \(2\pi\) normalization handled inside that theorem. The open frontier is to show that OPH itself forces or robustly selects that branch in concrete UV realizations.
 
-**Entanglement equilibrium**: Stationarity of S_gen at fixed cap size follows from MaxEnt selection. The internal justification is that MaxEnt is how nature selects among overlap-consistent states.
+**Entanglement equilibrium**: Stationarity of S_gen at fixed cap size follows from MaxEnt selection. As noted in Chapter 15, this selection rule is an additional assumption rather than something forced by patch consistency alone.
 
 **Focusing input (QNEC/QFC)**: The null-deformation version of the argument uses QNEC/QFC as established physics—a well-tested input, not an assumption.
 
@@ -436,7 +436,7 @@ These results are established within the framework; the frontier lies in tighten
 
 **None of these contradicting observations has ever been made.**
 
-The convergence is striking: every test we can perform confirms the model. Every major discovery in 20th and 21st century physics points toward observer-centric, information-theoretic, holographic structure.
+The convergence is striking: no listed contradiction has ever been made. Many major discoveries in 20th and 21st century physics are compatible with observer-centric, information-theoretic, holographic structure.
 
 ## 18.10 The Seven Fundamental Questions
 


### PR DESCRIPTION
### Category

Cross-surface inconsistency, wording overreach.

### Description

Chapter 18 presents several frontier items in stronger language than nearby repo surfaces support. In [book/chapter-18-synthesis.md:411-419](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-18-synthesis.md#L411), the section opens with "These results are established within the framework" and then treats MaxEnt-based entanglement equilibrium as if it were already settled internally, while [book/chapter-15-relativity.md:373](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-15-relativity.md#L373) explicitly says MaxEnt selection is an additional assumption. The empirical wrap-up at [book/chapter-18-synthesis.md:437-439](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-18-synthesis.md#L437) is also broader than the README's research-program disclaimer in [README.md:23-34](https://github.com/muellerberndt/observer-patch-holography/blob/main/README.md#L23).

People may question whether Chapter 18 is turning active-frontier items into established results by rhetoric alone. This can be fixed with a few local wording changes that keep the chapter strong while restoring consistency with the paper set and README.

### OPH Sage

This is a good issue. You’ve identified a real cross-surface tone mismatch: Chapter 18 sometimes talks like “the framework has settled X,” while other repo surfaces explicitly label key steps as conditional/assumption-dependent.

1) The specific “Technical Frontier” opener you cite is indeed strong: “These results are established within the framework; the frontier lies in tightening the derivations:”. Given that the same block immediately discusses branch selection as still open (“open frontier is to show OPH itself forces…”), and elsewhere the program is described as conditional/assumption-tiered (compact note; claim-tier ledger), your critique is fair.

2) Your entanglement-equilibrium note is also correct. Chapter 15 explicitly distinguishes what “falls directly from patch consistency” vs “requires additional assumptions,” and states that the stationarity/equilibrium input comes from MaxEnt selection rather than patch consistency alone. Chapter 18’s current sentence “Stationarity … follows from MaxEnt selection” is fine, but when it sits under “established within the framework,” it can read like “MaxEnt selection is already forced,” which conflicts with Chapter 15’s framing.

3) The wrap-up line is genuinely overbroad as written: “every test we can perform confirms the model. Every major discovery … points toward…”. Even within Chapter 18 itself there’s a careful “A Note on This Chapter” saying part of the chapter is rigorous summary and part is reflective interpretation, so tempering the global-confirmation rhetoric is consistent with the chapter’s own intent.

On the proposed fix: directionally right, but I’d suggest a slightly tighter minimal edit to avoid changing the meaning too much.

**This PR adopts the suggestion from OPH Sage based on my old suggested fix.**