### PR TITLE
fix: Wrapper build still has a multiply defined `references` label

### DIFF
--- a/paper/tex_fragments/PAPER.tex
+++ b/paper/tex_fragments/PAPER.tex
@@ -4691,7 +4691,7 @@ These are shared challenges across unification approaches. The framework provide
 
 \begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
 
-\subsection{References}\label{references}
+\subsection{References}\label{references-paper}
 
 \subsubsection{Foundational results used in this work}\label{foundational-results-used-in-this-work}
 

--- a/paper/tex_fragments/STRING_THEORY.tex
+++ b/paper/tex_fragments/STRING_THEORY.tex
@@ -441,7 +441,7 @@ Genus expansion & \(\log Z = \sum_{h \geq 0} N^{2-2h} F_h(\lambda)\) \\
 
 \begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
 
-\section{References}\label{references}
+\section{References}\label{references-string-theory}
 
 This derivation uses:
 

--- a/paper/tex_fragments/TECHNICAL_SUPPLEMENT.tex
+++ b/paper/tex_fragments/TECHNICAL_SUPPLEMENT.tex
@@ -1251,7 +1251,7 @@ Koide \(\delta\) (flavor continuation) & 2/9 & 0.222225 & deferred continuation 
 
 \begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
 
-\section{References}\label{references}
+\section{References}\label{references-technical-supplement}
 
 The derivations in this supplement are based on the OPH framework as specified in Part I of this manuscript. Standard results from:
 


### PR DESCRIPTION
## Wrapper build still has a multiply defined `references` label

### Category

Reference-integrity defect.

### Description

The wrapper currently compiles with a stable multiply defined LaTeX label warning for `references`. The duplicate label definitions are in [paper/tex_fragments/PAPER.tex:4694](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/tex_fragments/PAPER.tex#L4694), [paper/tex_fragments/STRING_THEORY.tex:444](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/tex_fragments/STRING_THEORY.tex#L444), and [paper/tex_fragments/TECHNICAL_SUPPLEMENT.tex:1254](https://github.com/muellerberndt/observer-patch-holography/blob/main/paper/tex_fragments/TECHNICAL_SUPPLEMENT.tex#L1254). A current compile of `paper/observers_are_all_you_need.tex` reports `Label 'references' multiply defined`.

People may question the wrapper’s cross-reference integrity when the build log already reports ambiguous labels in merged public surfaces. This is not a theory issue, but it is a real document-integrity defect. The references sections should use distinct labels or no label where none is referenced.