### PR TITLE
fix: separate structural proton claims from QCD-dependent ones (issue #49)

### DIFF
--- a/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
+++ b/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
@@ -55,7 +55,7 @@ and the total screen capacity
 \[
 N_{\mathrm{scr}} \equiv \log \dim \mathcal H_{\mathrm{tot}} \sim 10^{122}.
 \]
-In the current implementation, $P$ feeds the supplement-backed gauge/electroweak calibration sector and $N_{\mathrm{scr}}$ feeds the capacity branch for $\Lambda$; the D10--D11 numerical branches are reported only as implementation-level checks, not as the recovered core itself. Charged-lepton/Koide, texture, capacity-level neutrino estimates, dark-sector, baryogenesis, black-hole-spectroscopy, and string/worldsheet discussions are explicitly deferred continuations requiring additional ans\"atze beyond the recovered core and are not claimed as outputs of overlap consistency plus the stated scaling-limit and categorical premises. The purpose of this compact note is therefore to state a clean Phase-I claim set: relativity and Standard Model structure are the recovered core, while all downstream branches are either input-dependent or supplement-backed secondary sectors, or post-Phase-I phenomenology.
+In the current implementation, $P$ feeds the supplement-backed gauge/electroweak calibration sector and $N_{\mathrm{scr}}$ feeds the capacity branch for $\Lambda$; the D10--D11 numerical branches are reported only as implementation-level checks, not as the recovered core itself. Charged-lepton/Koide, texture, capacity-level neutrino estimates, dark-sector, baryogenesis, black-hole-spectroscopy, proton-spin, proton-lifetime estimates beyond the structural exclusion of gauge-mediated decay, and string/worldsheet discussions are explicitly deferred continuations requiring additional ans\"atze beyond the recovered core and are not claimed as outputs of overlap consistency plus the stated scaling-limit and categorical premises. The purpose of this compact note is therefore to state a clean Phase-I claim set: relativity and Standard Model structure are the recovered core, while all downstream branches are either input-dependent or supplement-backed secondary sectors, or post-Phase-I phenomenology.
 \end{abstract}
 
 \section{Introduction}
@@ -92,7 +92,7 @@ is recovered in the bosonic compact-gauge branch once the extended MAR admissibi
 \item The current quantitative implementation uses two external continuous configuration inputs, $P$ and $N_{\mathrm{scr}}$.
 \item The Higgs/top critical-surface branch adds no extra continuous fit once the gauge trajectory and scale-setting branch are fixed, while the charged-lepton/Koide continuation uses extra phenomenological structure beyond the core theorem package.
 \item A separate input-dependent capacity corollary ties the cosmological-constant branch to global screen capacity rather than local vacuum energy.
-\item Absence of gauge-mediated proton decay follows from product-group structure.
+\item Exclusion of gauge-mediated proton decay follows from product-group structure; any stronger proton-lifetime claim remains UV/EFT/QCD-dependent.
 \item Dark-sector, baryogenesis, string, and spectroscopy branches are kept visible, but only as program-level continuations or, where additional ans\"atze are involved, conjectural phenomenology.
 \item Overlap repair admits a unique schedule-independent normal form on the stated finite patch-net hypotheses.
 \end{enumerate}
@@ -129,7 +129,7 @@ Node & Output & Immediate OPH ingredients & Standard mathematics used & Extra no
 \textbf{D9} & Realized Standard Model quotient, hypercharges, the counting chain \(N_g=3\) then \(N_c=3\), and product-group corollaries (Theorem~\ref{thm:hypercharge}, Corollaries~\ref{cor:ng}, \ref{cor:nc}, Proposition~\ref{prop:z6}) & D8 & anomaly-cancellation algebra; Witten global-anomaly argument; CKM CP counting & realized one-generation chiral matter plus one Higgs package; asymptotic-freedom and MAR admissibility premises & Phase I realized-branch theorem/corollary chain \\
 \textbf{D10} & Gauge/electroweak numerical closure of the current supplement-backed implementation & D9 + external input \(P\) & RG evolution and matching conventions supplied in the supplement & pixel constraint; edge heat-kernel closure; supplement-backed beta-function and threshold conventions & Phase II calibration sector \\
 \textbf{D11} & Higgs/top critical-surface branch of the current supplement-backed implementation & D10 & RG transport and pole-mass conversion supplied in the supplement & critical-surface condition \(\lambda=\beta_\lambda=0\) at \(M_U\), plus the UV synchronization scale \(\mu_{\mathrm{sync}}\) used in the D11 transport; no new continuous fit once D10 is fixed & Phase II supplement-backed quantitative branch \\
-\textbf{D12} & Charged-lepton/Koide, texture, dark-sector, baryogenesis, black-hole spectroscopy, conditional string/worldsheet reorganizations, conjectural critical-superstring extensions, and other continuations & various subsets of D6, D9, D10, and D11 & branch-specific EFT and phenomenological manipulations & additional ans\"atze such as the uniform \(\mathbb Z_6\) center-label ensemble, discrete texture choices, dark-sector response assumptions, discrete-horizon assumptions, or extra worldsheet/CFT premises & Phase III phenomenological continuation / program-level branch \\
+\textbf{D12} & Charged-lepton/Koide, texture, dark-sector, baryogenesis, black-hole spectroscopy, proton-spin, proton-lifetime estimates beyond the gauge-channel exclusion, conditional string/worldsheet reorganizations, conjectural critical-superstring extensions, and other continuations & various subsets of D6, D9, D10, and D11 & branch-specific EFT and phenomenological manipulations & additional ans\"atze such as the uniform \(\mathbb Z_6\) center-label ensemble, discrete texture choices, dark-sector response assumptions, discrete-horizon assumptions, or extra worldsheet/CFT premises & Phase III phenomenological continuation / program-level branch \\
 \end{longtable}
 \endgroup
 
@@ -275,7 +275,7 @@ Node & Compact theorem labels and output & Immediate OPH ingredients & Standard 
 \textbf{D9} & Theorem~\ref{thm:hypercharge}, Corollaries~\ref{cor:ng}, \ref{cor:nc}, Proposition~\ref{prop:z6}: realized Standard Model quotient, hypercharges, the counting chain \(N_g=3\) then \(N_c=3\), and product-group corollaries & D8 & anomaly-cancellation algebra; Witten global-anomaly argument; CKM CP counting & realized one-generation chiral matter plus one Higgs package; asymptotic-freedom and MAR admissibility premises & realized-branch theorem/corollary chain \\
 \textbf{D10} & quantitative gauge/electroweak closure of Section~7 & D9 + external input \(P\) & RG evolution and matching conventions supplied in the supplement & pixel constraint; edge heat-kernel closure; supplement-backed beta-function and threshold conventions & calibration sector \\
 \textbf{D11} & Higgs/top subsection of Section~7 & D10 & RG transport and pole-mass conversion supplied in the supplement & critical-surface condition \(\lambda=\beta_\lambda=0\) at \(M_U\), plus the UV synchronization scale \(\mu_{\mathrm{sync}}\) used in the D11 transport; no new continuous fit once D10 is fixed & supplement-backed quantitative branch \\
-\textbf{D12} & Sections~8--10 program continuations, including conditional string/worldsheet reorganizations and conjectural critical-superstring extensions & various subsets of D6, D9, D10, and D11 & branch-specific EFT and phenomenological manipulations & additional ans\"atze such as the uniform \(\mathbb Z_6\) center-label ensemble, texture choices, dark-sector response assumptions, discrete-horizon assumptions, or extra worldsheet/CFT premises & phenomenological continuation / program-level branch \\
+\textbf{D12} & Sections~8--10 program continuations, including proton-spin and non-gauge proton-lifetime estimates together with the string/worldsheet branch & various subsets of D6, D9, D10, and D11 & branch-specific EFT and phenomenological manipulations & additional ans\"atze such as the uniform \(\mathbb Z_6\) center-label ensemble, texture choices, dark-sector response assumptions, discrete-horizon assumptions, or extra worldsheet/CFT premises & phenomenological continuation / program-level branch \\
 \end{longtable}
 \endgroup
 
@@ -2365,6 +2365,8 @@ for gauge-mediated proton decay is already a corollary of the realized Standard 
 \]
 is already isolated earlier as the separate input-dependent capacity corollary D6 once the screen-capacity identification is adopted. Neither point should be confused with the conjectural branches below.
 
+That structural proton statement is deliberately narrow: it excludes the simple-GUT gauge-boson channel only. It does not by itself close scalar-mediated or generic higher-dimensional baryon-violating operators, nor does it supply the RG transport and nonperturbative hadronic matrix elements needed for a full proton-lifetime prediction.
+
 \subsection{Dark-sector branch}
 
 The modular-anomaly proposal for an effective dark stress tensor requires more than the recovered gravity branch. The compact note does derive the modular additivity defect
@@ -2467,7 +2469,7 @@ Phase I recovered core (Theorem~\ref{thm:master}; D1--D5, D7--D9) & Confluence o
 Phase II input-dependent corollary (D6) & \(\Lambda=\frac{3\pi}{G N_{\mathrm{scr}}}\) once the screen-capacity identification is made, together with the separate order-of-magnitude neutrino estimate tied to the same capacity input & Failure of the screen-capacity identification or of the specific global capacity relation. Such a failure would not by itself erase the recovered core \\
 Phase II current implementation: calibration sector (D10) & Pixel-closure gauge/electroweak consistency, \(\alpha_i(m_Z)\), \(\alpha_{\mathrm{em}}^{-1}(m_Z)\), \(\sin^2\theta_W(m_Z)\), \(v\), and tree-level electroweak masses & Failure of the supplement-backed closure of the present implementation once \(P\) and the printed running/matching conventions are imposed \\
 Phase II current implementation: secondary quantitative branch (D11) & Higgs/top critical-surface branch & Failure of the extra critical-surface condition or of the supplement-backed RG transport used in that branch; such a failure does not by itself erase the recovered core \\
-Phase III deferred continuations (D12 and beyond) & Flavor ans\"atze, charged-lepton/Koide fits, texture branches, neutrino mass/mixing constructions beyond the D6 estimate, dark-sector response laws, baryogenesis estimates, black-hole spectroscopy templates, conditional string/worldsheet reorganizations, conjectural critical-superstring extensions, and other downstream phenomenology & Retraction of the corresponding continuation only. These branches are not part of the compact paper's recovered core and their failure is not, by itself, a falsification of relativity-plus-Standard-Model recovery \\
+Phase III deferred continuations (D12 and beyond) & Flavor ans\"atze, charged-lepton/Koide fits, texture branches, neutrino mass/mixing constructions beyond the D6 estimate, dark-sector response laws, baryogenesis estimates, proton-spin bookkeeping, proton-lifetime estimates beyond the gauge-channel exclusion, black-hole spectroscopy templates, conditional string/worldsheet reorganizations, conjectural critical-superstring extensions, and other downstream phenomenology & Retraction of the corresponding continuation only. These branches are not part of the compact paper's recovered core and their failure is not, by itself, a falsification of relativity-plus-Standard-Model recovery \\
 \end{longtable}
 \endgroup
 
@@ -2521,6 +2523,7 @@ The following do \emph{not} falsify Theorem~\ref{thm:master} if they fail in the
 \item Koide/charged-lepton constructions, texture exponents, or capacity-level neutrino estimates;
 \item modular-anomaly dark-sector response laws or MOND/RAR-style scaling claims;
 \item baryogenesis estimates based on extra suppression-counting assumptions;
+\item proton-spin ans\"atze or proton-lifetime estimates beyond the structural exclusion of gauge-mediated decay;
 \item discrete-horizon spectroscopy templates;
 \item large-$N_{\mathrm{edge}}$ string/worldsheet reorganizations.
 \end{enumerate}

--- a/paper/tex_fragments/TECHNICAL_SUPPLEMENT.tex
+++ b/paper/tex_fragments/TECHNICAL_SUPPLEMENT.tex
@@ -960,6 +960,13 @@ yields the MOND/RAR form: \[g_{\text{obs}} \approx g_b + \sqrt{a_0 g_b}\]
 
 \section{Proton Stability and Spin}\label{10-proton-stability-and-spin}
 
+This section separates three distinct claim types that were too compressed in older drafts:
+\begin{enumerate}
+\item \textbf{Structural output already closed on the realized D8--D9 branch:} the realized low-energy gauge group is a product up to finite quotient, so the adjoint contains no mixed \(X,Y\)-type gauge bosons and therefore no \emph{gauge-mediated} proton-decay channel of simple-GUT type.
+\item \textbf{QCD/EFT-dependent hadron claims:} any finite proton-lifetime estimate beyond that gauge-channel exclusion, and any statement about the proton spin decomposition, require explicit operator matching, renormalization conventions, and nonperturbative hadronic matrix elements.
+\item \textbf{Still-open completion burden:} the present supplement does not yet contain the nonperturbative light-quark/hadron completion needed to turn those QCD-dependent statements into derived OPH outputs.
+\end{enumerate}
+
 \subsection{Sector Factorization and Product Group}\label{101-sector-factorization-and-product-group}
 
 \textbf{Theorem 10.1 (Factorization Equivalence):} \[\text{Factorizing edge weights} \Leftrightarrow \text{Additive boundary Laplacian} \Leftrightarrow \text{Product gauge group}\]
@@ -972,22 +979,42 @@ Under the extended theory \(T_{\mathrm{ext}}\), the explicit MAR selector picks 
 
 \subsection{No Leptoquarks, No Gauge Proton Decay}\label{102-no-leptoquarks-no-gauge-proton-decay}
 
-\textbf{Corollary 10.2:} With product gauge group, the adjoint representation of the full connected gauge group is \[(8,1,0) \oplus (1,3,0) \oplus (1,1,0)\]
+\textbf{Corollary 10.2 (structural D8--D9 consequence only):} With product gauge group, the adjoint representation of the full connected gauge group is \[(8,1,0) \oplus (1,3,0) \oplus (1,1,0)\]
 
 equivalently, the adjoint of the derived gauge group is
 \[
 (8,1,0) \oplus (1,3,0).
 \]
 
-No gauge generators in mixed representations \((3,2,\pm 5/6)\) (the SU(5) \(X,Y\) bosons). Hence: \[\tau_p^{(\text{gauge})} = \infty\]
+There are therefore no gauge generators in mixed representations \((3,2,\pm 5/6)\), i.e.\ no simple-GUT \(X,Y\) bosons on the realized OPH branch. The structural claim is exactly
+\[
+\tau_p^{(\text{gauge})} = \infty,
+\]
+meaning that the gauge-boson proton-decay channel is absent.
+
+\textbf{What is not proved here.} This does \emph{not} establish full proton stability, and it does not justify the stronger shorthand \(\tau_p=\infty\). Scalar-mediated or higher-dimensional baryon-violating operators, RG transport of those operators from a UV completion, and the hadronic matrix elements entering exclusive proton-decay rates are all outside the present structural argument. Those steps are EFT/QCD-dependent and remain open in the current supplement. The electroweak baryon-violating counting discussed in Section~\ref{11-baryogenesis} is a separate high-temperature/topological issue rather than a zero-temperature proton-stability theorem.
 
 \subsection{Proton Spin Fraction}\label{103-proton-spin-fraction}
 
-\textbf{Casimir Equilibration Ansatz:} Spin sharing between quarks and gluons equilibrates according to coupling strength: \[\Delta\Sigma \approx \frac{C_F}{C_F + C_A}\]
+\textbf{Structural content already fixed.} On the realized D8--D9 branch the color factor is \(\mathrm{SU}(3)\), so the relevant Casimirs are
+\[
+C_F=\frac43,\qquad C_A=3.
+\]
+That is the full structural OPH input currently available for proton-spin bookkeeping.
 
-For SU(3): \(C_F = 4/3\), \(C_A = 3\): \[\Delta\Sigma = \frac{4/3}{4/3 + 3} = \frac{4}{13} \approx 0.308\]
+\textbf{QCD-dependent continuation ansatz.} If one adds the phenomenological ansatz that quark/gluon spin sharing equilibrates according to the color Casimirs, then
+\[
+\Delta\Sigma \approx \frac{C_F}{C_F + C_A}.
+\]
 
-Compare to lattice: \(\Delta\Sigma \approx 0.286\) (within 8\%).
+For \(\mathrm{SU}(3)\) this gives
+\[
+\Delta\Sigma = \frac{4/3}{4/3 + 3} = \frac{4}{13} \approx 0.308.
+\]
+
+Compared to the representative lattice benchmark \(\Delta\Sigma \approx 0.286\), this lands within about \(8\%\). But the displayed value is only a deferred continuation benchmark, not a theorem. The observable \(\Delta\Sigma\) is factorization-scheme and scale dependent and, in QCD, depends on the polarized axial-current matrix element together with gluon-spin and orbital-angular-momentum contributions.
+
+\textbf{Still open.} A first-principles OPH derivation of proton spin would require the nonperturbative light-quark/hadron completion of Phase I plus an explicit map from OPH data to renormalized proton matrix elements. Until that exists, the \(4/13\) estimate should be read only as a QCD-dependent continuation ansatz.
 
 \begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
 
@@ -1211,7 +1238,7 @@ This appendix does not extend the theorem-level list. It records every non-core 
 \item \textbf{Phase II input-dependent corollary (D6):} the capacity relation for \(\Lambda\) and the associated order-of-magnitude capacity / neutrino estimate.
 \item \textbf{Phase II calibration sector (D10):} gauge/electroweak closure of the D10 branch, including the associated beta-shift comparison.
 \item \textbf{Phase II secondary quantitative branch (D11):} the Higgs/top critical-surface branch once the D10 trajectory and the extra critical-surface condition are imposed.
-\item \textbf{Phase III deferred continuations (D12 and beyond):} charged-lepton/Koide, texture, neutrino mass/mixing constructions beyond the D6 estimate, dark-sector, baryogenesis, black-hole spectroscopy, string/worldsheet, proton-spin, and other downstream fits.
+\item \textbf{Phase III deferred continuations (D12 and beyond):} charged-lepton/Koide, texture, neutrino mass/mixing constructions beyond the D6 estimate, dark-sector, baryogenesis, black-hole spectroscopy, string/worldsheet, proton-spin, and any proton-lifetime estimate beyond the structural exclusion of gauge-mediated decay.
 \end{enumerate}
 
 These failures localize by tier: item 4 retracts the corresponding continuation only; item 3 challenges D11; item 2 challenges D10; item 1 challenges the screen-capacity identification only. None of them erases the recovered core D1--D5 plus D7--D9 by itself.
@@ -1223,7 +1250,7 @@ These failures localize by tier: item 4 retracts the corresponding continuation 
 \item extend the compact-gauge reconstruction from the bosonic internal-gauge branch to the fermionic/super-Tannakian chiral branch while preserving the D7--D9 Standard Model structural chain;
 \item derive or independently fix the external continuous inputs $P$ and $N_{\mathrm{scr}}$, and complete a fully auditable D10--D11 numerical pipeline with explicit running, threshold, and matching conventions;
 \item separate the D6 capacity relation from flavor-style add-ons by deciding exactly which neutrino or cosmological continuations survive without additional ans\"atze;
-\item only after items 1--4 are secured, reopen the Phase-III continuations: charged-lepton/Koide structure, texture exponents, dark-sector response laws, baryogenesis, black-hole spectroscopy, string/worldsheet reorganization, proton-spin bookkeeping, and any similar late-stage continuation such as strong-CP proposals.
+\item only after items 1--4 are secured, reopen the Phase-III continuations: charged-lepton/Koide structure, texture exponents, dark-sector response laws, baryogenesis, black-hole spectroscopy, string/worldsheet reorganization, proton-spin bookkeeping, proton-lifetime estimates beyond the structural gauge-channel exclusion, and any similar late-stage continuation such as strong-CP proposals.
 \end{enumerate}
 
 Interpretive strange-loop / existence narratives sit below that ledger entirely. They are philosophical continuations, not appendix-backed theorem or benchmark claims. This supplement does not define a theorem-usable configuration space for a global emergence map, prove that observer formation and reconstruction close to an internal self-map on such a space, or supply the compactness/contractivity/stability premises needed for an existence or stability theorem.
@@ -1241,7 +1268,7 @@ Quantity / branch & OPH Value & Observed & Status \\
 \bottomrule\noalign{}
 \endlastfoot
 \(a_0\) (dark-sector continuation) & \(1.03 \times 10^{-10}\) m/s\textsuperscript{2} & \(1.2 \times 10^{-10}\) m/s\textsuperscript{2} & deferred continuation benchmark \\
-\(\Delta\Sigma\) (spin continuation) & 0.308 & 0.29 \ensuremath{\pm} 0.03 & deferred continuation benchmark \\
+\(\Delta\Sigma\) (spin continuation; QCD-dependent ansatz) & 0.308 & 0.29 \ensuremath{\pm} 0.03 & deferred continuation benchmark \\
 \(\eta_B\) (baryogenesis estimate) & \(4.6 \times 10^{-10}\) & \(6.1 \times 10^{-10}\) & deferred continuation benchmark \\
 Koide \(Q\) (flavor continuation) & 2/3 & 0.666664 & deferred continuation benchmark \\
 Koide \(\delta\) (flavor continuation) & 2/9 & 0.222225 & deferred continuation benchmark \\


### PR DESCRIPTION
- Partition proton claims in the technical supplement into structural D8-D9 output, QCD/EFT-dependent hadron claims, and the still-open nonperturbative completion burden
- Narrow proton stability to the gauge-mediated decay exclusion and demote broader proton-lifetime and proton-spin statements to continuation-level status
- Align the compact note ledgers and falsifiability language with the same narrower proton claim boundary