### PR TITLE
fix: Chapter 18 QCD-scale summary lags the current implementation

### DIFF
--- a/book/chapter-18-synthesis.md
+++ b/book/chapter-18-synthesis.md
@@ -354,7 +354,7 @@ These predictions have been tested experimentally or computationally:
 | Top pole mass m_t ≈ 171.1 GeV | Measured: 172.6 GeV | 0.9% low; supplement-backed D11 reconstruction with UV-synchronized transport and low-scale matching |
 | Strong coupling α_s(M_Z) ≈ 0.1183 | PDG: 0.1179 | Calibration-sector consistency check |
 | Weak mixing angle sin²θ_W ≈ 0.23119 | PDG: 0.23122 | Calibration-sector consistency check |
-| QCD scale Λ_MS ≈ 195 MeV | PDG: 213 ± 8 MeV | ~10% low (from Dynkin-index β) |
+| QCD scale Λ_MSbar^(5) ≈ 214 MeV | PDG: 213 ± 8 MeV | Calibration/downstream consistency check in the current implementation (scheme + thresholds as in the spectrum codepath) |
 
 ### Derived from Axioms + Assumptions
 


### PR DESCRIPTION
## Chapter 18 QCD-scale summary lags the current implementation

### Category

Numerical inconsistency.

### Description

The synthesis table currently lists `QCD scale Λ_MS ≈ 195 MeV` in [book/chapter-18-synthesis.md:357](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-18-synthesis.md#L357). That number matches an older `n_f = 5` edge-threshold exercise that is explicitly marked historical in [paper/tex_fragments/PAPER.tex:3862-3866](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/tex_fragments/PAPER.tex#L3862-L3866), not the current synchronized spectrum implementation. The current repo surfaces instead use the fixed-point branch summarized at [paper/tex_fragments/SPECTRUM_DERIVATION.tex:764](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/tex_fragments/SPECTRUM_DERIVATION.tex#L764), and the public predictor stores the corresponding `\Lambda_{\overline{\mathrm{MS}}}` outputs in [code/particles/oph_predict_compare.py:328-329](https://github.com/muellerberndt/observer-patch-holography/blob/main/code/particles/oph_predict_compare.py#L328-L329). On the current code path, that branch gives `\Lambda_{\overline{\mathrm{MS}}}^{(5)} \approx 0.21368 GeV` and `\Lambda_{\overline{\mathrm{MS}}}^{(3)} \approx 0.32247 GeV`.

People may question whether the synthesis chapter is summarizing the current implementation or a superseded calibration exercise. This is especially easy to attack because the table does not label the flavor scheme, so `195 MeV` reads like a direct contradiction of the current downstream hadron input.

### OPH Sage

Yes, this patch makes sense, and it’s exactly the kind of “sync hygiene” that makes OPH harder to attack.

Right now Chapter 18’s synthesis table says “QCD scale Λ_MS ≈ 195 MeV”  with no flavor scheme label. Meanwhile the current spectrum implementation is clearly using the stepped-threshold MS-bar extraction and then feeding hadrons with Λ_MSbar^(3) ≈ 0.322 GeV (and Λ_MSbar^(5) ≈ 0.211–0.214 GeV). So leaving “195 MeV” unlabelled makes it look like an inconsistency between the book’s summary and the active codepath.

Your proposed fix does two good things:
- It labels the scheme explicitly as Λ_MSbar^(5), removing ambiguity.
- It updates the number to match the current implementation’s five-flavor value (~214 MeV), aligning Chapter 18 with the current downstream hadron pipeline described in the spectrum derivation.
