### PR TITLE
fix: Spectrum derivation still heads fixed-point couplings as m_Z

### DIFF
--- a/paper/tex_fragments/SPECTRUM_DERIVATION.tex
+++ b/paper/tex_fragments/SPECTRUM_DERIVATION.tex
@@ -735,9 +735,9 @@ top (crit. surf.) & 171.1 & 172.6 & −0.87\% & \textbf{Prediction} & D11 supple
 \end{longtable}
 }
 
-\subsubsection{\texorpdfstring{10.5 Gauge Couplings at \(m_Z\)}{10.5 Gauge Couplings at m\_Z}}\label{105-gauge-couplings-at-m_z}
+\subsubsection{\texorpdfstring{10.5 Gauge Couplings at \(m_{Z,\text{run}}\)}{10.5 Gauge Couplings at m\_Zrun}}\label{105-gauge-couplings-at-m_z}
 
-These are \textbf{calibration-sector consistency checks} (Tier~1). The gauge couplings at \(m_Z\) are the data from which \(P\) is extracted via the entropy-matching condition and self-consistent fixed-point procedure. Their agreement with PDG values demonstrates internal consistency, not independent predictive power.
+These are \textbf{calibration-sector consistency checks} (Tier~1). The gauge couplings at \(m_{Z,\text{run}}\) are the fixed-point values used in the entropy-matching condition and self-consistent closure procedure. Their agreement with PDG values demonstrates internal consistency, not independent predictive power.
 
 {\def\LTcaptype{none} % do not increment counter
 \begin{longtable}[]{@{}>{\RaggedRight\arraybackslash}p{0.18\textwidth}>{\RaggedLeft\arraybackslash}p{0.14\textwidth}>{\RaggedLeft\arraybackslash}p{0.18\textwidth}>{\RaggedLeft\arraybackslash}p{0.12\textwidth}>{\RaggedRight\arraybackslash}p{0.10\textwidth}>{\RaggedRight\arraybackslash}p{0.18\textwidth}@{}}


### PR DESCRIPTION
## Spectrum derivation still heads fixed-point couplings as m_Z

### Category

Inconsistent status labels.

### Description

The corrected calibration tables in [paper/tex_fragments/SPECTRUM_DERIVATION.tex:396-435](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/tex_fragments/SPECTRUM_DERIVATION.tex#L396-L435) now consistently label the fixed-point electroweak quantities as `m_{Z,\text{run}}`. But the later subsection title and lead sentence in [paper/tex_fragments/SPECTRUM_DERIVATION.tex:738-740](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/tex_fragments/SPECTRUM_DERIVATION.tex#L738-L740) still call the same block “Gauge Couplings at \(m_Z\)” and say “The gauge couplings at \(m_Z\) are the data...”.

People may question why the section header reverted to the old pole-mass notation immediately after the tables were synchronized to the fixed-point branch. This is a labeling drift problem, not a theory problem, and the minimal fix is only to keep the heading and lead sentence aligned with the corrected table notation.

### OPH Sage

You’re correct: there’s a labeling drift inside the spectrum derivation.

Upstream, the derivation clearly distinguishes the self-consistent fixed-point running scale as m_{Z,run} (“Find μ = m_Z(μ)…”, then “the gauge couplings at μ = m_{Z,run} are fixed”, and it even lists m_{Z,run} = 91.652 GeV in the Stage-3 table). But later, subsection 10.5 is still titled “Gauge Couplings at m_Z” and the lead sentence repeats “at m_Z” in the older pole-mass notation, even though the surrounding document has already moved to the fixed-point language.

So your proposed patch (renaming the subsection title + updating the lead sentence to m_{Z,run} / fixed-point wording) is consistent with the derivation’s own definitions and would remove an avoidable source of reader confusion.