### PR TITLE
fix: release date

### DIFF
--- a/paper/observers_are_all_you_need.tex
+++ b/paper/observers_are_all_you_need.tex
@@ -134,7 +134,7 @@
 
 \title{Observers Are All You Need}
 \author{B. M\"uller}
-\date{March 13, 2026}
+\date{\OPHPaperReleaseDate}
 
 \begin{document}
 \maketitle

--- a/paper/reality_as_consensus_protocol.tex
+++ b/paper/reality_as_consensus_protocol.tex
@@ -18,7 +18,7 @@
 \title{Reality as a Consensus Protocol:\\
 The Fixed-Point Computation That Implements Physics}
 \author{B.\ M\"uller}
-\date{March 13, 2026}
+\date{\OPHPaperReleaseDate}
 
 \begin{document}
 \maketitle


### PR DESCRIPTION
## Wrapper title date drifts from the shared release banner

### Category

Metadata synchronization gap.

### Description

The wrapper paper still hardcodes `\date{March 13, 2026}` in [paper/observers_are_all_you_need.tex:137](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/observers_are_all_you_need.tex#L137), while the same document imports the shared release metadata from [paper/release_info.tex:1-5](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/release_info.tex#L1-L5), which currently prints release `r1341` dated `March 20, 2026`.

People may question which date is authoritative when the title block and release banner disagree inside the same PDF. This does not affect the claim set. It is a straightforward synchronization fix so the wrapper uses the same release source already printed on its first page.