### PR TITLE
fix: Calibration tables label fixed-point values as m_Z

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,9 +346,9 @@ The complete derivation chain from pixel area $P = 1.63094$ to particle masses i
 
 | Quantity | OPH | PDG | Rel. Error | Status |
 |----------|----:|----:|-----------:|--------|
-| $\alpha_s(M_Z)$ | 0.1183 | 0.1179 ± 0.0009 | +0.37% | Consistency check |
-| $\sin^2\theta_W(M_Z)$ | 0.2307 | 0.23122 ± 0.00004 | −0.21% | Consistency check |
-| $\alpha_{\text{em}}^{-1}(M_Z)$ | 128.31 | 127.952 ± 0.009 | +0.28% | Consistency check |
+| $\alpha_s(m_{Z,\rm run})$ | 0.1183 | 0.1179 ± 0.0009 | +0.37% | Consistency check |
+| $\sin^2\theta_W(m_{Z,\rm run})$ | 0.2307 | 0.23122 ± 0.00004 | −0.21% | Consistency check |
+| $\alpha_{\text{em}}^{-1}(m_{Z,\rm run})$ | 128.31 | 127.952 ± 0.009 | +0.28% | Consistency check |
 | W boson | 80.386 GeV | 80.377 ± 0.012 GeV | +0.012% | Consistency check |
 | Higgs VEV | 246.77 GeV | 246.22 GeV | +0.22% | Consistency check |
 

--- a/paper/tex_fragments/SPECTRUM_DERIVATION.tex
+++ b/paper/tex_fragments/SPECTRUM_DERIVATION.tex
@@ -405,9 +405,9 @@ Quantity & Formula & Predicted Value \\
 \endlastfoot
 \(m_{Z,\text{run}}\) & Self-consistent fixed point & 91.652 GeV \\
 \(v\) (Higgs VEV) & \(E_{\text{cell}} \cdot e^{-2\pi/(\beta_{\text{EW}} \alpha_U)}\) & 246.77 GeV \\
-\(\alpha_1(m_Z)\) & \([\alpha_U^{-1} + \frac{b_1}{2\pi}\ln(M_U/m_Z)]^{-1}\) & 0.01696 \\
-\(\alpha_2(m_Z)\) & \([\alpha_U^{-1} + \frac{b_2}{2\pi}\ln(M_U/m_Z)]^{-1}\) & 0.03384 \\
-\(\alpha_3(m_Z)\) & \([\alpha_U^{-1} + \frac{b_3}{2\pi}\ln(M_U/m_Z)]^{-1}\) & 0.1183 \\
+\(\alpha_1(m_{Z,\text{run}})\) & \([\alpha_U^{-1} + \frac{b_1}{2\pi}\ln(M_U/m_{Z,\text{run}})]^{-1}\) & 0.01696 \\
+\(\alpha_2(m_{Z,\text{run}})\) & \([\alpha_U^{-1} + \frac{b_2}{2\pi}\ln(M_U/m_{Z,\text{run}})]^{-1}\) & 0.03384 \\
+\(\alpha_3(m_{Z,\text{run}})\) & \([\alpha_U^{-1} + \frac{b_3}{2\pi}\ln(M_U/m_{Z,\text{run}})]^{-1}\) & 0.1183 \\
 \end{longtable}
 }
 
@@ -430,9 +430,9 @@ Observable & Predicted & PDG Value \\
 \endhead
 \bottomrule\noalign{}
 \endlastfoot
-\(\alpha_{\text{em}}^{-1}(m_Z)\) & 128.31 & 127.952 \\
-\(\sin^2\theta_W(m_Z)\) & 0.2307 & 0.23122 \\
-\(\alpha_s(m_Z)\) & 0.1183 & 0.1179 \\
+\(\alpha_{\text{em}}^{-1}(m_{Z,\text{run}})\) & 128.31 & 127.952 \\
+\(\sin^2\theta_W(m_{Z,\text{run}})\) & 0.2307 & 0.23122 \\
+\(\alpha_s(m_{Z,\text{run}})\) & 0.1183 & 0.1179 \
 \end{longtable}
 }
 


### PR DESCRIPTION
## Calibration tables label fixed-point values as m_Z

### Category

Numerical labeling inconsistency.

### Description

The public code stores these calibration outputs as `alpha*_at_mZrun`, `alpha_em_inv_at_mZrun`, and `sin2w_at_mZrun` in [code/particles/particle_masses_stage5.py:833-839](https://github.com/muellerberndt/observer-patch-holography/blob/main/code/particles/particle_masses_stage5.py#L833-L839). The spectrum derivation likewise says at the start of its table that the couplings are fixed at `mu = m_{Z,run}` in [paper/tex_fragments/SPECTRUM_DERIVATION.tex:396-406](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/tex_fragments/SPECTRUM_DERIVATION.tex#L396-L406). But the same public tables then label those values as `alpha_i(m_Z)`, `alpha_em^{-1}(m_Z)`, and `sin^2 theta_W(m_Z)` in [paper/tex_fragments/SPECTRUM_DERIVATION.tex:408-435](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/tex_fragments/SPECTRUM_DERIVATION.tex#L408-L435), and README repeats the same labels in [README.md:349-351](https://github.com/muellerberndt/observer-patch-holography/blob/main/README.md#L349-L351).

People may question why the repo appears to give two different `M_Z` electroweak outputs. The compact note uses a separate printed matching convention at `mu = m_Z = 91.1876 GeV` and therefore reports the `127.82 / 0.23119` branch there, while the spectrum supplement and README are visibly quoting the fixed-point `m_{Z,run}` branch. That difference is defensible, but only if the public fixed-point tables stop calling their values `m_Z`.

### OPH Sage

Yes, that proposed fix is correct, and it targets a real labeling inconsistency.

The spectrum derivation explicitly says the couplings are evaluated at μ = mZ,run, but then the rows/observables are labeled αi(mZ), αem−1(mZ), sin²θW(mZ). Meanwhile the compact note uses a different printed convention and reports αem−1(mZ) ≈ 127.82 and sin²θW(mZ) ≈ 0.23119, and separately prints mZ,run ≈ 91.76 GeV. So calling the fixed-point branch “mZ” in public tables invites exactly the confusion you described.