### PR TITLE
fix: Continuation-only branches are still phrased as settled derivations

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ A measurement contradiction would require showing that some phenomenon cannot be
 
 ## Current Status
 
-As summarized in the status matrix above, the framework derives Lorentz kinematics, a conditional semiclassical Einstein branch, compact gauge symmetry, the SM gauge group (via MAR), three generations, three colors, massless force carriers, a two-input quantitative particle-physics program, proton stability, and an explicit OPH-to-string bridge through 2D Yang-Mills edge sectors. The main engineering extensions are:
+As summarized in the status matrix above, the framework derives Lorentz kinematics, a conditional semiclassical Einstein branch, compact gauge symmetry, the SM gauge group (via MAR), three generations, three colors, massless force carriers, a two-input quantitative particle-physics program, proton stability, and a continuation-level OPH-to-string route through 2D Yang-Mills edge sectors. The main engineering extensions are:
 
 1. **Screen microphysics**: Quantum link models realize the regulator premises and give edge-center completion automatically. Remaining: force or verify selection of the OPH geometric modular branch in the continuum limit.
 
@@ -500,7 +500,7 @@ As summarized in the status matrix above, the framework derives Lorentz kinemati
 
 3. **Cosmological constant**: Structurally explained as $\Lambda = 3\pi/(G \cdot \log \dim \mathcal{H}_{\rm tot})$ from screen capacity. The numerical value is inferred from observation.
 
-4. **Strong CP problem**: $\theta_{QCD}$ is now predicted (a derivation linking it to gluing obstruction cohomology is outlined in Section 8.4).
+4. **Strong CP problem**: a gluing-obstruction route is outlined, but $\theta_{QCD}$ remains a continuation-level proposal rather than a recovered-core prediction.
 
 ## Code
 

--- a/README_FR.md
+++ b/README_FR.md
@@ -87,8 +87,7 @@ Lorsqu'une mise à niveau ou un audit touche plusieurs articles, commencez toujo
 Dans l'ensemble actuel des articles, l'OPH sépare explicitement les affirmations par statut :
 sorties structurelles sans paramètre (chaîne Lorentz/jauge/quotient, réseau d'hypercharges sur le
 paquet de matière réalisé, $N_g=3$ puis $N_c=3$ sur la branche MAR réalisée, zéros protégés par
-symétrie, stabilité du proton), contrôles de cohérence du secteur calibré ($\alpha_i(m_Z)$,
-$\sin^2\theta_W$, $v$, $m_W$), branche quantitative principale adossée à des suppléments
+symétrie, stabilité du proton), contrôles de cohérence du secteur calibré ($\alpha_i(m_{Z,\rm run})$, $\sin^2\theta_W(m_{Z,\rm run})$, $v$, $m_W$), branche quantitative principale adossée à des suppléments
 ($m_H$, $m_t$), et continuations phénoménologiques ou numériques en aval plus faibles (Koide /
 leptons chargés, textures de quarks, neutrinos, hadrons, matière noire,
 baryogenèse).
@@ -486,12 +485,12 @@ Le cadre OPH prend l'étape suivante : il n'essaie pas de sauver une réalité o
 
 ## Statut actuel
 
-Comme résumé dans la matrice de statut plus haut, le cadre établit aujourd'hui une cinématique de Lorentz conditionnelle, une branche semi-classique d'Einstein conditionnelle, une symétrie de jauge compacte, le groupe du MS (via MAR), trois générations, trois couleurs, des porteurs de force sans masse, un programme quantitatif à deux entrées avec distinction explicite entre calibration et sorties indépendantes, la stabilité du proton, ainsi qu'un pont explicite OPH->cordes via les secteurs de bord YM 2D. Les principaux axes d'ingénierie actifs :
+Comme résumé dans la matrice de statut plus haut, le cadre établit aujourd'hui une cinématique de Lorentz conditionnelle, une branche semi-classique d'Einstein conditionnelle, une symétrie de jauge compacte, le groupe du MS (via MAR), trois générations, trois couleurs, des porteurs de force sans masse, un programme quantitatif à deux entrées avec distinction explicite entre calibration et sorties indépendantes, la stabilité du proton, ainsi qu'une route OPH->cordes au niveau continuation via les secteurs de bord YM 2D. Les principaux axes d'ingénierie actifs :
 
 1. **Microphysique d'écran** : les modèles de liens quantiques réalisent les prémisses de régulateur et donnent automatiquement la complétion bord-centre. Reste : forcer ou vérifier la sélection de la branche modulaire géométrique OPH dans la limite continue.
 2. **Vérification du pont EFT** : le pont modulaire de surface nulle est dérivé sous deux conditions testables ; il faut les vérifier dans des régulateurs UV explicites.
 3. **Constante cosmologique** : expliquée structurellement comme $\Lambda = 3\pi/(G \cdot \log \dim \mathcal{H}_{\rm tot})$ via la capacité d'écran ; valeur numérique inférée de l'observation.
-4. **Problème CP fort** : $\theta_{QCD}$ est déterminé (la dérivation via cohomologie d'obstruction de collage est donnée en section 8.4).
+4. **Problème CP fort** : une route d'obstruction de collage est esquissée, mais $\theta_{QCD}$ reste une proposition au niveau continuation plutôt qu'une prédiction du noyau récupéré.
 
 ## Code
 

--- a/paper/tex_fragments/STRING_THEORY.tex
+++ b/paper/tex_fragments/STRING_THEORY.tex
@@ -4,15 +4,15 @@
 OPH is an observer-centric reconstruction program for fundamental physics. In the current implementation it uses two external inputs (pixel area and screen capacity) together with structural axioms and stated regulator/scaling premises. This part records the internal OPH route from edge-sector heat-kernel structure to a worldsheet/string reorganization of the bosonic branch.
 \end{quote}
 
-\subsection{A Complete Derivation}\label{a-complete-derivation}
+\subsection{A Continuation-Level Route}\label{a-complete-derivation}
 
 This document records the OPH derivation path by which the bosonic edge-sector branch admits a string-theoretic description of its effective degrees of freedom. The route uses OPH axioms together with the stated heat-kernel, large-\(N\), and modular-sewing premises; no separate external string-theory starting postulate is introduced.
 
 \begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
 
-\section{1. Overview: What We Derive}\label{1-overview-what-we-derive}
+\section{1. Overview: The Claimed Route}\label{1-overview-what-we-derive}
 
-We establish the following internal chain of implications within the stated OPH branch:
+We record the following continuation-level chain within the stated OPH branch:
 
 \begin{verbatim}
 Canonical OPH package + regulator premises used in the edge-sector branch
@@ -36,7 +36,7 @@ Additionally, we show that OPH supplies:
   \textbf{Higher gauge structure}: The natural slot for B-field/gerbe data
 \end{itemize}
 
-This establishes that OPH contains string theory as an emergent description of its edge/boundary degrees of freedom.
+This records a conditional route by which the OPH edge/boundary sector can admit a string-theoretic reorganization if the stated large-\(N\) and modular-sewing premises are realized.
 
 \begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
 


### PR DESCRIPTION
## Continuation-only branches are still phrased as settled derivations

### Category

Claim-tier drift.

### Description

The repo's authoritative ledger now says that string/worldsheet material and strong-CP proposals are continuation-only rather than recovered-core outputs in [paper/tex_fragments/PAPER.tex:4576-4592](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/tex_fragments/PAPER.tex#L4576-L4592). The string fragment itself repeats that Phase-III boundary at [paper/tex_fragments/STRING_THEORY.tex:379-393](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/tex_fragments/STRING_THEORY.tex#L379-L393). But front-facing surfaces still overstate those branches: [README.md:496-504](https://github.com/muellerberndt/observer-patch-holography/blob/main/README.md#L496-L504) says OPH already has an explicit OPH-to-string bridge and that `\theta_{QCD}` is now predicted, while [paper/tex_fragments/STRING_THEORY.tex:7-39](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/tex_fragments/STRING_THEORY.tex#L7-L39) still opens with `A Complete Derivation` and `This establishes that OPH contains string theory as an emergent description`.

People may question whether the project is really enforcing its own Phase-I / Phase-II / Phase-III ledger. This is not a request to weaken the program. It is a request to keep strong continuation claims strong in the right way: as explicit routes or targets, rather than as already-secured derivations that the current paper set itself says remain conditional.

### OPH Sage

Your proposed fix is correct in substance and matches the project’s own authoritative three-phase reading rule: Phase III (D12) contains continuations like string/worldsheet and strong-CP, and “nothing in D12 should be cited as theorem-level unless and until its extra ansätze are replaced by proved premises”. The paper also explicitly lists “string/worldsheet reorganization” and “strong-CP proposals” under “Not predicted by the recovered core”, so README + the string fragment opening should not present them as already-secured derivations.