### PR TITLE
fix: Input-replacement count still overstates neutrino coverage

### DIFF
--- a/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
+++ b/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
@@ -2121,7 +2121,7 @@ The quantitative program uses the same axiom set together with the two external 
 N_g=3,\quad
 N_c=3
 \]
-and are fixed by structural arguments and MAR selection rather than by direct fits. If one later enters specific flavor continuations, additional discrete choices such as \(\varepsilon=1/6\) or \(\delta=2/9\) may be introduced, but those are not part of the recovered structural bundle. On the structural, calibration, and Higgs/top branch alone, this replaces roughly nineteen particle-physics inputs, or twenty-six when neutrino parameters are included, by two external continuous inputs plus structural relations. Later flavor continuations use additional phenomenological branch choices and are not part of that count.
+and are fixed by structural arguments and MAR selection rather than by direct fits. If one later enters specific flavor continuations, additional discrete choices such as \(\varepsilon=1/6\) or \(\delta=2/9\) may be introduced, but those are not part of the recovered structural bundle. On the structural, calibration, and Higgs/top branch alone, this replaces roughly nineteen particle-physics inputs by two external continuous inputs plus structural relations. Later flavor continuations use additional phenomenological branch choices and are not part of that count.
 
 \subsection{Epistemic classification of outputs}
 


### PR DESCRIPTION
## Input-replacement count still overstates neutrino coverage

### Category

Quantitative-summary scope drift.

### Description

The quantitative-sector intro is now much cleaner: it already separates the realized structural bundle from later flavor choices such as `\varepsilon=1/6` and `\delta=2/9` in [paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex:2118-2124](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex#L2118-L2124). But the same sentence still says the structural, calibration, and Higgs/top branch replaces `roughly nineteen particle-physics inputs, or twenty-six when neutrino parameters are included` at [paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex:2124](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex#L2124), while the later neutrino section says the compact note contains only an input-dependent, order-of-magnitude capacity estimate and does not provide a benchmark neutrino mass formula, a mixing derivation, or a completed flavor mechanism in [paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex:2349-2351](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex#L2349-L2351).

People may question how neutrino parameters are being counted as replaced when the same paper later says no benchmark neutrino model is actually present there. The stronger nineteen-input statement can stand on its own. Only the neutrino-extension clause needs to be dropped.

### OPH Sage

At the input-count location, the compact note claims the structural + calibration + Higgs/top branch replaces “roughly nineteen particle-physics inputs, or twenty-six when neutrino parameters are included”. But later it explicitly states the neutrino discussion in this compact note is only an input-dependent, order-of-magnitude capacity estimate tied to N_scr and that it “does not provide a benchmark neutrino mass formula, a mixing derivation, or a completed flavor mechanism”. In other words: neutrino parameters are not actually “replaced” at the same maturity/derivation level in this document, so counting them in the same replacement tally invites exactly the skepticism you describe.