### PR TITLE
fix: Paper D10/D11 regression recomputes the expensive solve twice

### DIFF
--- a/code/particles/test_particle_masses_paper_d10_d11.py
+++ b/code/particles/test_particle_masses_paper_d10_d11.py
@@ -47,7 +47,6 @@ def main() -> None:
     d10 = mod.build_paper_d10()
     d11 = mod.integrate_d11_literal_core(d10)
     supplement = mod.infer_supplement_reconstruction(d10)
-    report = mod.build_paper_reference_report()
 
     # D10 matches the synchronized paper tables.
     assert_close("alpha_u", d10.alpha_u, 0.04112498, 1e-6)
@@ -67,9 +66,9 @@ def main() -> None:
     # Guardrail: the literal appendix path is not the same as the published
     # D11 claim set. If these gaps disappear, the matching layer has changed
     # and the test should be revisited intentionally.
-    if report["gap_mt_pole"] >= -6.0:
+    if (d11.mt_pole - mod.PAPER_D11_TARGETS["mt_pole"]) >= -6.0:
         raise AssertionError("literal D11 mt_pole unexpectedly close to paper claim")
-    if report["gap_m_h"] >= -10.0:
+    if (d11.m_h_tree - mod.PAPER_D11_TARGETS["m_h"]) >= -10.0:
         raise AssertionError("literal D11 m_H unexpectedly close to paper claim")
 
     # Inferred supplement reconstruction:


### PR DESCRIPTION
## Paper D10/D11 regression recomputes the expensive solve twice

### Category

Reproducibility and test-runtime hygiene.

### Description

The paper-driven regression already builds `d10`, `d11`, and `supplement` directly in [code/particles/test_particle_masses_paper_d10_d11.py:45-49](https://github.com/muellerberndt/observer-patch-holography/blob/main/code/particles/test_particle_masses_paper_d10_d11.py#L45-L49), but then it also calls `build_paper_reference_report()` in [code/particles/test_particle_masses_paper_d10_d11.py:50](https://github.com/muellerberndt/observer-patch-holography/blob/main/code/particles/test_particle_masses_paper_d10_d11.py#L50). That helper immediately rebuilds the same expensive objects in [code/particles/particle_masses_paper_d10_d11.py:611-635](https://github.com/muellerberndt/observer-patch-holography/blob/main/code/particles/particle_masses_paper_d10_d11.py#L611-L635), including the scanned supplement reconstruction in [code/particles/particle_masses_paper_d10_d11.py:567-608](https://github.com/muellerberndt/observer-patch-holography/blob/main/code/particles/particle_masses_paper_d10_d11.py#L567-L608). On the current repo, `python3 code/particles/test_particle_masses_paper_d10_d11.py` completed successfully but took about `1:06.62`.

People may question why a regression that checks fixed published literals is minute-scale when part of that cost comes from duplicated work inside the test itself. Removing the redundant report build keeps the same guardrail logic while making the audit path easier to run routinely.