### PR TITLE
fix: Paper defects

### DIFF
--- a/paper/observers_are_all_you_need.tex
+++ b/paper/observers_are_all_you_need.tex
@@ -348,7 +348,7 @@ Problem domain & Current status & OPH mechanism / scope note \\
 \bottomrule
 \endfoot
 Quantum gravity consistency & Phase I recovered core (conditional scaling-limit) & Conditional Lorentz and Jacobson-type Einstein branches from modular geometry, the null bridge, and fixed-cap stationarity. \\
-Measurement problem & Mixed: fixed-cutoff theorem package / interpretive synthesis & The synchronized screen-microphysics audit surface proves a fixed-cutoff central-record / Born-L\"uders package for observer-accessible events. Broader philosophical closure claims remain interpretive in this wrapper. \\
+Measurement problem & Mixed: fixed-cutoff theorem package / interpretive synthesis & The synchronized screen-microphysics paper proves a fixed-cutoff central-record / Born-L\"uders package for observer-accessible events. Broader philosophical closure claims remain interpretive in this wrapper. \\
 Cosmological principle and horizon homogeneity & Interpretive or organizational synthesis & MaxEnt state selection under symmetric constraints motivates isotropy and homogeneity stories. Those stories remain outside the independent Phase-I theorems. \\
 Problem of time & Interpretive or organizational synthesis & Modular flow from the BW$_{S^2}$ geometric branch provides a physical time parameter for each observer patch. It remains a useful organizational principle, not a separate recovered-core theorem in this wrapper. \\
 Supersymmetry non-observation vs.\ unification & Phase II quantitative branch & MSSM-like \(\beta\)-shift comparisons from edge-sector weighting belong to the D10 calibration layer. They sit outside the recovered-core theorem package. \\
@@ -380,7 +380,7 @@ O=(P,\mathcal{A}(P),\rho,R),
 \]
 where $P$ is a screen patch, $\mathcal{A}(P)$ is its local algebra, $\rho$ is the local state, and $R$ is the record algebra. Records are implemented by approximately commuting projectors in overlap centers, so they are shareable without violating no-cloning constraints for generic quantum states.
 
-On the synchronized screen-microphysics audit surface, the observer-facing measurement interface is now theorem-bearing at fixed cutoff: one has a finite central record algebra, Born probabilities for its event projectors, and L\"uders conditioning on that same commuting record algebra. The observer-paper role is therefore to import that fixed-cutoff measurement package into the surrounding observer vocabulary, not to reclassify it as mere interpretive rhetoric.
+On the synchronized screen-microphysics paper, the observer-facing measurement interface is now theorem-bearing at fixed cutoff: one has a finite central record algebra, Born probabilities for its event projectors, and L\"uders conditioning on that same commuting record algebra. The observer-paper role is therefore to import that fixed-cutoff measurement package into the surrounding observer vocabulary, not to reclassify it as mere interpretive rhetoric.
 
 \section{Markov Collar Factorization}
 For a collar tripartition $A$-$B$-$D$ with conditional mutual information $I(A:D|B)\le\varepsilon$, the exact Markov limit gives
@@ -418,9 +418,9 @@ For approximate Markov collars, recovery is controlled by the standard bound
 \]
 This gives quantitative trace-distance control on the recovered state under finite conditional mutual information (finite collar error). Interpreting that control as observer continuation requires additional modeling assumptions beyond the bound itself.
 
-The fixed-cutoff audit-surface claim is stronger than the bare recoverability estimate written above. On the synchronized screen-microphysics surface, exact checkpoint restoration preserves the full future law of observer-accessible events, while an \(\varepsilon\)-accurate restoration changes that future law by at most \(\varepsilon\) in total variation. So the present wrapper cites a theorem-bearing continuation package at fixed cutoff even though the stronger strange-loop closure story remains open.
+The fixed-cutoff microphysics claim is stronger than the bare recoverability estimate written above. On the synchronized screen-microphysics paper, exact checkpoint restoration preserves the full future law of observer-accessible events, while an \(\varepsilon\)-accurate restoration changes that future law by at most \(\varepsilon\) in total variation. So the present wrapper cites a theorem-bearing continuation package at fixed cutoff even though the stronger strange-loop closure story remains open.
 
 \section{Physical Meaning}
-The continuation mechanism discussed here is now partly theorem-bearing and partly program-level. At fixed cutoff, the synchronized screen-microphysics audit surface proves a checkpoint/restoration theorem and backup corollary for observer-accessible event algebras. This wrapper records the observer-facing meaning of that theorem and its algebraic prerequisites; it is not the primary proof surface. What still remains open is the stronger substrate-selection, strange-loop closure, uniqueness, and stability package.
+The continuation mechanism discussed here is now partly theorem-bearing and partly program-level. At fixed cutoff, the synchronized screen-microphysics paper proves a checkpoint/restoration theorem and backup corollary for observer-accessible event algebras. This wrapper records the observer-facing meaning of that theorem and its algebraic prerequisites; it is not the primary proof surface. What still remains open is the stronger substrate-selection, strange-loop closure, uniqueness, and stability package.
 
 \end{document}

--- a/paper/reality_as_consensus_protocol.tex
+++ b/paper/reality_as_consensus_protocol.tex
@@ -36,15 +36,15 @@ The formalism is the computational spine of Observer-Patch Holography (OPH), a f
 
 \section{Introduction}
 
-Here is the claim, stated as plainly as possible:
+Here is the OPH proposal, stated as plainly as possible:
 
 \begin{center}
 \fbox{\parbox{0.88\textwidth}{\centering
-Objective physical law $=$ the gauge-invariant normal form\\
+In OPH, objective physical law is modeled by the gauge-invariant normal form\\
 of an asynchronous local reconciliation process.}}
 \end{center}
 
-That becomes mathematically sharp once you define patches, overlaps, local repair maps, and gauge equivalence. By the end of this paper you will have the proofs.
+That proposal becomes mathematically sharp once you define patches, overlaps, local repair maps, and gauge equivalence. By the end of this paper you will have the model theorems behind it.
 
 The idea goes like this. Suppose the universe has no global state. No God's-eye view, no master clock, no centralized ledger. All that exists are local observers, each holding a local description of their patch of reality, connected to neighbors through overlap regions where their descriptions must be compatible. When two neighbors disagree on their shared boundary, a local repair rule fires and updates one of them. This process runs asynchronously, with no preferred order of execution.
 

--- a/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
+++ b/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
@@ -71,7 +71,7 @@ This paper presents a single framework that addresses this list as a conditional
 Two decisions shape the present version.
 
 \begin{enumerate}[leftmargin=2em]
-\item The compact note presents the main theorem statements in one place, but some quantitative conventions and implementation details live in repository supplements.\footnote{Broader interpretive questions are deferred here so the compact note can keep its claim-tier boundary explicit.} For length, several theorem-level arguments below are recorded only as proof sketches; the synchronized main paper is the full-proof surface for those derivations.
+\item The compact note presents the main theorem statements in one place, but some quantitative conventions and implementation details live in repository supplements.\footnote{Broader interpretive questions are deferred here so the compact note can keep its claim-tier boundary explicit.} For length, several theorem-level arguments below are recorded only as proof sketches; the synchronized main paper contains the full derivations.
 \item The paper separates exact structural theorems, conditional scaling-limit branches, calibration-sector outputs, and phenomenological continuations. This keeps strong claims visible and weak claims identifiable.
 \end{enumerate}
 

--- a/paper/screen_microphysics_and_observer_synchronization.tex
+++ b/paper/screen_microphysics_and_observer_synchronization.tex
@@ -51,7 +51,7 @@ interfaces, while the continuum/gravity and global-consensus lifts remain open.
 \item Make the bridge from local registers to patches, overlaps, records, observers, and
 synchronization explicit enough to build toy simulators and fixed-cutoff theorem packages.
 \item Keep theorem claims, simulator claims, and conjectural bridges sharply separated.
-\item Feed the existing OPH microphysics, repair, and observer task lanes without pretending
+\item Feed the existing OPH microphysics, repair, and observer branches without pretending
 to close them automatically.
 \end{enumerate}
 
@@ -1390,7 +1390,7 @@ edge-state or local sampler).
 sector probabilities, attempted edge moves, and pass/fail statistics for every cycle.
 \end{enumerate}
 
-This remains a phase-1 architecture note. A successful pilot would show that one fixed-cutoff
+This remains a fixed-cutoff microphysics note. A successful pilot would show that one fixed-cutoff
 screen model can instantiate the declared objects and measurements; it would not identify a
 unique UV completion or close any continuum claim.
 
@@ -1725,7 +1725,7 @@ and correction menus on a finite screen.
 \end{enumerate}
 
 So the paper still does \emph{not} claim ``OPH microphysics solved.'' What it does claim is that
-one concrete regulated build surface has been made explicit enough to carry the mapped
+one concrete regulated fixed-cutoff note has been made explicit enough to carry the mapped
 fixed-cutoff theorem packages directly, while leaving uniqueness and continuum lift open.
 
 \subsection{Open bridges left deliberately open}
@@ -1734,27 +1734,28 @@ The deliberately open bridges are now narrower than they were at the start of th
 \begin{enumerate}[leftmargin=2em]
 \item \textbf{Microphysics uniqueness.}
 Nothing below claims that the octahedral $\mathbb Z_2$ pilot, the $S_3$ upgrade, or the
-thermalized edge-law branch are the unique OPH microphysics. They are the explicit regulated
-audit surfaces on which the present observer-side theorem packages are carried and the remaining
-structural branches are made explicit enough to finish.
+thermalized edge-law branch are the unique OPH microphysics. They are explicit regulated
+fixed-cutoff constructions on which the present observer-side theorem packages are carried and
+the remaining structural branches are made explicit enough to finish.
 \item \textbf{Global repair theory.}
 The local repair kernel, the regulator embedding, the edge-law package, and the local
-measurement/backup packages are closed here as fixed-cutoff audit surfaces. What remains beyond
-those mapped leaf tasks is the next layer only: global termination, local confluence,
+measurement/backup packages are carried here as fixed-cutoff theorem packages. What remains
+beyond those branches is the next layer only: global termination, local confluence,
 refinement-stable consensus, continuum-limit uniqueness, and the larger continuum/gravity lift.
 \item \textbf{Continuum / gravity lift.}
 The present results are fixed-cutoff theorems. This note still does not derive the OPH
 continuum, the geometric modular branch, or gravity from the finite regulator.
 \item \textbf{Downstream merges.}
 The later compact, reality, and observer papers still need notation-synchronized merges. For all
-four mapped leaves, those later edits are now packaging and placement work on downstream
-surfaces, not new proof obligations on the present microphysics audit surface.
+four imported packages, those later edits are now packaging and placement work on downstream
+papers, not new proof obligations on the present microphysics note.
 \end{enumerate}
 
 So the right asymmetry is now this: imported OPH structure stays imported, the finite reference
-architecture stays finite, all four mapped leaves are closed on this microphysics paper surface,
-and the remaining open work is the larger uniqueness / consensus / continuum program rather than
-unfinished leaf-level theorem packaging.
+architecture stays finite, the two observer-side theorem packages are closed on this microphysics
+paper surface, and the regulator and edge-law branches now have their remaining closure gaps made
+explicit rather than hidden. The remaining open work is the larger uniqueness / consensus /
+continuum program together with those still-open regulator and edge-law closures.
 
 \section{Audit-Surface Status of the Mapped Leaf Tasks}
 
@@ -1872,13 +1873,13 @@ observable family, the regulator pushes forward to the exact finite packet-level
 that family. When it fails, the embedding proved here still stands, but the missing quotient
 closure is explicit and logged rather than hidden.
 
-\paragraph{Audit conclusion.}
-This closes \texttt{papers.reality.a.01} on the present microphysics audit surface. The later
-consensus paper no longer needs to posit patch vertices, overlap alphabets, syndrome components,
-or candidate menus abstractly. Those objects are now fixed here by the regulator. What remains
-beyond \texttt{a.01} is the next layer only: packet-level closure when available, global
-termination, local confluence, schedule robustness, normal-form existence,
-residual-obstruction classification, and refinement-limit lift.
+\paragraph{Conclusion for this package.}
+This closes the regulated patch-net embedding package on the present microphysics paper. The
+later consensus paper no longer needs to posit patch vertices, overlap alphabets, syndrome
+components, or candidate menus abstractly. Those objects are now fixed here by the regulator.
+What remains next is packet-level closure when available, global termination, local confluence,
+schedule robustness, normal-form existence, residual-obstruction classification, and
+refinement-limit lift.
 
 \subsection{Edge heat-kernel / Casimir theorem}\label{sec:microphysics-feeds-e24}
 
@@ -1958,10 +1959,10 @@ heat-kernel / Casimir form
 w_\beta(R)\propto d_R e^{-\beta C_2(R)}
 \end{equation}
 on irreducible representation labels $R$. Thus the explicit screen microphysics carries the
-compact-paper edge-law branch on this audit surface, while leaving only refinement-stable
+compact-paper edge-law branch in this note, while leaving only refinement-stable
 universality and UV uniqueness for later work.
 
-\paragraph{Fixed-cutoff audit closure.}
+\paragraph{Fixed-cutoff closure.}
 The previous reference-model section supplies the concrete same-overlap realization needed for
 audit here: a declared cut register on each overlap, explicit sector projectors, an exact
 edge-state mode, a local sampler mode, and a compact-group truncation branch with
@@ -1969,11 +1970,11 @@ $\Delta_{IJ}^{\mathrm{QL}}=\sum_R C_2(R)\Pi_R^{(IJ)}$. So the theorem above is n
 Markov-chain exercise. It is the explicit fixed-cutoff edge law of the same regulated overlap
 microphysics used for synchronization and repair.
 
-\paragraph{Audit conclusion.}
-This closes \texttt{papers.compact.e.24} on the present microphysics audit surface. The later
+\paragraph{Conclusion for this package.}
+This closes the edge heat-kernel / Casimir package on the present microphysics paper. The later
 compact-paper merge still needs notation-synchronized transplant of this theorem package, but
-not a new proof. What remains beyond \texttt{e.24} is the larger uniqueness and
-refinement-stable universality program, not an unfinished leaf-level Casimir derivation.
+not a new proof. What remains next is the larger uniqueness and refinement-stable universality
+program, not an unfinished leaf-level Casimir derivation.
 
 \subsection{Measurement / Born-rule theorem stack}
 
@@ -2034,7 +2035,7 @@ defined but auditable.
 \paragraph{Merge boundary.}
 This closes the fixed-cutoff measurement/Born-rule package on the microphysics surface. The later
 supplement and observer-paper merges should simply import the same record algebra, Born trace,
-and conditioning statements onto their house notation.
+and conditioning statements into their surrounding notation.
 
 \subsection{Observer continuation / backup theorem stack}
 
@@ -2100,7 +2101,7 @@ for every later channel $\mathcal E$, and therefore the induced difference of al
 probabilities is bounded by $\varepsilon$.
 
 \paragraph{Identity criterion.}
-Two checkpoints represent the same observer on this audit surface iff they induce the same
+Two checkpoints represent the same observer in this paper iff they induce the same
 future law on the observer-accessible event algebra. Exact sameness means equality of that law;
 \(\varepsilon\)-approximate sameness means total-variation distance at most \(\varepsilon\).
 Thus the observer-identity criterion is operational and testable rather than rhetorical.
@@ -2118,23 +2119,23 @@ statements above into the observer paper's surrounding vocabulary.
 
 The program-level reading is now different from the earlier phase-1-only reading.
 \begin{enumerate}[leftmargin=2em]
-\item \texttt{papers.reality.a.01} now has an explicit regulated tuple and local interface
-theorem here, but still needs one more closure pass before audit.
-\item \texttt{papers.compact.e.24} now has an explicit thermalized finite-group branch here, but
-still needs one more closure pass on the compact heat-kernel lift before audit.
-\item \texttt{papers.observers.b.03} is closed here by the central record algebra, Born trace,
-and conditioning theorem stack.
-\item \texttt{papers.observers.e.18} is closed here by the checkpoint/restoration/error/identity
-theorem stack.
-\item What remains after this paper is the unfinished closure of \texttt{a.01} and
-\texttt{e.24}, plus merge propagation, refinement-stable universality, global consensus
-analysis, and continuum/gravity lift.
+\item The regulated patch-net embedding package now has an explicit regulated tuple and local
+interface theorem here, but its downstream closure still needs one more pass.
+\item The edge heat-kernel / Casimir package now has an explicit thermalized finite-group branch
+here, but its compact heat-kernel lift still needs one more pass.
+\item The fixed-cutoff measurement/Born-rule package is closed here by the central record
+algebra, Born trace, and conditioning theorem stack.
+\item The fixed-cutoff observer checkpoint/restoration package is closed here by the
+checkpoint/restoration/error/identity theorem stack.
+\item What remains after this paper is the unfinished regulator and edge-law closure work, plus
+merge propagation, refinement-stable universality, global consensus analysis, and
+continuum/gravity lift.
 \end{enumerate}
 
 So the microphysics side paper is no longer merely upstream scaffolding for those four leaves. It
-is already the theorem-bearing audit surface for the two observer-side closures, and it remains
-the active work surface on which the regulator and edge-law leaves are being finished before later
-paper merges.
+is already the theorem-bearing source for the two observer-side closures, and it remains the
+active paper on which the regulator and edge-law branches are being finished before later paper
+merges.
 
 \section{Conclusion}
 
@@ -2151,9 +2152,8 @@ structural branches:
 
 That still does \emph{not} identify the unique OPH UV completion, prove global repair
 convergence, derive the continuum/gravity branch, or finish the remaining regulator and edge-law
-closures. But it is no longer accurate to describe the paper as only a build surface. It is now
-the current audit surface on which \texttt{papers.observers.b.03} and
-\texttt{papers.observers.e.18} are closed, while \texttt{papers.reality.a.01} and
-\texttt{papers.compact.e.24} remain the next unfinished microphysics leaves.
+closures. But it is no longer accurate to describe the paper as only a simulator-facing scaffold. It is now
+the current source paper for the closed observer-side theorem packages, while the regulated
+patch-net embedding and edge-law branches remain the next unfinished microphysics packages.
 
 \end{document}

--- a/paper/tex_fragments/STRING_THEORY.tex
+++ b/paper/tex_fragments/STRING_THEORY.tex
@@ -68,7 +68,7 @@ Together with the local MaxEnt clause of the OPH axioms, these theorem-local pre
 
 \section{Einstein Equation from Entanglement Equilibrium}\label{3-einstein-equation-from-entanglement-equilibrium}
 
-Before turning to string theory, this part first recalls that OPH recovers gravity, the "target-space dynamics" that any string theory must reproduce.
+Before turning to string theory, this part first recalls the conditional OPH gravity branch, the "target-space dynamics" that any string theory must reproduce. The branch uses the same geometric-modular, fixed-cap-stationarity, and null-stress premises stated in Part~I.
 
 \subsection{Setup: Null Deformation Problem}\label{31-setup-null-deformation-problem}
 
@@ -116,7 +116,7 @@ The result \(R_{kk} = 8\pi G T_{kk}\) for all null \(k\) means: \[E_{ab} k^a k^b
 
 Therefore \(E_{ab} = \phi \, g_{ab}\), giving: \[R_{ab} = 8\pi G \langle T_{ab} \rangle + \phi \, g_{ab}\]
 
-In Einstein tensor form: \[\boxed{G_{ab} + \Lambda g_{ab} = 8\pi G \langle T_{ab} \rangle}\]
+In Einstein tensor form, on that same conditional branch: \[\boxed{G_{ab} + \Lambda g_{ab} = 8\pi G \langle T_{ab} \rangle}\]
 
 where \(\Lambda := \frac{1}{2}R - \phi\) is constant by the Bianchi identity.
 
@@ -166,7 +166,7 @@ For \(\Sigma_0 = S^2\) (genus 0): \[Z_{\text{2D YM}}(S^2) = \sum_R d_R^2 \exp\le
 
 \textbf{Identification:} \[t = \frac{g_{\text{YM}}^2 A}{2}\]
 
-\textbf{Theorem 4.1:} OPH edge-sector MaxEnt gives a fully-fledged 2D Yang-Mills theory on the screen, with collar diffusion parameter \(t\) playing the role of "coupling \ensuremath{\times} area".
+\textbf{Theorem 4.1:} OPH edge-sector MaxEnt gives the 2D Yang-Mills heat-kernel partition-function form for the edge branch, with collar diffusion parameter \(t\) playing the role of "coupling \ensuremath{\times} area". In the effective 2D Yang-Mills regime, this is the standard 2D YM identification.
 
 \begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
 
@@ -194,7 +194,7 @@ where:
 
 The \(1/N\) expansion coefficients count \textbf{branched coverings} of the target surface,i.e., "string configurations without folds."
 
-This is a genuine string theory:
+On that conditional large-\(N\) branch, this is a genuine string-theoretic reorganization:
 
 \begin{itemize}
 \tightlist
@@ -218,7 +218,7 @@ Define generating functional: \[F(t) := \log Z_{\text{edge}}(t)\]
 
 In controlled large-\(N\) regime: \[F(t) = \sum_{h \geq 0} N^{2-2h} F_h(\lambda), \quad \lambda := g_{\text{YM}}^2 N\]
 
-This is a perturbative closed-string genus expansion.
+This is therefore a perturbative closed-string genus expansion on the same conditional branch.
 
 \begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
 


### PR DESCRIPTION
# Phase 1-4 collective fix summary

This summary records the high-level cleanup applied across the audited Phase 1-4 paper surfaces after the broad and deep wording/status passes.

The main goal of this fix set was not to weaken OPH's strongest claims, but to make the public paper stack harder to attack on avoidable presentation grounds. The changes kept the claim ladder strong while removing wording that looked like internal workflow export, tightening cross-file status discipline, and making the authority surfaces speak with one voice about what is theorem-level, what is fixed-cutoff, and what remains continuation-level.

## What was fixed

- Internal manuscript-management language such as `full-proof surface`, `audit surface`, `task lanes`, `house notation`, and related workflow phrasing was removed from the public paper prose.
- The wrapper and side-paper surfaces were synchronized so they no longer blur the distinction between inherited theorem status and locally proved content.
- The screen-microphysics note was cleaned so its front matter, mid-body status language, and conclusion no longer disagree about whether observer-side packages are closed and whether regulator/edge-law packages remain open.
- The consensus side paper's opening framing was softened so the boxed statement now matches the later text that correctly treats the physical-reality identification as OPH interpretation built on exact model theorems.
- The string/worldsheet fragment was brought back into line with the compact authority note by restoring the conditional status of the Einstein branch, the large-\(N\) string reorganization, and the 2D Yang-Mills bridge.

## Files updated

- `paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex`
- `paper/observers_are_all_you_need.tex`
- `paper/reality_as_consensus_protocol.tex`
- `paper/screen_microphysics_and_observer_synchronization.tex`
- `paper/tex_fragments/STRING_THEORY.tex`

## Net effect

After this cleanup, the Phase 1-4 paper surfaces present a more consistent public-facing story:

- the compact note remains the claim-tier authority;
- the wrapper records inherited status without sounding like internal workflow;
- the consensus and microphysics side papers read like papers rather than task trackers;
- the string fragment stays strong, but no longer overstates continuation-level branches as already closed theorem-level outputs.

At the high-level audit layer, this removes the main wording and status-discipline attacks that were still exposed across Phases 1-4.