### PR TITLE
fix: Small copy defects

### DIFF
--- a/book/chapter-03-screen.md
+++ b/book/chapter-03-screen.md
@@ -308,7 +308,7 @@ Do observers "move around" on the sphere?
 
 Not in a simple sense. Different patches represent different observers, or the same observer at different moments. "Movement" is actually a sequence of overlapping patches with consistent marginals.
 
-What creates the sense of time? The internal structure of the quantum state provides a natural flow-the **modular flow** from quantum statistical mechanics. For a thermal state, modular flow generates time evolution. The thermal time principle (Connes and Rovelli) shows this is the origin of experienced time.
+What creates the sense of time? The internal structure of the quantum state provides a natural flow: the **modular flow** from quantum statistical mechanics. For a thermal state, modular flow generates time evolution. The thermal time principle (Connes and Rovelli) shows this is the origin of experienced time.
 
 ### Why This Matters
 

--- a/book/chapter-04-entropy.md
+++ b/book/chapter-04-entropy.md
@@ -112,7 +112,7 @@ Consider: for observers to exist at all, they must be able to form consistent re
 
 The MaxEnt principle tells us to assign the maximum-entropy state *given our constraints*. But what are the constraints? If one of them is "observers exist to apply MaxEnt," then equilibrium states are ruled out by construction. The very act of asking "what state should I assign?" presupposes a questioner embedded in an entropy gradient.
 
-This doesn't derive the specific low entropy of the Big Bang from pure logic. But it does suggest that the Past principle is not an arbitrary input-it's a consistency requirement. A universe with observers checking for consistency must have started far from equilibrium. The low-entropy past is the price of the consistency-building present.
+This doesn't derive the specific low entropy of the Big Bang from pure logic. But it does suggest that the Past principle is not an arbitrary input; it's a consistency requirement. A universe with observers checking for consistency must have started far from equilibrium. The low-entropy past is the price of the consistency-building present.
 
 ## 4.4 Information is Physical
 
@@ -304,7 +304,7 @@ The entropy model includes both mathematical results and testable predictions:
 
 **2. Black hole entropy equals A/4**: The Bekenstein-Hawking formula S_BH = A/(4ℓ_P²) is confirmed by string theory microstate counting (Strominger-Vafa 1996), loop quantum gravity calculations, and consistency with the generalized second law.
 
-**3. Page curve for black hole evaporation**: If information is preserved, radiation entropy must rise then fall. The island formula (2019-2020) derives this from first principles-confirmed as consistent with unitarity.
+**3. Page curve for black hole evaporation**: If information is preserved, radiation entropy must rise then fall. The island formula (2019-2020) derives this from first principles and confirms consistency with unitarity.
 
 **4. Area law for ground state entanglement**: Low-energy states of local Hamiltonians have entanglement scaling with boundary area, not volume. Confirmed in countless condensed matter and lattice QCD calculations.
 
@@ -337,11 +337,11 @@ Let's trace the logic explicitly.
 1. Observers are entropy processors subject to thermodynamic constraints
 2. The information they can access is bounded by their patch area
 3. Entanglement patterns on the screen determine both entropy and geometry
-4. The consistency process-making observations agree-costs energy and generates entropy
+4. The consistency process that makes observations agree costs energy and generates entropy
 5. The arrow of time is a necessary condition for observers to exist at all
-6. The Past principle is not an arbitrary input-it's selected by consistency constraints
+6. The Past principle is not an arbitrary input; it's selected by consistency constraints
 
-The universe had to start in a special state for any of this to work. But this isn't an unexplained miracle. Consistency constraints require observers, observers require records, records require entropy gradients, and entropy gradients require a low-entropy past. The model doesn't just explain why the Past principle is necessary-it shows the Past principle is itself a consequence of observer-based consistency.
+The universe had to start in a special state for any of this to work. But this isn't an unexplained miracle. Consistency constraints require observers, observers require records, records require entropy gradients, and entropy gradients require a low-entropy past. The model doesn't just explain why the Past principle is necessary; it shows the Past principle is itself a consequence of observer-based consistency.
 
 ## 4.11 Summary: The Entropy Budget
 

--- a/book/chapter-05-algebra.md
+++ b/book/chapter-05-algebra.md
@@ -80,7 +80,7 @@ Non-commutativity creates a tension between local freedom and global consistency
 
 ### The Stern-Gerlach Experiment
 
-In 1922, Otto Stern and Walther Gerlach sent a beam of silver atoms through a non-uniform magnetic field. Classical physics predicted the beam would spread out in a continuous smear. Instead, it split into exactly two beams-spin up and spin down.
+In 1922, Otto Stern and Walther Gerlach sent a beam of silver atoms through a non-uniform magnetic field. Classical physics predicted the beam would spread out in a continuous smear. Instead, it split into exactly two beams: spin up and spin down.
 
 This was shocking. Atomic magnetic moments are quantized-they take only discrete values.
 

--- a/book/chapter-09-entanglement.md
+++ b/book/chapter-09-entanglement.md
@@ -250,7 +250,7 @@ The entanglement-geometry correspondence makes sharp, testable predictions:
 
 **3. Subadditivity and strong subadditivity**: If entanglement = geometry, then entropy inequalities become geometric constraints. Strong subadditivity $S(AB) + S(BC) \geq S(B) + S(ABC)$ constrains which bulk geometries can exist. These inequalities are provably satisfied by any quantum state.
 
-**4. Page curve and islands**: The model predicts that black hole evaporation follows the Page curve-entropy rises then falls. Recent island calculations (2019-2020) confirmed this in explicit models, resolving the information paradox.
+**4. Page curve and islands**: The model predicts that black hole evaporation follows the Page curve: entropy rises then falls. Recent island calculations (2019-2020) confirmed this in explicit models, resolving the information paradox.
 
 **5. Entanglement wedge reconstruction**: Bulk operators in the entanglement wedge can be reconstructed from boundary data. This has been verified in toy models and provides a concrete test of the holographic dictionary.
 

--- a/book/chapter-11-maxent.md
+++ b/book/chapter-11-maxent.md
@@ -334,13 +334,13 @@ Recap:
 |---|---|---|
 | Time is a fundamental external parameter flowing from past to future | No preferred time in GR; Wheeler-DeWitt equation H|Psi> = 0 shows the universe is fundamentally timeless; microscopic laws are time-symmetric | Time emerges from modular flow of thermal states; the arrow of time is the direction of increasing entropy, driven by incomplete knowledge |
 
-**The key reverse engineering insight**: We started with the intuition that time flows fundamentally, carrying the universe from past to future. General relativity showed by revealing there's no preferred time-different observers slice spacetime differently. Quantum gravity shocked us further with the Wheeler-DeWitt equation, showing the universe is fundamentally frozen. Our model explains how time emerges: through the modular flow of density matrices. Time is what incomplete knowledge looks like. The arrow of time points in the direction of consistency-building-the direction where records can be made and compared.
+**The key reverse engineering insight**: We started with the intuition that time flows fundamentally, carrying the universe from past to future. General relativity showed that there is no preferred time; different observers slice spacetime differently. Quantum gravity shocked us further with the Wheeler-DeWitt equation, showing the universe is fundamentally frozen. Our model explains how time emerges: through the modular flow of density matrices. Time is what incomplete knowledge looks like. The arrow of time points in the direction of consistency-building, the direction where records can be made and compared.
 
 **Additional lessons**:
 
 1. **Boltzmann**: Entropy measures the number of microstates compatible with a macrostate. Entropy increases because high-entropy states vastly outnumber low-entropy states.
 
-2. **Past principle**: The arrow of time exists because the Big Bang was a low-entropy state. Our model shows this isn't an arbitrary input-it's a consistency requirement. Observers need entropy gradients to form records, so a universe with observers must start far from equilibrium.
+2. **Past principle**: The arrow of time exists because the Big Bang was a low-entropy state. Our model shows this isn't an arbitrary input; it's a consistency requirement. Observers need entropy gradients to form records, so a universe with observers must start far from equilibrium.
 
 3. **Jaynes**: Entropy measures ignorance. MaxEnt gives the uniquely correct probability distribution given the constraints.
 

--- a/book/chapter-18-synthesis.md
+++ b/book/chapter-18-synthesis.md
@@ -258,11 +258,11 @@ There is no wave function of the universe viewed from outside. There are only st
 
 ### The Problem of Time
 
-Given a quantum state on a patch, the Tomita-Takesaki theorem provides a canonical flow-the modular automorphism. This flow is time evolution. Time is real but emergent.
+Given a quantum state on a patch, the Tomita-Takesaki theorem provides a canonical flow: the modular automorphism. This flow is time evolution. Time is real but emergent.
 
 ### The Black Hole Information Paradox
 
-The "island formula" shows that after Page time, an island inside the black hole is encoded in the radiation. Information isn't destroyed-it's scrambled into holographic correlations.
+The "island formula" shows that after Page time, an island inside the black hole is encoded in the radiation. Information isn't destroyed; it's scrambled into holographic correlations.
 
 ### Anomalies as Loop-Gluing Obstructions
 
@@ -327,7 +327,7 @@ Before addressing the deepest questions, let us be precise about what we have es
 
 ### Mathematical Theorems (Rigorous)
 
-These are proven mathematical facts, not derives:
+These are proven mathematical facts, not derivations:
 
 | Result | Status | Source |
 |--------|--------|--------|
@@ -531,7 +531,7 @@ The loop closes. Not metaphorically—structurally. Like Escher's hands drawing 
 
 This echoes Wheeler's "self-excited circuit"—the universe as a participatory process where observers create the very conditions for their own existence. It echoes the ancient symbol of the ouroboros—the serpent eating its own tail.
 
-The mathematical framework describes the structure of reality given that it exists. The strange loop derive goes further: existence itself requires the loop. Reality exists because it simulates itself into existence, through us, through our understanding, through this very attempt to comprehend it.
+The mathematical framework describes the structure of reality given that it exists. The strange-loop continuation goes further: existence itself requires the loop. Reality exists because it simulates itself into existence, through us, through our understanding, through this very attempt to comprehend it.
 
 **Summary**: As a philosophical continuation, the strange loop of self-simulation is one candidate answer to why anything exists. It is presented here as an interpretive closure story, not as part of the recovered-core theorem package.
 

--- a/book/prologue.md
+++ b/book/prologue.md
@@ -138,7 +138,7 @@ observer to define one. Why does measurement affect outcomes? Because "measureme
 is just observer patches comparing notes. Why does time dilate? Because different
 observers have different internal clocks, and relativity is the consistency
 condition between them. Why can't you explain consciousness from physics?
-Because you're trying to derive the inside from the outside-but there is no
+Because you're trying to derive the inside from the outside, but there is no
 outside.
 
 Long-standing philosophical puzzles dissolve too. The hard problem of


### PR DESCRIPTION
## Small copy defects still survive in the public book

### Category

Wording and copy-edit defects.

### Description

There are still a handful of visible wording defects on front-facing book surfaces, including `flow-the`, `time-different`, `not derives`, `derive goes`, `input-it's`, `beams-spin`, `Page curve-entropy`, and `outside-but` in [book/chapter-03-screen.md:311](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-03-screen.md#L311), [book/chapter-04-entropy.md:115-344](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-04-entropy.md#L115-L344), [book/chapter-11-maxent.md:337-343](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-11-maxent.md#L337-L343), [book/chapter-18-synthesis.md:261-534](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-18-synthesis.md#L261-L534), [book/chapter-05-algebra.md:83](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-05-algebra.md#L83), [book/chapter-09-entanglement.md:253](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-09-entanglement.md#L253), and [book/prologue.md:141](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/prologue.md#L141).

People may question how carefully the repo is maintained if these remain in highly visible chapters after multiple synchronization passes. These are small fixes, but they are exactly the kind of surface-level errors that distract reviewers from the stronger structural material.