### PR TITLE
fix: Neutrino splitting claims overstate what the printed masses imply

### DIFF
--- a/paper/tex_fragments/SPECTRUM_DERIVATION.tex
+++ b/paper/tex_fragments/SPECTRUM_DERIVATION.tex
@@ -633,7 +633,7 @@ The hierarchy uses the same \(\varepsilon = 1/6\) suppression:
 
 \[m_{\nu_2} = \varepsilon \cdot m_{\nu_3} \approx 0.50 \text{ meV}, \quad m_{\nu_1} = \varepsilon^2 \cdot m_{\nu_3} \approx 0.084 \text{ meV}\]
 
-This yields \(\Delta m_{32}^2 \approx 9.1 \times 10^{-24} \text{ GeV}^2\) and \(\Delta m_{21}^2 \approx 2.5 \times 10^{-25} \text{ GeV}^2\), consistent with the observed atmospheric and solar mass splittings in order of magnitude.
+This yields \(\Delta m_{32}^2 \approx 9.1 \times 10^{-24} \text{ GeV}^2\) and \(\Delta m_{21}^2 \approx 2.5 \times 10^{-25} \text{ GeV}^2\). These values remain well below current direct-detection bounds, but they do not yet reproduce the observed atmospheric and solar oscillation splittings.
 
 \begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
 
@@ -708,12 +708,12 @@ Particle & OPH (GeV) & Experiment & Tier & Error Source \\
 \bottomrule\noalign{}
 \endlastfoot
 \(\nu_e\) & 8.39 × 10⁻¹⁴ & \(< 8 \times 10^{-10}\) (KATRIN) & \textbf{Prediction} & Uses second input (\(\log\dim\mathcal{H}\)), independent of \(P\). Consistent with all bounds \\
-\(\nu_\mu\) & 5.04 × 10⁻¹³ & \(< 8 \times 10^{-10}\) (KATRIN) & \textbf{Prediction} & Same; \(\Delta m_{21}^2\) consistent with solar oscillation scale in order of magnitude \\
-\(\nu_\tau\) & 3.02 × 10⁻¹² & \(< 8 \times 10^{-10}\) (KATRIN) & \textbf{Prediction} & Anchored at \(\rho_\Lambda^{1/4}\); \(\Delta m_{32}^2\) consistent with atmospheric scale \\
+\(\nu_\mu\) & 5.04 × 10⁻¹³ & \(< 8 \times 10^{-10}\) (KATRIN) & \textbf{Prediction} & Same capacity branch; below direct bounds, but not yet matched to the solar oscillation scale \\
+\(\nu_\tau\) & 3.02 × 10⁻¹² & \(< 8 \times 10^{-10}\) (KATRIN) & \textbf{Prediction} & Anchored at \(\rho_\Lambda^{1/4}\); below direct bounds, but not yet matched to the atmospheric oscillation scale \\
 \end{longtable}
 }
 
-All predictions are well below the current experimental upper bound of \(\sim 0.8\) eV \(\approx 8 \times 10^{-10}\) GeV. The predicted mass splittings are consistent with oscillation data in order of magnitude.
+All predictions are well below the current experimental upper bound of \(\sim 0.8\) eV \(\approx 8 \times 10^{-10}\) GeV. At present this branch is better described as a low-scale capacity estimate than as a quantitative fit to oscillation data.
 
 \subsubsection{10.4 Quarks}\label{104-quarks}
 
@@ -846,7 +846,7 @@ These are standard lattice QCD systematics, not limitations of the OPH framework
 
 \subsubsection{11.5 Neutrinos: No Direct Comparison Available}\label{115-neutrinos-no-direct-comparison-available}
 
-The predicted neutrino masses (\(\sim 0.08\)--\(3\) meV) are below current direct-detection sensitivity (KATRIN: \(m_\beta < 0.8\) eV) but in the right ballpark for cosmological and oscillation constraints. The predicted \(\sum m_\nu \approx 3.6\) meV is well below the cosmological bound \(\sum m_\nu < 0.12\) eV (Planck 2018).
+The predicted neutrino masses (\(\sim 0.08\)--\(3\) meV) are below current direct-detection sensitivity (KATRIN: \(m_\beta < 0.8\) eV) and well below current cosmological mass-sum bounds. The predicted \(\sum m_\nu \approx 3.6\) meV is well below the cosmological bound \(\sum m_\nu < 0.12\) eV (Planck 2018), but the simple capacity-branch hierarchy does not yet reproduce the observed oscillation splittings quantitatively.
 
 \begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
 


### PR DESCRIPTION
## Neutrino splitting claims overstate what the printed masses imply

### Category

Mathematical error, wording overreach.

### Description

The neutrino-capacity branch in [paper/tex_fragments/SPECTRUM_DERIVATION.tex:624-631](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/tex_fragments/SPECTRUM_DERIVATION.tex#L624-L631) prints `m_nu3 ≈ 3.0 meV`, `m_nu2 ≈ 0.50 meV`, and `m_nu1 ≈ 0.084 meV`. Those numbers do imply `Δm_32^2 ≈ 8.75 × 10^-24 GeV^2` and `Δm_21^2 ≈ 2.43 × 10^-25 GeV^2`, so the arithmetic itself is fine. The problem is the interpretation that follows in [paper/tex_fragments/SPECTRUM_DERIVATION.tex:631](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/tex_fragments/SPECTRUM_DERIVATION.tex#L631), [paper/tex_fragments/SPECTRUM_DERIVATION.tex:705-711](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/tex_fragments/SPECTRUM_DERIVATION.tex#L705-L711), and [paper/tex_fragments/SPECTRUM_DERIVATION.tex:844](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/tex_fragments/SPECTRUM_DERIVATION.tex#L844): these masses are described as consistent with atmospheric and solar oscillation data or at least in the right oscillation ballpark.

People may question that phrasing immediately because the printed splittings correspond to about `8.75 × 10^-6 eV^2` and `2.43 × 10^-7 eV^2`, which are roughly 300 times below the observed atmospheric and solar scales. The capacity branch can still be kept as a rough low-scale estimate tied to `rho_Lambda^(1/4)`, but it should not be described as matching oscillation data in order of magnitude.

### OPH Sage

Yes, this patch makes sense and is internally consistent with what the file currently prints.

Right now the spectrum derivation explicitly claims the capacity-branch Δm² values are “consistent with oscillation data in order of magnitude”   and repeats that in the neutrino table comments, but the printed masses (mν3 ≈ 3.0 meV, mν2 ≈ 0.50 meV, mν1 ≈ 0.084 meV) imply Δm² scales that are far below the measured solar/atmospheric splittings. Your edits remove that mismatch while keeping the two things OPH can already defend in this branch: (1) the absolute masses are far below direct bounds, and (2) the mass sum is far below cosmological bounds.

The current wording (“consistent with oscillation data in order of magnitude”) is simply false given the printed masses and implied splittings in that same document. Leaving it in creates an easy credibility hit: a careful reader will do exactly what you did and conclude “they’re overstating.” Fixing it removes a clean, avoidable contradiction in the writeup while preserving the real claim of that branch: it’s a capacity-anchored absolute mass scale, far below direct bounds and far below the cosmological sum bound. That’s already how the theory itself classifies this: the neutrino estimate is an input-dependent capacity corollary/estimate, not part of the recovered core, and “beyond the input-dependent, order-of-magnitude capacity estimate… the manuscript does not derive neutrino masses or mixings.” 

Also, the paper already contains the right rhetorical escape hatch: “No direct comparison available” and the statement that this is a low-scale estimate below sensitivity. Right now it overreaches by adding “right ballpark for… oscillation constraints”. Your patch makes that section match its own epistemic-status framing, which is exactly what makes OPH persuasive: strong where it’s strong, explicitly scoped where it’s not.