### PR TITLE
fix: README entanglement_first_law.py leftover

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,7 +506,6 @@ As summarized in the status matrix above, the framework derives Lorentz kinemati
 | [oph_qcd.py](code/particles/oph_qcd.py) | 4-loop MSbar QCD running and Λ extraction |
 | [oph_lattice_su3_quenched_v5.py](code/particles/oph_lattice_su3_quenched_v5.py) | Quenched Wilson SU(3) lattice for hadron mass ratios |
 | [oph_no_cheat_audit.py](code/particles/oph_no_cheat_audit.py) | Static + runtime anti-leak audit |
-| [entanglement_first_law.py](code/entanglement_first_law.py) | Verifies the entanglement first law δS = δ⟨K⟩ numerically |
 
 ### Book Chapters
 

--- a/README_FR.md
+++ b/README_FR.md
@@ -495,7 +495,6 @@ Comme résumé dans la matrice de statut plus haut, le cadre établit aujourd'hu
 | [oph_qcd.py](code/particles/oph_qcd.py) | Running QCD MSbar à 4 boucles et extraction de $\Lambda$ |
 | [oph_lattice_su3_quenched_v5.py](code/particles/oph_lattice_su3_quenched_v5.py) | Lattice SU(3) de Wilson trempé pour les ratios de masses hadroniques |
 | [oph_no_cheat_audit.py](code/particles/oph_no_cheat_audit.py) | Audit anti-fuite statique + exécution |
-| [entanglement_first_law.py](code/entanglement_first_law.py) | Vérifie numériquement la première loi d'intrication $\delta S = \delta\langle K\rangle$ |
 
 ### Chapitres du livre
 


### PR DESCRIPTION
## README links a missing entanglement-first-law script

### Category

Documentation integrity.

### Description

The English README inventory advertises a standalone script called `code/entanglement_first_law.py` in [README.md:501-509](https://github.com/muellerberndt/observer-patch-holography/blob/main/README.md#L501-L509). But the current public tree under [`code/particles/`](https://github.com/muellerberndt/observer-patch-holography/tree/main/code/particles) contains the maintained numerical scripts, and there is no `code/entanglement_first_law.py` file in the repository.

People may question whether a cited numerical verification script was removed, forgotten, or never published. That is an avoidable credibility hit because the paper set already contains an explicit appendix for the entanglement-first-law check, so the README should not point readers to a nonexistent repo artifact.