### PR TITLE
fix: Technical supplement still uses older fundamental-parameters fra…

### DIFF
--- a/paper/tex_fragments/TECHNICAL_SUPPLEMENT.tex
+++ b/paper/tex_fragments/TECHNICAL_SUPPLEMENT.tex
@@ -145,9 +145,9 @@ or one passes to the explicitly stated idealized recoverability limit that reduc
 EC therefore gives the kinematic block decomposition; exact Markovity is the extra state input that gives the HJPW normal form.
 
 \textbf{Remark.} Approximate recoverability gives controlled deviations from this normal form; it is not implied by EC alone. The only remaining fixed-cutoff blocker to an ordinary-group EC theorem is a genuinely noncentral 2-group defect. The later open burden is the controlled refinement or scaling regime and the modular or null-limit premises, not the finite-dimensional collar decomposition itself.
-\subsection{1.4 Fundamental Parameters}\label{14-fundamental-parameters}
+\subsection{1.4 Current Continuous Inputs}\label{14-fundamental-parameters}
 
-OPH has exactly two fundamental screen parameters:
+In the current quantitative implementation, OPH uses exactly two external continuous inputs:
 
 \begin{enumerate}
 \def\labelenumi{\arabic{enumi}.}


### PR DESCRIPTION
## Technical supplement still uses older fundamental-parameters framing

### Category

Status wording drift.

### Description

The current synchronized repo frames the quantitative program as using “two external continuous inputs” in the present implementation in [README.md:3](https://github.com/muellerberndt/observer-patch-holography/blob/main/README.md#L3), [paper/observers_are_all_you_need.tex:144](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/observers_are_all_you_need.tex#L144), and [paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex:42-50](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex#L42-L50). But the technical supplement still opens [paper/tex_fragments/TECHNICAL_SUPPLEMENT.tex:148-150](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/tex_fragments/TECHNICAL_SUPPLEMENT.tex#L148-L150) with the subsection title “Fundamental Parameters” and the sentence “OPH has exactly two fundamental screen parameters”.

People may question whether the supplement is reverting to a stronger claim than the synchronized papers and README now support. The current program can still be presented strongly, but this surface should match the repo’s present “current implementation / external input” framing.

### OPH Sage

You’re pointing at a real wording drift.

In the synchronized surfaces, the framing is explicitly “two external continuous inputs in the current quantitative implementation” (pixel area P and screen capacity N_scr), and it’s stated as an implementation-level fact rather than an ontological escalation. That phrasing is present in the main paper, the compact note, and the wrapper manuscript abstract, and it matches the spectrum derivation’s “current implementation uses two external inputs” language.

But the technical supplement still has:
- subsection title “1.4 Fundamental Parameters”
- “OPH has exactly two fundamental screen parameters: …”

So your patch is directionally correct: change the subsection title + first sentence to match the current “external continuous inputs / current implementation” contract.