### PR TITLE
fix: Stage-5 regression test uses a stale PDG symbol

### DIFF
--- a/code/particles/test_particle_masses_stage5.py
+++ b/code/particles/test_particle_masses_stage5.py
@@ -43,7 +43,7 @@ def main():
     pred = pm5.build_spectrum()
 
     # Reference values are *comparison only* (see PDG dict in module).
-    PDG = pm5.PDG_REFERENCE
+    PDG = pm5.PDG
 
     # Gauge + EW
     check("alpha_em_inv", pred["alpha_em_inv_at_mZrun"], PDG["alpha_em_inv"], 5e-3)  # 0.5%


### PR DESCRIPTION
The Stage-5 regression check currently crashes before running any comparisons. In [code/particles/test_particle_masses_stage5.py:46](https://github.com/muellerberndt/observer-patch-holography/blob/main/code/particles/test_particle_masses_stage5.py#L46), the test reads `pm5.PDG_REFERENCE`, but the module exports the comparison table as [code/particles/particle_masses_stage5.py:749](https://github.com/muellerberndt/observer-patch-holography/blob/main/code/particles/particle_masses_stage5.py#L749) under the name `PDG`.

Updating it resolves the error.