### PR TITLE
fix: normalize the monograph architecture (issue #41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,6 +532,8 @@ As summarized in the status matrix above, the framework derives Lorentz kinemati
 
 ### Book Chapters
 
+Core explanatory chapters
+
 | Chapter | Title | Topic |
 |---------|-------|-------|
 | [Prologue](book/prologue.md) | Prologue | Setting the stage |
@@ -547,13 +549,28 @@ As summarized in the status matrix above, the framework derives Lorentz kinemati
 | [10](book/chapter-10-error-correction.md) | Error Correction | Reality as a quantum code |
 | [11](book/chapter-11-maxent.md) | MaxEnt | Entropy, time, and modular flow |
 | [12](book/chapter-12-symmetry.md) | Symmetry | Conservation laws from consistency |
+
+Physics branch chapters
+
+| Chapter | Title | Topic |
+|---------|-------|-------|
 | [13](book/chapter-13-desitter.md) | De Sitter | Our universe's holographic screen |
 | [14](book/chapter-14-standard-model.md) | Standard Model | Particles from gluing constraints |
 | [15](book/chapter-15-relativity.md) | Relativity | Spacetime from modular time |
 | [16](book/chapter-16-matter.md) | Matter | Classical physics as emergent stability |
 | [17](book/chapter-17-darwin.md) | Darwin's Laws | Laws as evolutionary survivors |
+
+Interpretive chapters
+
+| Chapter | Title | Topic |
+|---------|-------|-------|
 | [18](book/chapter-18-synthesis.md) | Synthesis | Putting it all together |
 | [19](book/chapter-19-metaphysics.md) | Metaphysics | Qualia and the hard problem |
+
+Speculative epilogue
+
+| Chapter | Title | Topic |
+|---------|-------|-------|
 | [Epilogue](book/epilogue.md) | Epilogue | One last surprise |
 
 ## Building Your Own Reality Simulator

--- a/book/prologue.md
+++ b/book/prologue.md
@@ -189,6 +189,13 @@ The structure follows the logic of reverse engineering:
 
 This model rests on established mathematics and physics, extended by four axioms and one selection principle. The results are striking: a conditional scaling-limit gravity branch, the Standard Model gauge structure, and a quantitative particle-physics program all emerge from the framework. Within that program, charged-lepton masses remain a sharp but weaker continuation, while the Higgs and top masses come from a supplement-backed critical-surface branch that adds no further continuous fit once the gauge trajectory and scale-setting branch are fixed and is now documented as a UV-synchronized D11 reconstruction with small low-scale matching corrections. Our goal is to show you how deep the rabbit hole goes.
 
+## How This Book Is Organized
+
+Chapters 1-12 cover the observer-first framework and structural tools.
+Chapters 13-17 cover the main physics branches.
+Chapters 18-19 are synthesis and interpretation.
+The epilogue is speculative continuation material.
+
 ## Let's Go
 
 Reality is the strangest program ever written. It's been running since the

--- a/paper/observers_are_all_you_need.tex
+++ b/paper/observers_are_all_you_need.tex
@@ -167,7 +167,8 @@ Observer-Patch Holography (OPH) is an observer-centric reconstruction program fo
 \input{tex_fragments/TECHNICAL_SUPPLEMENT.tex}
 
 \clearpage
-\part{Interpretive Epilogue: Strange Loop Hypothesis}
+% Parts I-V carry synchronized derivation and supplement material; later parts are interpretive or speculative appendices and do not alter the compact paper's claim tiers.
+\part{Interpretive Appendix: Strange-Loop Proposal}
 
 \section{Interpretive Status, Dependencies, and Schematic Fixed-Point Ansatz}
 This part is an interpretive epilogue. It is not part of the Phase-I recovered core, not part of the D10--D11 supplement-backed implementation, and not a theorem derived from the OPH axioms. The notation below is only a schematic way to state the closure idea; no existence, uniqueness, or stability theorem for the map \(\Phi\) is claimed here.
@@ -259,7 +260,7 @@ This wrapper is standalone only in the documentary sense: every derivation cited
 For claim-tier purposes, the authoritative ledger is the compact note's ``Results at a Glance'' / ``Predictive Status and Falsifiability'' pair together with Part~I Section~8. In that three-phase program, the recovered core is D1--D5 together with D7--D9; D6 is a separate input-dependent corollary; D10--D11 are the current supplement-backed numerical implementation; and D12 collects deferred continuations. This wrapper should be read as a synchronized compilation surface that inherits those statuses rather than upgrading them.
 
 \clearpage
-\part{Observer Continuation and Backup Mechanism}
+\part{Speculative Appendix: Observer Continuation and Backup}
 
 \section{Observer as Algebraic Pattern}
 In OPH, an observer is represented by


### PR DESCRIPTION
- Rename the wrapper's appendix-tier parts so interpretive and speculative material are labeled explicitly
- Add a short architecture map to the book prologue
- Regroup the README book section into core, physics-branch, interpretive, and speculative tiers