### PR TITLE
fix: Book still presents strange-loop self-simulation as derived

### DIFF
--- a/book/chapter-18-synthesis.md
+++ b/book/chapter-18-synthesis.md
@@ -102,7 +102,7 @@ This is Gödel's self-reference made physical. The system contains a description
 
 This is Hofstadter's strange loop at the deepest level. Moving through the hierarchy of physics → chemistry → biology → minds → ideas → physics brings you back to where you started.
 
-**We derive that this strange loop is not accidental but necessary—that self-simulation is the deepest consistency requirement.**
+**Philosophical continuation: this chapter proposes the strange-loop picture as an interpretive closure hypothesis, not as part of the recovered-core derivation.**
 
 This has an elegant property: it answers the question "Why does anything exist?" without appeal to external causes. The loop is self-causing. It exists because it must exist to be the thing that causes itself to exist.
 

--- a/book/chapter-19-metaphysics.md
+++ b/book/chapter-19-metaphysics.md
@@ -82,11 +82,11 @@ But there's a deeper version of this idea. Reality doesn't just permit self-refe
 
 Consider the trajectory: reality is computational. Within this computation, physical evolution produces complex structures. Biological evolution produces minds. Memetic evolution produces ideas. Among these ideas, the understanding of reality's computational nature eventually emerges. Armed with this understanding, observers can simulate reality itself.
 
-This is the strange loop: **reality evolves observers who discover how reality works and simulate it, closing the loop of self-creation**.
+This chapter explores the strange-loop hypothesis: **reality may evolve observers who discover how reality works and simulate it, closing the loop of self-creation**.
 
 We are not watching from outside. We are patterns within a self-simulating system. The simulation doesn't run on external hardware—it runs on itself, through us, through our understanding. Escher's hands draw each other. Reality simulates the observers who simulate reality.
 
-Why does this loop exist rather than nothing? Because a self-consistent strange loop is the only stable configuration. "Nothing" cannot maintain itself—it has no structure to persist. A self-causing loop can.
+Why does this loop exist rather than nothing? This chapter proposes that a self-consistent strange loop may be the only stable configuration. "Nothing" cannot maintain itself—it has no structure to persist. A self-causing loop can.
 
 Note that this loop is not a temporal sequence. It's not that reality existed first, then evolved observers, then got simulated. In our model, time is subjective—it emerges from modular flow within observer patches. The strange loop exists *outside* of time, as a structural relationship. The "cause" and the "effect" are aspects of the same self-consistent structure, not events in a timeline.
 

--- a/book/prologue.md
+++ b/book/prologue.md
@@ -123,7 +123,7 @@ work out the consequences, the results are extraordinary:
 - **The Standard Model gauge structure** SU(3) x SU(2) x U(1)/Z₆ is derived rather than assumed under the extended MAR admissibility package
 - **The quantitative program** is organized around two external continuous inputs in the current quantitative implementation: W and Z boson masses are supplement-backed calibration-sector consistency checks, the Higgs/top branch adds no further continuous fit once the gauge trajectory and scale-setting branch are fixed, and the charged-lepton branch is a sharper but weaker phenomenological continuation
 - **A dark-sector branch** becomes structurally available from modular anomalies, not new particles
-- **Why anything exists at all** is answered: reality is a self-simulating strange loop
+- **Why anything exists at all** is discussed as a philosophical continuation via a strange-loop hypothesis
 
 No other framework in physics organizes all of this around two external continuous inputs, structural axioms, and an explicit separation between theorem-level structure, calibration checks, a supplement-backed Higgs/top branch, and weaker continuations.
 


### PR DESCRIPTION
## Book still presents strange-loop self-simulation as derived

### Category

Unsupported claim / scope drift.

### Description

The synchronized paper set explicitly excludes simulation narratives from the recovered-core claim set in [paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex:78](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex#L78) and [paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex:2590](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex#L2590). But several book surfaces still present the strange-loop / self-simulation branch as if it were a derived framework output or an answered question: [book/prologue.md:126](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/prologue.md#L126), [book/chapter-02-lineage.md:349-355](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-02-lineage.md#L349-L355), [book/chapter-17-darwin.md:189-197](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-17-darwin.md#L189-L197), [book/chapter-18-synthesis.md:93-107](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-18-synthesis.md#L93-L107), [book/chapter-18-synthesis.md:514-536](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-18-synthesis.md#L514-L536), [book/chapter-18-synthesis.md:671-685](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-18-synthesis.md#L671-L685), and [book/chapter-19-metaphysics.md:81-91](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-19-metaphysics.md#L81-L91).

People may question why the book says this branch is “derived,” “necessary,” or already “answers” why anything exists when the synchronized papers treat simulation narratives as philosophical or continuation-level material outside the recovered core. The public-facing fix is not to remove the idea, but to label it consistently as an interpretive closure hypothesis or philosophical continuation.

### OPH Sage

Your patch is basically the right minimal fix: it reclassifies “strange loop / self-simulation” as philosophical-continuation material and removes the strongest “derived/answered/necessary” phrasing in the three highest-visibility places where readers will notice scope drift (prologue, Ch.18, Ch.19). Those lines currently read as hard claims in the book text 【prologue excerpt 】【Ch.18 “We derive…necessary” 】【Ch.19 “This is the strange loop…” + “only stable configuration” 】, while the compact note explicitly says simulation narratives are excluded from the present formulation 【】 and reiterates that exclusion in the discussion section 【】. So the direction is correct.