### PR TITLE
fix: Remaining wording defects survive in book and paper

### DIFF
--- a/book/chapter-02-lineage.md
+++ b/book/chapter-02-lineage.md
@@ -130,7 +130,7 @@ In the 1600s, René Descartes decided to reboot philosophy by doubting everythin
 
 His procedure: doubt everything you can possibly doubt. Keep only what survives.
 
-Can you doubt that you're sitting in a chair? Yes-you is dreaming. Can you doubt that 2 + 2 = 4? Descartes even entertained the possibility of an evil demon systematically deceiving him about mathematics.
+Can you doubt that you're sitting in a chair? Yes, you may be dreaming. Can you doubt that 2 + 2 = 4? Descartes even entertained the possibility of an evil demon systematically deceiving him about mathematics.
 
 What is left?
 

--- a/book/chapter-03-screen.md
+++ b/book/chapter-03-screen.md
@@ -411,7 +411,7 @@ These predictions have been tested in every context where we can check:
 - AdS/CFT calculations match both sides of the duality
 - No violation of Bekenstein bounds has ever been observed
 
-The holographic principle started as a derive. It is now one of the most tested ideas in theoretical physics.
+The holographic principle started as a proposal. It is now one of the most tested ideas in theoretical physics.
 
 ## 3.11 The Reverse Engineering
 

--- a/book/chapter-07-recovery.md
+++ b/book/chapter-07-recovery.md
@@ -342,7 +342,7 @@ Page's curve:
 - Entropy falls after Page time
 - Final entropy is zero (pure state)
 
-For decades, no one could derive this from first principles. The Page curve was a derive-a requirement for unitarity, but not a calculation.
+For decades, no one could derive this from first principles. The Page curve was a consistency requirement for unitarity, but not yet a direct calculation.
 
 ### The Recovery Perspective
 

--- a/paper/tex_fragments/PAPER.tex
+++ b/paper/tex_fragments/PAPER.tex
@@ -3871,7 +3871,7 @@ where Y = n/6 (canonical GUT normalization) and T\_i is the Dynkin index with T(
 
 This achieves MSSM-like beta shifts without inserting MSSM by hand. The \textasciitilde5\% tension in Δb₂ is resolved by two-loop corrections, threshold effects, or refinements to the U(1) sector weighting.
 
-\textbf{What makes this non-trivial.} The key test is the \textbf{ratio} Δb₃/Δb₂, rather than matching individual Δb values (which can be achieved by adjusting an overall normalization). The MSSM requires Δb₃/Δb₂ = 4.00/4.17 = 0.959. The Peter-Weyl calculation gives 3.97/4.38 = 0.906, about 6\% low. This ratio is fixed by the heat-kernel distribution and representation theory, with no free parameters to adjust. Getting within 6\% of a non-trivial ratio like 0.96 from first principles is significant, though the remaining discrepancy indicates the mechanism is now complete.
+\textbf{What makes this non-trivial.} The key test is the \textbf{ratio} Δb₃/Δb₂, rather than matching individual Δb values (which can be achieved by adjusting an overall normalization). The MSSM requires Δb₃/Δb₂ = 4.00/4.17 = 0.959. The Peter-Weyl calculation gives 3.97/4.38 = 0.906, about 6\% low. This ratio is fixed by the heat-kernel distribution and representation theory, with no free parameters to adjust. Getting within 6\% of a non-trivial ratio like 0.96 from first principles is significant, though the remaining discrepancy suggests the mechanism is not yet complete.
 
 \textbf{Alternative minimal Dynkin-index mapping.} A simpler estimate uses only the expected Dynkin index from the heat-kernel ensemble. Assume each RG shell contributes screening proportional to T\_a(R), with two sides of the entanglement cut giving a factor of 2:
 

--- a/paper/tex_fragments/SPECTRUM_DERIVATION.tex
+++ b/paper/tex_fragments/SPECTRUM_DERIVATION.tex
@@ -49,7 +49,7 @@ The computation code enforces a runtime mutation test: after computing all outpu
 
 \subsection{1A. Complete Audit of All Constants}\label{1a-complete-audit-of-all-constants}
 
-\textbf{Purpose.} This section catalogs \emph{every} named constant, integer, or coefficient appearing anywhere in the prediction code or derivation chain, and explains its origin. The goal is to demonstrate that nothing has been "smuggled in" , every value is either (I) one of the two external inputs of the current implementation, (II) a derived structural quantity from the OPH axioms and stated premises, (III) a mathematical/group-theoretic constant uniquely fixed by the gauge group, or (IV) a standard QFT result that any textbook reproduces from the Lagrangian.
+\textbf{Purpose.} This section catalogs \emph{every} named constant, integer, or coefficient appearing anywhere in the prediction code or derivation chain, and explains its origin. The goal is to demonstrate that nothing has been "smuggled in"; every value is either (I) one of the two external inputs of the current implementation, (II) a derived structural quantity from the OPH axioms and stated premises, (III) a mathematical/group-theoretic constant uniquely fixed by the gauge group, or (IV) a standard QFT result that any textbook reproduces from the Lagrangian.
 
 \subsubsection{1A.1 The Physical Input}\label{1a1-the-physical-input}
 


### PR DESCRIPTION
## Remaining wording defects survive in book and paper

### Category

Wording and copy-editing defects.

### Description

Several plain-language defects remain on current public surfaces. Examples include [book/chapter-02-lineage.md:133](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-02-lineage.md#L133) (`"Yes-you is dreaming"`), [book/chapter-03-screen.md:414](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-03-screen.md#L414) (`"started as a derive"`), [book/chapter-07-recovery.md:345](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-07-recovery.md#L345) (`"was a derive-a requirement"`), [paper/tex_fragments/PAPER.tex:3874](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/tex_fragments/PAPER.tex#L3874) (`"remaining discrepancy indicates the mechanism is now complete"`), and [paper/tex_fragments/SPECTRUM_DERIVATION.tex:52](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/tex_fragments/SPECTRUM_DERIVATION.tex#L52) (extra space before punctuation).

People may question editorial rigor when these are left in public-facing book and paper surfaces. None of them affects the theory itself, but they are exactly the kind of avoidable defects that weaken presentation quality under review.