### PR TITLE
fix: demote unsupported chiral closure claims (issue #26)

### DIFF
--- a/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
+++ b/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
@@ -39,7 +39,7 @@ Observer-Overlap Consistency\\[0.4em]
 \OPHPaperReleaseBanner
 
 \begin{abstract}
-We present a compact, falsifiable Phase-I statement of Observer-Patch Holography (OPH) as a conditional reconstruction program whose claimed recovered core is limited to relativity and Standard Model structure. From five axioms, the stated scaling-limit/categorical regularity package, and two external continuous inputs used only in the current quantitative implementation, the compact note derives a schedule-independent normal form for overlap consistency, a conditional Lorentz branch on the screen, a conditional Jacobson-type Einstein branch from fixed-cap generalized-entropy stationarity together with the null modular bridge and the scaling-limit null-stress premise, and conditional compact gauge reconstruction in the bosonic internal-gauge branch from a refinement-stable symmetric edge-sector colimit. After Axiom~\ref{ax:mar} (Minimal Admissible Realization, MAR) is imposed on the connected positive-dimensional Lie admissible class with one connected abelian charge factor, the realized low-energy gauge group on that realized branch is
+We present a compact, falsifiable Phase-I statement of Observer-Patch Holography (OPH) as a conditional reconstruction program whose claimed recovered core is limited to relativity and bosonic compact-gauge reconstruction, together with a separate visible realized-branch extension for Standard-Model-like low-energy structure. From five axioms, the stated scaling-limit/categorical regularity package, and two external continuous inputs used only in the current quantitative implementation, the compact note derives a schedule-independent normal form for overlap consistency, a conditional Lorentz branch on the screen, a conditional Jacobson-type Einstein branch from fixed-cap generalized-entropy stationarity together with the null modular bridge and the scaling-limit null-stress premise, and conditional compact gauge reconstruction in the bosonic internal-gauge branch from a refinement-stable symmetric edge-sector colimit. If one further supplies the realized one-generation Standard Model chiral matter package with one Higgs doublet together with the MAR admissibility premises used in Section~6, the visible realized-branch extension identifies
 \[
 \frac{\SU(3)\times \SU(2)\times \U(1)}{\mathbb Z_6},
 \qquad
@@ -47,7 +47,7 @@ N_g=3,
 \qquad
 N_c=3,
 \]
-together with the exact rational hypercharge lattice for the realized one-generation Standard Model chiral matter package with one Higgs doublet. The realized counting chain is sequential rather than joint: on the realized MAR-admissible branch, the asymptotic-freedom/CP-capability window and minimal admissibility yield \(N_g=3\), and then Witten's \(\SU(2)\) anomaly parity constraint together with the same realized-branch selector yield \(N_c=3\). The two external continuous inputs of the present implementation are the pixel area
+together with the exact rational hypercharge lattice on that imported matter package. The two external continuous inputs of the present implementation are the pixel area
 \[
 P \equiv a_{\mathrm{cell}}/\ell_P^2 = 1.63094
 \]
@@ -55,7 +55,7 @@ and the total screen capacity
 \[
 N_{\mathrm{scr}} \equiv \log \dim \mathcal H_{\mathrm{tot}} \sim 10^{122}.
 \]
-In the current implementation, $P$ feeds a supplement-backed gauge-coupling calibration sector and $N_{\mathrm{scr}}$ feeds the capacity branch for $\Lambda$; these non-core numerical branches are reported only as implementation-level checks, not as the recovered core itself. Charged-lepton/Koide, texture, capacity-level neutrino estimates, dark-sector, baryogenesis, black-hole-spectroscopy, proton-spin, proton-lifetime estimates beyond the structural exclusion of gauge-mediated decay, and string/worldsheet discussions are explicitly deferred continuations requiring additional ans\"atze beyond the recovered core and are not claimed as outputs of overlap consistency plus the stated scaling-limit and categorical premises. The purpose of this compact note is therefore to state a clean Phase-I claim set: relativity and Standard Model structure are the recovered core, while all downstream branches are either input-dependent or supplement-backed secondary sectors, or post-Phase-I phenomenology.
+In the current implementation, $P$ feeds a supplement-backed gauge-coupling calibration sector and $N_{\mathrm{scr}}$ feeds the capacity branch for $\Lambda$; these non-core numerical branches are reported only as implementation-level checks, not as the recovered core itself. Charged-lepton/Koide, texture, capacity-level neutrino estimates, dark-sector, baryogenesis, black-hole-spectroscopy, proton-spin, proton-lifetime estimates beyond the structural exclusion of gauge-mediated decay, and string/worldsheet discussions are explicitly deferred continuations requiring additional ans\"atze beyond the recovered core and are not claimed as outputs of overlap consistency plus the stated scaling-limit and categorical premises. The purpose of this compact note is therefore to state a clean Phase-I claim set: relativity and bosonic compact-gauge reconstruction are the recovered core, while the Standard-Model-like realized branch, the input-dependent sectors, and all downstream continuations remain visible but non-core.
 \end{abstract}
 
 \section{Introduction}
@@ -83,12 +83,8 @@ The results emphasized in this paper are ordered below by a combination of impac
 
 \begin{enumerate}[leftmargin=2em]
 \item A conditional Jacobson-type Einstein branch is recovered from observer-overlap modular geometry, an explicit fixed-cap generalized-entropy stationarity premise, the geometric-branch selection burden, and an explicit null-modular / null-stress scaling-limit package; in the null modular bridge, quasi-local propagation, endpoint control, half-sided inclusion, and the explicit positive null-translation generator are now supplied internally through the derived Borchers stage, while the density upgrade and null-stress identification remain explicit downstream burdens.
-\item The exact Standard Model gauge structure
-\[
-\frac{\SU(3)\times\SU(2)\times\U(1)}{\mathbb Z_6}
-\]
-is recovered in the bosonic compact-gauge branch once the MAR admissibility package is imposed.
-\item On the realized one-generation chiral matter plus one-Higgs package, anomaly constraints and Yukawa invariance fix the hypercharge lattice, and on the realized MAR-admissible branch the counting chain yields \(N_g=3\) and then, using Witten's \(\SU(2)\) anomaly parity constraint, \(N_c=3\).
+\item A compact gauge group is reconstructed in the bosonic internal-gauge branch, and the product-group selector arguments are kept distinct from that reconstructed-core theorem.
+\item On the imported realized one-generation chiral matter plus one-Higgs package, anomaly constraints and Yukawa invariance fix the hypercharge lattice, while MAR admissibility and Witten's \(\SU(2)\) anomaly constrain \(N_g\) and \(N_c\).
 \item The current quantitative implementation uses two external continuous configuration inputs, $P$ and $N_{\mathrm{scr}}$.
 \item Downstream matter-sector continuations, including charged-lepton/Koide structure, remain visible but explicitly outside the compact paper's recovered-core theorem package.
 \item A separate input-dependent capacity corollary ties the cosmological-constant branch to global screen capacity rather than local vacuum energy.
@@ -101,11 +97,11 @@ is recovered in the bosonic compact-gauge branch once the MAR admissibility pack
 
 This section is the authoritative status ledger for the compact note and the sync rule for mirrored summary surfaces. The three-phase boundary used throughout is
 \[
-\text{Phase I}=(D1\text{--}D5)\cup(D7\text{--}D9),\qquad
-\text{Phase II}=D6\cup D10,\qquad
+\text{Phase I}=(D1\text{--}D5)\cup D7,\qquad
+\text{Phase II}=D6\cup(D8\text{--}D10),\qquad
 \text{Phase III}=D12.
 \]
-Phase I is the recovered-core claim set. Phase II contains the separate input-dependent capacity corollary and the current supplement-backed gauge-calibration sector. Phase III collects deferred continuations. The canonical five-axiom basis, the two external continuous inputs, and the technical-premise labels used below are fixed in Section~\ref{sec:premise-ledger}. Each row names a node in the reconstruction program, records its immediate OPH-side parents, separates imported standard mathematics from extra non-axiom physical premises or external inputs, and states the resulting claim tier.
+Phase I is the recovered-core claim set. Phase II contains the separate input-dependent capacity corollary, the visible realized-branch selector extension for low-energy gauge structure, and the current supplement-backed gauge-calibration sector. Phase III collects deferred continuations. The canonical five-axiom basis, the two external continuous inputs, and the technical-premise labels used below are fixed in Section~\ref{sec:premise-ledger}. Each row names a node in the reconstruction program, records its immediate OPH-side parents, separates imported standard mathematics from extra non-axiom physical premises or external inputs, and states the resulting claim tier.
 
 \begingroup
 \scriptsize
@@ -125,14 +121,14 @@ Node & Output & Immediate OPH ingredients & Standard mathematics used & Extra no
 \textbf{D5} & Jacobson-type Einstein branch: rest-frame relation plus conditional tensor upgrade (Lemma~\ref{lem:smallball}, Theorem~\ref{thm:einstein}, Corollary~\ref{cor:einstein}) & D3+D4 and Axioms~\ref{ax:screen}--\ref{ax:entropy} & Jacobson small-ball first law; null-to-tensor reconstruction modulo a metric term & T9 fixed-cap stationarity; locally Lorentzian \(d=4\) scaling regime; small-ball constancy assumptions; D4 carried remainder negligible at order \(\ell^4\); all local directions/reference states for the tensor upgrade & Phase I conditional scaling-limit theorem/corollary \\
 \textbf{D6} & Capacity branch for \(\Lambda\) and the separate order-of-magnitude neutrino estimate (Proposition~\ref{prop:lambda}, Corollary~\ref{cor:lambda}) & D5 leaves a \(+\Lambda g_{ab}\) ambiguity & de Sitter entropy relation and dimensional analysis & external input \(N_{\mathrm{scr}}\) and the screen-capacity identification & Phase II input-dependent corollary / estimate \\
 \textbf{D7} & Compact gauge reconstruction (Theorem~\ref{thm:compactgauge}) & Axioms~\ref{ax:screen}--\ref{ax:entropy} & Doplicher--Roberts / Tannaka reconstruction & T7 and T10--T11 together with the directed-colimit/fiber clause of T12; the refinement-stable qualifier on that colimit is supplied internally by Axiom~\ref{ax:maxent} & Phase I conditional structural theorem \\
-\textbf{D8} & Product gauge structure up to finite quotient (Lemmas~\ref{lem:mincontent}--\ref{lem:commutant}, Theorem~\ref{thm:sm}) & D7 + Axiom~\ref{ax:mar} & compact Lie representation classification; Schur's lemma & connected positive-dimensional Lie admissible class; one connected abelian factor; faithful action on the minimal coupled carrier; vanishing obstruction \([z]=0\) & Phase I realized-branch theorem \\
-\textbf{D9} & Realized Standard Model quotient, hypercharges, the counting chain \(N_g=3\) then \(N_c=3\), and product-group corollaries (Theorem~\ref{thm:hypercharge}, Corollaries~\ref{cor:ng}, \ref{cor:nc}, Proposition~\ref{prop:z6}) & D8 & anomaly-cancellation algebra; Witten global-anomaly argument; CKM CP counting & realized one-generation chiral matter plus one Higgs package; asymptotic-freedom and MAR admissibility premises & Phase I realized-branch theorem/corollary chain \\
+\textbf{D8} & Product gauge structure up to finite quotient (Lemmas~\ref{lem:mincontent}--\ref{lem:commutant}, Theorem~\ref{thm:sm}) & D7 + Axiom~\ref{ax:mar} & compact Lie representation classification; Schur's lemma & imported admissible chiral matter package with one Higgs; connected positive-dimensional Lie admissible class; one connected abelian factor; faithful action on the minimal coupled carrier; vanishing obstruction \([z]=0\) & Phase II conditional realized-branch theorem \\
+\textbf{D9} & Realized Standard Model quotient, hypercharges, the counting consequences \(N_g=3\) and \(N_c=3\), and product-group corollaries (Theorem~\ref{thm:hypercharge}, Corollaries~\ref{cor:ng}, \ref{cor:nc}, Proposition~\ref{prop:z6}) & D8 & anomaly-cancellation algebra; Witten global-anomaly argument; CKM CP counting & realized one-generation chiral matter plus one Higgs package; asymptotic-freedom and MAR admissibility premises & Phase II conditional realized-branch theorem/corollary chain \\
 \textbf{D10} & Gauge-coupling numerical closure of the current supplement-backed implementation & D9 + external input \(P\) & RG evolution and matching conventions supplied in the supplement & pixel constraint; edge heat-kernel closure; supplement-backed beta-function and threshold conventions & Phase II calibration sector \\
 \textbf{D12} & Charged-lepton/Koide, texture, dark-sector, baryogenesis, black-hole spectroscopy, proton-spin, proton-lifetime estimates beyond the gauge-channel exclusion, conditional string/worldsheet reorganizations, conjectural critical-superstring extensions, and other continuations & various subsets of D6, D9, and D10 & branch-specific EFT and phenomenological manipulations & additional ans\"atze such as the uniform \(\mathbb Z_6\) center-label ensemble, discrete texture choices, dark-sector response assumptions, discrete-horizon assumptions, or extra worldsheet/CFT premises & Phase III phenomenological continuation / program-level branch \\
 \end{longtable}
 \endgroup
 
-Accordingly, the recovered-core structural program of the compact note is D1--D5 together with D7--D9. D6 is the separate Phase-II input-dependent corollary; D10 is the current Phase-II supplement-backed calibration sector; and D12 is the Phase-III continuation layer. The only external continuous inputs are \(N_{\mathrm{scr}}\) in D6 and \(P\) in D10, together with descendants built from those branches.
+Accordingly, the recovered-core structural program of the compact note is D1--D5 together with D7. D6 and the visible realized-branch selector extension D8--D9 sit in Phase II, D10 is the current Phase-II supplement-backed calibration sector, and D12 is the Phase-III continuation layer. The only external continuous inputs are \(N_{\mathrm{scr}}\) in D6 and \(P\) in D10, together with descendants built from those branches.
 \section{Five Axioms, Two External Continuous Inputs in the Current Quantitative Implementation, and Technical Premises}\label{sec:premise-ledger}
 
 This section is the authoritative premise ledger and dependency map for the compact note. The OPH basis used below is exactly the five core axioms, the two external continuous inputs of the current quantitative implementation, and the theorem-local technical premises collected afterward. Older A1--A4 / B / MX / LR / R0--R1 packaging is retained elsewhere only as shorthand for pieces of this canonical package, not as a competing axiom basis. In the present version, the local finite-constraint MaxEnt/refinement branch already internalizes the quasi-local propagation and refinement-stability control that older packaging sometimes carried as separate regularity language, Theorem~\ref{thm:bw} fixes the cap generator and its \(2\pi\) normalization on the OPH Bisognano--Wichmann geometric branch without adding any separate cap-isotropy selector, and Corollary~\ref{cor:n2} derives the null half-sided modular pair inside the synchronized bridge. What remains genuinely theorem-external is the scaling-limit scope clause, the geometric-branch selection burden, the density-upgrade burden, fixed-cap stationarity, the bosonic/fiber-functor fork, the relativistic null-stress identification premise, and the vanishing obstruction premise where invoked.
@@ -270,8 +266,8 @@ Node & Compact theorem labels and output & Immediate OPH ingredients & Standard 
 \textbf{D5} & Lemma~\ref{lem:smallball}, Theorem~\ref{thm:einstein}, Corollary~\ref{cor:einstein}: Jacobson-type Einstein branch via a rest-frame relation plus conditional tensor upgrade & D3+D4 and Axioms~\ref{ax:screen}--\ref{ax:entropy} & Jacobson small-ball first law; Lemma~\ref{lem:nullreconstruct} for the null-to-tensor upgrade modulo a metric term & T9 fixed-cap stationarity; locally Lorentzian \(d=4\) scaling regime; small-ball constancy assumptions; D4 carried remainder negligible at order \(\ell^4\); all local directions/reference states for the tensor upgrade & conditional scaling-limit theorem/corollary \\
 \textbf{D6} & Proposition~\ref{prop:lambda}, Corollary~\ref{cor:lambda}: capacity branch for \(\Lambda\), plus the separate neutrino estimate & D5, which already leaves the \(+\Lambda g_{ab}\) ambiguity & de Sitter entropy relation and dimensional analysis & external input \(N_{\mathrm{scr}}\) and the screen-capacity identification & input-dependent corollary / estimate \\
 \textbf{D7} & Theorem~\ref{thm:compactgauge}: compact gauge reconstruction & Axioms~\ref{ax:screen}--\ref{ax:entropy} & Doplicher--Roberts / Tannaka reconstruction & T7 and T10--T11 together with the directed-colimit/fiber clause of T12; the refinement-stable qualifier on that colimit is supplied internally by Axiom~\ref{ax:maxent} & conditional structural theorem \\
-\textbf{D8} & Lemmas~\ref{lem:mincontent}--\ref{lem:commutant}, Theorem~\ref{thm:sm}: product gauge structure up to finite quotient & D7 + Axiom~\ref{ax:mar} & compact Lie representation classification; Schur's lemma & connected positive-dimensional Lie admissible class; one connected abelian factor; faithful action on the minimal coupled carrier; vanishing obstruction \( [z]=0 \) & realized-branch theorem \\
-\textbf{D9} & Theorem~\ref{thm:hypercharge}, Corollaries~\ref{cor:ng}, \ref{cor:nc}, Proposition~\ref{prop:z6}: realized Standard Model quotient, hypercharges, the counting chain \(N_g=3\) then \(N_c=3\), and product-group corollaries & D8 & anomaly-cancellation algebra; Witten global-anomaly argument; CKM CP counting & realized one-generation chiral matter plus one Higgs package; asymptotic-freedom and MAR admissibility premises & realized-branch theorem/corollary chain \\
+\textbf{D8} & Lemmas~\ref{lem:mincontent}--\ref{lem:commutant}, Theorem~\ref{thm:sm}: product gauge structure up to finite quotient & D7 + Axiom~\ref{ax:mar} & compact Lie representation classification; Schur's lemma & imported admissible chiral matter package with one Higgs; connected positive-dimensional Lie admissible class; one connected abelian factor; faithful action on the minimal coupled carrier; vanishing obstruction \( [z]=0 \) & Phase II conditional realized-branch theorem \\
+\textbf{D9} & Theorem~\ref{thm:hypercharge}, Corollaries~\ref{cor:ng}, \ref{cor:nc}, Proposition~\ref{prop:z6}: realized Standard Model quotient, hypercharges, the counting consequences \(N_g=3\) and \(N_c=3\), and product-group corollaries & D8 & anomaly-cancellation algebra; Witten global-anomaly argument; CKM CP counting & realized one-generation chiral matter plus one Higgs package; asymptotic-freedom and MAR admissibility premises & Phase II conditional realized-branch theorem/corollary chain \\
 \textbf{D10} & gauge-coupling numerical closure of Section~7 & D9 + external input \(P\) & RG evolution and matching conventions supplied in the supplement & pixel constraint; edge heat-kernel closure; supplement-backed beta-function and threshold conventions & calibration sector \\
 \textbf{D12} & Sections~8--10 program continuations, including charged-lepton/Koide structure, proton-spin and non-gauge proton-lifetime estimates together with the string/worldsheet branch & various subsets of D6, D9, and D10 & branch-specific EFT and phenomenological manipulations & additional ans\"atze such as the uniform \(\mathbb Z_6\) center-label ensemble, texture choices, dark-sector response assumptions, discrete-horizon assumptions, or extra worldsheet/CFT premises & phenomenological continuation / program-level branch \\
 \end{longtable}
@@ -279,8 +275,8 @@ Node & Compact theorem labels and output & Immediate OPH ingredients & Standard 
 
 No theorem in the compact note is meant to hide standard mathematical imports or extra physical premises inside the phrase ``from the axioms.'' The authoritative unpacking of every such claim is the dependency DAG above. In particular, quasi-local propagation and the refinement-stable sector-persistence notion are now internal to the local finite-constraint MaxEnt branch, the cap generator and its \(2\pi\) normalization are packaged inside Theorem~\ref{thm:bw} on the OPH geometric branch, the half-sided modular pair is derived inside Corollary~\ref{cor:n2}, and the remaining explicit gravity-side burdens are the downstream density-upgrade, fixed-cap stationarity, and null-stress-identification hypotheses. The only rows that use the two external continuous inputs are D6, D10, the separate order-of-magnitude neutrino estimate attached to D6, and downstream branches built from them.
 
-\begin{theorem}[Summary theorem for the recovered relativity-plus-Standard-Model core]\label{thm:master}
-This theorem packages the recovered-core nodes D1--D5 and D7--D9 of the authoritative dependency DAG above. Node D6 is a separate input-dependent corollary, while D10 and D12 remain outside this theorem's scope. Assume Axioms~\ref{ax:screen}--\ref{ax:entropy}, Axiom~\ref{ax:mar}, Assumption~\ref{ass:technical}, and the hypotheses of Theorems~\ref{thm:confluence}, \ref{thm:bw}, \ref{thm:stress}, \ref{thm:einstein}, \ref{thm:compactgauge}, \ref{thm:sm}, and \ref{thm:hypercharge}, together with Corollaries~\ref{cor:ng}, \ref{cor:nc}, and Proposition~\ref{prop:z6}. Then, in the controlled refinement/scaling regime singled out by Assumption~\ref{ass:technical}:
+\begin{theorem}[Summary theorem for the recovered relativity-plus-bosonic-gauge core]\label{thm:master}
+This theorem packages the recovered-core nodes D1--D5 and D7 of the authoritative dependency DAG above. Node D6 is a separate input-dependent corollary, D8--D10 are visible but non-core realized-branch extensions, and D12 remains outside this theorem's scope. Assume Axioms~\ref{ax:screen}--\ref{ax:entropy}, Assumption~\ref{ass:technical}, and the hypotheses of Theorems~\ref{thm:confluence}, \ref{thm:bw}, \ref{thm:stress}, \ref{thm:einstein}, and \ref{thm:compactgauge}. Then, in the controlled refinement/scaling regime singled out by Assumption~\ref{ass:technical}:
 \begin{enumerate}[label=(\roman*),leftmargin=2em]
 \item overlap repair admits a unique schedule-independent normal form;
 \item cap modular flow is geometric in the assumed modular phase and yields the connected Lorentz group
@@ -295,28 +291,15 @@ at the cap center in the diamond rest frame; if that rest-frame relation holds f
 \[
 G_{ab}+\Lambda g_{ab}=8\pi G\,\langle T_{ab}\rangle;
 \]
-\item the refinement-stable transportable edge-sector category reconstructs a compact gauge group, and the realized connected gauge structure has the form
-\[
-\frac{\SU(3)\times\SU(2)\times\U(1)}{\Gamma}
-\]
-for some finite central subgroup \(\Gamma\).
+\item the refinement-stable transportable edge-sector category reconstructs a compact gauge group in the bosonic internal-gauge branch.
 \end{enumerate}
-After the hypercharge lattice, generation-count, color-count, and trivial-action quotient steps, the finite quotient is fixed to \(\Gamma=\mathbb Z_6\), so the realized gauge structure on the realized MAR-admissible branch is
-\[
-\frac{\SU(3)\times\SU(2)\times\U(1)}{\mathbb Z_6},
-\qquad
-N_g=3,
-\qquad
-N_c=3,
-\]
-with the exact Standard Model hypercharge lattice on the realized matter package. Here the realized-branch counting chain is sequential: the asymptotic-freedom/CP-capability window and minimal admissibility first yield \(N_g=3\), and then Witten's \(\SU(2)\) anomaly parity constraint together with the same realized-branch selector yield \(N_c=3\).
 \end{theorem}
 
 \begin{proof}
-Items (i)--(iii) are collected from Theorem~\ref{thm:confluence}, Corollary~\ref{cor:lorentz}, Theorem~\ref{thm:einstein}, and Corollary~\ref{cor:einstein}. The compact gauge reconstruction is Theorem~\ref{thm:compactgauge}; the product gauge structure up to finite quotient is Theorem~\ref{thm:sm}; and the final identification of the exact Standard Model quotient is Theorem~\ref{thm:hypercharge} together with Corollaries~\ref{cor:ng}, \ref{cor:nc}, and Proposition~\ref{prop:z6}.
+Items (i)--(iii) are collected from Theorem~\ref{thm:confluence}, Corollary~\ref{cor:lorentz}, Theorem~\ref{thm:einstein}, and Corollary~\ref{cor:einstein}. The compact gauge reconstruction is Theorem~\ref{thm:compactgauge}.
 \end{proof}
 
-Theorem~\ref{thm:master} therefore packages only the recovered relativity-plus-Standard-Model core: D1--D5 together with D7--D9. The D6 capacity relation is a separate input-dependent corollary; the calibration sector and phenomenological continuations remain outside its scope.
+Theorem~\ref{thm:master} therefore packages only the recovered relativity-plus-bosonic-gauge core: D1--D5 together with D7. The D6 capacity relation is a separate input-dependent corollary, D8--D10 are visible but non-core realized-branch extensions, and the calibration sector and phenomenological continuations remain outside its scope.
 
 \subsection*{Usually Postulated Elsewhere, Recovered or Continued Here with Explicit Status}
 
@@ -328,9 +311,9 @@ Structure & Common treatment & OPH treatment \\
 \midrule
 Lorentz kinematics & background symmetry or starting axiom & conditional scaling-limit branch from geometric modular flow on screen caps \\
 Einstein dynamics & fundamental field equation & conditional first-variation relation with tensor upgrade from generalized entropy, null modular data, and entanglement equilibrium \\
-Gauge group & model input & conditional compact group reconstruction from edge sectors; exact SM quotient selected on the realized MAR-admissible branch \\
-Hypercharge lattice & matter-assignment input & solved from anomaly cancellation and Yukawa invariance on the realized one-generation chiral matter plus one-Higgs package \\
-Color and generation count & empirical input & fixed on the realized MAR-admissible branch by anomaly, CP capability, asymptotic freedom, and minimality \\
+Gauge group & model input & conditional compact group reconstruction from edge sectors in the bosonic branch; a separate visible realized-branch extension then selects a product group once an admissible chiral matter package is supplied \\
+Hypercharge lattice & matter-assignment input & solved only on the imported realized one-generation chiral matter plus one-Higgs package used by the visible realized-branch extension \\
+Color and generation count & empirical input & fixed only on that same visible realized-branch extension by anomaly, CP capability, asymptotic freedom, and minimality \\
 Flavor hierarchy unit & model-dependent small parameter & phenomenological ansatz \(\varepsilon=1/6\) motivated by a uniform \(\mathbb Z_6\) center-label ensemble \\
 Koide phase & phenomenological fit & continuation ansatz tied to the previously fixed discrete data as \(\delta=2/9\) \\
 Cosmological constant & local vacuum-energy puzzle & global screen-capacity term after the input-dependent capacity identification \\
@@ -2165,9 +2148,9 @@ String sector & Fundamental dual description & Effective large-$N_{\mathrm{edge}
 
 This section is the authoritative falsifiability ledger for the three-phase program. In the compact note, the recovered core is
 \[
-(D1\text{--}D5)\cup(D7\text{--}D9),
+(D1\text{--}D5)\cup D7,
 \]
-namely the relativity chain together with the realized Standard Model structural chain. D6 is a separate input-dependent capacity corollary, D10 is an implementation-level supplement-backed calibration branch, and D12 collects deferred continuations.
+namely the relativity chain together with bosonic compact-gauge reconstruction. D6 is a separate input-dependent capacity corollary, D8--D10 are visible but non-core realized-branch extensions, and D12 collects deferred continuations.
 
 \subsection{Prediction audit by claim tier}
 
@@ -2180,10 +2163,11 @@ Tier & Representative outputs & What would actually falsify the tier \\
 \endhead
 \bottomrule
 \endfoot
-Phase I recovered core (Theorem~\ref{thm:master}; D1--D5, D7--D9) & Confluence of overlap repair, conditional Lorentz kinematics, the conditional Jacobson-type Einstein branch in the stated scaling regime, compact gauge reconstruction in the bosonic branch, the realized Standard Model quotient chain, the exact hypercharge lattice on the realized matter package, the realized counting chain \(N_g=3\) then \(N_c=3\), and the product-group consequence of no gauge-mediated proton decay & A mathematical failure in the derivation chain, or data that require a different realized gauge quotient, different realized hypercharges, a different color or generation count on the admissible branch, or gauge-mediated proton decay \\
+Phase I recovered core (Theorem~\ref{thm:master}; D1--D5, D7) & Confluence of overlap repair, conditional Lorentz kinematics, the conditional Jacobson-type Einstein branch in the stated scaling regime, and compact gauge reconstruction in the bosonic branch & A mathematical failure in the derivation chain, or a failure of the bosonic compact-gauge reconstruction package once its stated categorical premises are imposed \\
 Phase II input-dependent corollary (D6) & \(\Lambda=\frac{3\pi}{G N_{\mathrm{scr}}}\) once the screen-capacity identification is made, together with the separate order-of-magnitude neutrino estimate tied to the same capacity input & Failure of the screen-capacity identification or of the specific global capacity relation. Such a failure would not by itself erase the recovered core \\
+Phase II visible realized-branch extension (D8--D9) & Product gauge structure up to finite quotient, the realized \(\SU(3)\times\SU(2)\times\U(1)/\mathbb Z_6\) branch, exact hypercharges on the imported one-generation/one-Higgs package, the counting consequences \(N_g=3\) and \(N_c=3\), and the product-group corollary of no gauge-mediated proton decay & Failure of the selector chain once the imported chiral matter package and the stated MAR/anomaly premises are granted. Such a failure would retract this realized-branch extension, not the recovered-core bosonic reconstruction theorem \\
 Phase II current implementation: calibration sector (D10) & Pixel-closure gauge-coupling consistency, \(\alpha_i(m_Z)\), \(\alpha_{\mathrm{em}}^{-1}(m_Z)\), and \(\sin^2\theta_W(m_Z)\) & Failure of the supplement-backed closure of the present implementation once \(P\) and the printed running/matching conventions are imposed \\
-Phase III deferred continuations (D12 and beyond) & Flavor ans\"atze, charged-lepton/Koide fits, texture branches, neutrino mass/mixing constructions beyond the D6 estimate, dark-sector response laws, baryogenesis estimates, proton-spin bookkeeping, proton-lifetime estimates beyond the gauge-channel exclusion, black-hole spectroscopy templates, conditional string/worldsheet reorganizations, conjectural critical-superstring extensions, and other downstream phenomenology & Retraction of the corresponding continuation only. These branches are not part of the compact paper's recovered core and their failure is not, by itself, a falsification of relativity-plus-Standard-Model recovery \\
+Phase III deferred continuations (D12 and beyond) & Flavor ans\"atze, charged-lepton/Koide fits, texture branches, neutrino mass/mixing constructions beyond the D6 estimate, dark-sector response laws, baryogenesis estimates, proton-spin bookkeeping, proton-lifetime estimates beyond the gauge-channel exclusion, black-hole spectroscopy templates, conditional string/worldsheet reorganizations, conjectural critical-superstring extensions, and other downstream phenomenology & Retraction of the corresponding continuation only. These branches are not part of the compact paper's recovered core and their failure is not, by itself, a falsification of the recovered relativity-plus-bosonic-gauge core \\
 \end{longtable}
 \endgroup
 
@@ -2195,9 +2179,13 @@ Mirrored interpretive surfaces may discuss a separate OPH-internal state-and-law
 
 Once the claim boundary is made explicit, the sharpest discriminators are the ones that do not depend on auxiliary flavor, dark-sector, baryogenesis, or string ans\"atze.
 
-\subsubsection{Realized Standard Model gauge structure}
+\subsubsection{Bosonic compact-gauge core}
 
-On the realized MAR-admissible branch, the compact note fixes
+At recovered-core level, the compact note fixes only the existence of a compact gauge group in the bosonic internal-gauge branch under the hypotheses of Theorem~\ref{thm:compactgauge}. The stronger low-energy Standard-Model-like statements belong to the visible realized-branch extension described next.
+
+\subsubsection{Visible realized Standard Model branch}
+
+On the imported realized one-generation chiral matter package with one Higgs doublet, together with the MAR admissibility premises used in Section~6, the visible realized-branch extension fixes
 \[
 G_{\mathrm{phys}}=
 \frac{\SU(3)\times\SU(2)\times\U(1)}{\mathbb Z_6},
@@ -2206,7 +2194,7 @@ N_g=3,
 \qquad
 N_c=3,
 \]
-with the exact one-generation hypercharge lattice. Here the realized counting chain is sequential: the CP/UV admissibility window and minimal admissibility yield \(N_g=3\), and Witten's \(\SU(2)\) anomaly parity with that realized generation count yields \(N_c=3\).
+with the exact one-generation hypercharge lattice.
 \[
 Y_Q=\frac16,\qquad
 Y_L=-\frac12,\qquad
@@ -2215,7 +2203,7 @@ Y_d=\frac13,\qquad
 Y_e=1,\qquad
 Y_H=\frac12.
 \]
-Evidence that the realized low-energy gauge structure or realized hypercharges differ from these values would directly contradict the recovered core.
+Evidence that the realized low-energy gauge structure or realized hypercharges differ from these values would directly contradict this visible realized-branch extension, but not by itself the recovered-core bosonic reconstruction theorem.
 
 \subsubsection{Product-group corollary}
 
@@ -2241,11 +2229,11 @@ The following do \emph{not} falsify Theorem~\ref{thm:master} if they fail in the
 \item discrete-horizon spectroscopy templates;
 \item large-$N_{\mathrm{edge}}$ string/worldsheet reorganizations.
 \end{enumerate}
-These are all post-Phase-I, non-core branches. Some are Phase-II input-dependent estimates, while the rest are Phase-III continuations. None is part of the compact note's recovered relativity-plus-Standard-Model core.
+These are all post-Phase-I, non-core branches. Some are Phase-II input-dependent estimates, while the rest are Phase-III continuations. None is part of the compact note's recovered relativity-plus-bosonic-gauge core.
 
 \subsection{What the compact paper claims after scope-cleaning}
 
-After the present scope clean, the compact paper claims exactly this: observer-overlap consistency, together with the stated scaling-limit and categorical premises, recovers a conditional relativity branch and the realized Standard Model structural branch. The Phase-II capacity relation and the current Phase-II D10 calibration sector remain visible but secondary. Everything in Phase III is explicitly non-core.
+After the present scope clean, the compact paper claims exactly this: observer-overlap consistency, together with the stated scaling-limit and categorical premises, recovers a conditional relativity branch and a bosonic compact-gauge core. The visible realized-branch extension to Standard-Model-like low-energy structure requires the imported chiral matter package and its stated MAR/anomaly premises. The Phase-II capacity relation and the current Phase-II D10 calibration sector remain visible but secondary. Everything in Phase III is explicitly non-core.
 
 \section{Common Objections and Clarifications}
 
@@ -2281,9 +2269,9 @@ The framework is strongest where the outputs are discrete or structurally rigid:
 \begin{enumerate}[leftmargin=2em]
 \item the Lorentz branch inside the assumed geometric modular phase;
 \item the conditional scaling-limit Einstein branch under fixed-cap stationarity and the null-stress premise;
-\item the Standard Model gauge quotient chain;
-\item exact hypercharges on the realized one-generation matter package with one Higgs doublet;
-\item the realized counting chain \(N_g=3\) then \(N_c=3\) on the realized MAR-admissible branch;
+\item compact gauge reconstruction in the bosonic branch;
+\item the visible realized-branch gauge quotient chain on the imported one-generation matter package with one Higgs doublet;
+\item exact hypercharges and the counting consequences \(N_g=3\) and \(N_c=3\) only on that same visible realized-branch extension;
 \item the compact two-input economy of the present quantitative implementation, kept explicit as a secondary layer rather than as part of Phase I.
 \end{enumerate}
 
@@ -2297,9 +2285,9 @@ Topics intentionally excluded from the present formulation include simulation na
 
 \section{Conclusion}
 
-Observer-Patch Holography starts from overlap consistency of observer patches and yields, within one framework, several effective structures usually treated separately in modern fundamental physics. The compact note supports a unique schedule-independent normal form for overlap repair, a conditional Lorentz branch in the assumed geometric modular phase, a conditional Jacobson-type Einstein branch under fixed-cap stationarity and the null-stress premise, the Standard Model gauge quotient with exact hypercharges on the realized matter package under the MAR admissibility package in the bosonic internal-gauge branch, the realized counting chain \(N_g=3\) then \(N_c=3\) on that branch, a separate supplement-backed gauge-calibration sector that remains secondary to the recovered core, and a separate input-dependent cosmological-capacity corollary. It also records several phenomenological continuations whose present status is weaker and is labeled as such in the text.
+Observer-Patch Holography starts from overlap consistency of observer patches and yields, within one framework, several effective structures usually treated separately in modern fundamental physics. The compact note supports a unique schedule-independent normal form for overlap repair, a conditional Lorentz branch in the assumed geometric modular phase, a conditional Jacobson-type Einstein branch under fixed-cap stationarity and the null-stress premise, and conditional compact gauge reconstruction in the bosonic internal-gauge branch. It also records a visible realized-branch extension which, once an imported one-generation chiral matter package with one Higgs doublet is supplied together with the stated MAR/anomaly premises, yields the Standard Model gauge quotient with exact hypercharges and the counting consequences \(N_g=3\) and \(N_c=3\). The current supplement-backed gauge-calibration sector remains secondary to the recovered core, and the input-dependent cosmological-capacity corollary remains separate. It also records several phenomenological continuations whose present status is weaker and is labeled as such in the text.
 
-Accordingly, the framework functions as a candidate underlying theory from which general relativity and the Standard Model may arise as effective descriptions once the stated scaling-limit and categorical premises are realized. The next technical tasks are sharper quantitative control, a fuller fermionic gauge branch, and explicit UV completions that land in the required modular/geometric phase.
+Accordingly, the framework functions as a candidate underlying theory from which general relativity may arise as an effective description once the stated scaling-limit and categorical premises are realized, and from which a Standard-Model-like realized branch may arise only after one also supplies the imported chiral matter package together with the stated MAR/anomaly premises. The next technical tasks are sharper quantitative control, a fuller fermionic gauge branch, and explicit UV completions that land in the required modular/geometric phase.
 
 \appendix
 

--- a/paper/tex_fragments/GAUGE_GROUP_DERIVATION.tex
+++ b/paper/tex_fragments/GAUGE_GROUP_DERIVATION.tex
@@ -1,17 +1,17 @@
-\section{Gauge Group Derivation: Standard Model Closure from MAR plus Explicit Gauge Premises}\label{gauge-group-derivation-standard-model-closure-under-extended-mar}
+\section{Gauge Group Derivation: Conditional Standard Model Selector from MAR plus Explicit Gauge Premises}\label{gauge-group-derivation-standard-model-closure-under-extended-mar}
 
 \begin{quote}
 OPH is an observer-centric reconstruction program for fundamental physics. The quantitative branches discussed in this paper use two external inputs (pixel area and screen capacity) together with structural axioms and explicit regulator/scaling premises. This part focuses only on the conditional compact-gauge branch and the explicit MAR selector that acts on the admissible low-energy class.
 \end{quote}
 
 \begin{quote}
-\textbf{Integrated derivation within this manuscript}: this part extends the core OPH framework in Part I.
+\textbf{Visible realized-branch extension within this manuscript}: this part extends the bosonic compact-gauge core from Part I by adding an explicit admissible low-energy sector package.
 
-\textbf{Overview.} We show that, once Tannaka/DR reconstruction is applied to the refinement-stable edge-sector colimit, the extended gauge-selection package \(T_{\mathrm{ext}}\), meaning the five OPH axioms together with the explicit transportability premise \([z]=0\) and the gauge-reconstruction hypotheses of Part I, selects the Standard Model connected Lie gauge-sector factors once the admissible class includes one connected abelian charge factor. On the realized admissible branch, the CP/UV window and MAR fix the generation count, Witten's \(\mathrm{SU}(2)\) anomaly parity then fixes the color count, and the realized hypercharge lattice fixes the global gauge quotient:
+\textbf{Overview.} We show that, once Tannaka/DR reconstruction is applied to the refinement-stable edge-sector colimit, the extended gauge-selection package \(T_{\mathrm{ext}}\), meaning the five OPH axioms together with the explicit transportability premise \([z]=0\), the gauge-reconstruction hypotheses of Part I, and an imported admissible chiral low-energy sector package with one Higgs doublet, selects the Standard Model connected Lie gauge-sector factors once the admissible class includes one connected abelian charge factor. On that visible realized branch, the CP/UV admissibility window and MAR constrain the generation count, Witten's \(\mathrm{SU}(2)\) anomaly parity constrains the color count, and the realized hypercharge lattice fixes the global gauge quotient:
 
 \[G_{\mathrm{phys}} = \frac{SU(3) \times SU(2) \times U(1)}{\mathbb{Z}_6}, \qquad N_g = 3, \qquad N_c = 3.\]
 
-Within the positive-dimensional connected Lie admissible class, no other gauge-sector package, no other color multiplicity, and no other generation count satisfies all admissibility conditions while minimizing the complexity vector \(C(\mathfrak S)\).
+Within the positive-dimensional connected Lie admissible class just described, no other gauge-sector package, no other color multiplicity, and no other generation count satisfies all admissibility conditions while minimizing the complexity vector \(C(\mathfrak S)\).
 \end{quote}
 
 \begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
@@ -20,7 +20,7 @@ Within the positive-dimensional connected Lie admissible class, no other gauge-s
 
 \subsubsection{The Extended Theory}\label{11-the-extended-theory}
 
-The derivation proceeds within the extended gauge-selection package \(T_{\mathrm{ext}}\): the five OPH axioms from Part I, the explicit loop-coherent gluing premise \([z]=0\), and the refinement-stable gauge-reconstruction hypotheses used in Theorem 6.1.
+The derivation proceeds within the extended gauge-selection package \(T_{\mathrm{ext}}\): the five OPH axioms from Part I, the explicit loop-coherent gluing premise \([z]=0\), the refinement-stable gauge-reconstruction hypotheses used in Theorem 6.1, and the imported admissible chiral matter package on which MAR acts.
 
 The roles of each component:
 
@@ -64,7 +64,7 @@ This is an internal constraint on the sector structure, not an external physical
 
 \subsection{Admissibility Conditions}\label{2-admissibility-conditions}
 
-An \textbf{OPH-realizable gauge sector package} \(\mathfrak S = (G, \text{matter content})\) consists of a compact gauge group \(G\) reconstructed via Tannaka-Krein from the refinement-stable edge-sector category (Theorem 6.1) together with its associated chiral matter spectrum. A sector package \(\mathfrak S\) is \textbf{admissible} if it satisfies all of the following conditions:
+An \textbf{OPH-realizable gauge sector package} \(\mathfrak S = (G, \text{matter content})\) consists of a compact gauge group \(G\) reconstructed via Tannaka-Krein from the refinement-stable edge-sector category (Theorem 6.1) together with an associated low-energy chiral matter spectrum. This fragment treats that chiral matter package as part of the imported admissible low-energy data on which MAR acts. A sector package \(\mathfrak S\) is \textbf{admissible} if it satisfies all of the following conditions:
 
 \subsubsection{(i) Loop-coherent / transportable}\label{i-loop-coherent--transportable}
 
@@ -90,9 +90,9 @@ The gauge sector is free of all perturbative anomalies (ABJ anomaly cancellation
 
 \subsubsection{(iii) Refinement-stable with light chiral matter}\label{iii-refinement-stable-with-light-chiral-matter}
 
-The MaxEnt/refinement-stable state supports light charged fermions without fine-tuning. This requires the matter content to be \emph{chiral} , i.e., left-handed and right-handed fermions carry different gauge representations , so that vector-like mass terms are forbidden by gauge symmetry.
+The MaxEnt/refinement-stable state supports light charged fermions without fine-tuning. In this fragment, that requirement is imposed as an admissibility premise on the low-energy sector package: the matter content is taken to be \emph{chiral}, i.e., left-handed and right-handed fermions carry different gauge representations, so that vector-like mass terms are forbidden by gauge symmetry.
 
-\emph{Rationale:} Lemma 6.7 (Part I of this manuscript \S{}6.3) shows that refinement stability forbids unprotected relevant operators. A gauge-invariant Dirac mass term is relevant; if both chiralities are in conjugate representations, the mass term is allowed and drives the fermions to the cutoff. Corollary 6.8 then selects chiral content as the natural refinement-stable option.
+\emph{Rationale:} Lemma 6.7 (Part I of this manuscript \S{}6.3) shows that refinement stability forbids unprotected relevant operators. A gauge-invariant Dirac mass term is relevant; if both chiralities are in conjugate representations, the mass term is allowed and drives the fermions to the cutoff. Corollary 6.8 is used here only as a naturalness motivation on an assumed fermionic EFT branch; it does not by itself derive a fermionic sign object, Weyl-sector structure, anomaly data, or the chiral matter package used below.
 
 \subsubsection{(iv) Single-Higgs Yukawa-completable}\label{iv-single-higgs-yukawa-completable}
 
@@ -134,7 +134,7 @@ where:
   \(N_g\) is the \textbf{number of chiral generations}.
 \end{itemize}
 
-MAR is already Axiom 5 of the canonical OPH package. This subsection fixes only the exact formal statement used by the gauge proof; it does not introduce a separate non-core selector.
+MAR is already Axiom 5 of the canonical OPH package. This subsection fixes only the exact formal statement used by the gauge proof; it does not introduce a separate non-core selector. Because \(\mathfrak S\) already contains chiral matter content and one Higgs doublet, MAR does not derive those ingredients; it selects among packages once supplied.
 
 Lexicographic minimality means: first minimize \(\chi_{\mathrm{cpl}}\); among ties, minimize \(N_{\mathrm{nonab}}\); among further ties, minimize \(N_c\); among final ties, minimize \(N_g\). The object minimized here is the full sector package \(\mathfrak S\), not the bare tensor category alone. MAR is therefore an explicit selector on the admissible class, not a theorem derived from the earlier axioms.
 
@@ -147,7 +147,7 @@ Lexicographic minimality means: first minimize \(\chi_{\mathrm{cpl}}\); among ti
 \item
   \emph{It is not "minimalism in general."} MAR only selects among sectors that pass all six admissibility filters. Plain minimality (smallest \(G\)) would yield \(U(1)\) or \(SU(2)\), which fail conditions (iii)--(v). The admissibility conditions do the heavy lifting; MAR breaks the remaining degeneracy.
 \item
-  \emph{It is powerful.} Product gauge structure and the specific factors \(SU(3) \times SU(2) \times U(1)\) follow from MAR applied to the admissible class; on the realized branch the CP/UV window and MAR then give \(N_g = 3\), and Witten parity with that realized generation count gives \(N_c = 3\).
+  \emph{It is powerful.} Product gauge structure and the specific factors \(SU(3) \times SU(2) \times U(1)\) follow from MAR applied to the admissible class; on the same visible realized branch the CP/UV window and MAR constrain \(N_g\), and Witten parity then constrains \(N_c\).
 \end{enumerate}
 
 \textbf{Remark (coupled vs. faithful).} Earlier drafts overloaded the first MAR coordinate with the abstract group-theoretic minimal faithful representation dimension. That is not the quantity used in the gauge proof. For \(G_{\mathrm{phys}} \cong S(U(3) \times U(2))\), the block-diagonal action on \(\mathbb{C}^3 \oplus \mathbb{C}^2\) is faithful of dimension \(5\), but it places the complex and pseudoreal charge types on disconnected invariant subspaces. MAR minimizes the coupled carrier dimension \(\chi_{\mathrm{cpl}}\), for which the minimal SM carrier is \(\mathbb{C}^3 \otimes \mathbb{C}^2\) of dimension \(6\).
@@ -156,11 +156,9 @@ Lexicographic minimality means: first minimize \(\chi_{\mathrm{cpl}}\); among ti
 
 \subsection{Main Theorem}\label{4-main-theorem}
 
-\textbf{Theorem (Standard Model closure from the full gauge-selection package).} Under the full gauge-selection package \(T_{\mathrm{ext}}\), together with the refinement-stable reconstruction hypotheses of Theorem 6.1:
+\textbf{Theorem (Conditional Standard Model selector from the full gauge-selection package).} Under the full gauge-selection package \(T_{\mathrm{ext}}\), together with the refinement-stable reconstruction hypotheses of Theorem 6.1 and the imported admissible chiral matter package just described:
 
 \[G_{\mathrm{phys}} = \frac{SU(3) \times SU(2) \times U(1)}{\mathbb{Z}_6}, \qquad N_g = 3, \qquad N_c = 3.\]
-
-The realized counting chain is sequential rather than joint: the CP/UV admissibility window and MAR first select \(N_g = 3\), and Witten's \(\mathrm{SU}(2)\) anomaly parity then fixes \(N_c = 3\).
 
 \emph{The proof is given in \S{}5--\S{}7 below.}
 
@@ -184,7 +182,7 @@ The premise \([z] = 0\) ensures that this reconstruction is global: charges are 
 
 \textbf{Lemma 5.1.} Any admissible sector must contain at least two genuinely different nonabelian charge types: one pseudoreal and one complex.
 
-\emph{Proof.} Admissibility condition (iii) requires light chiral matter. By Corollary 6.8 (Part I of this manuscript \S{}6.3), refinement stability forces the matter content to be chiral. To support chiral fermions that can form gauge-invariant Yukawa couplings with a single Higgs doublet (condition iv), the gauge group must admit both:
+\emph{Proof.} Admissibility condition (iii) requires light chiral matter. Corollary 6.8 (Part I of this manuscript \S{}6.3) supplies only the naturalness motivation for imposing that condition on an assumed fermionic EFT branch; it does not derive the chiral matter package. Given that admissibility premise, to support chiral fermions that can form gauge-invariant Yukawa couplings with a single Higgs doublet (condition iv), the gauge group must admit both:
 
 \begin{itemize}
 \tightlist
@@ -286,11 +284,11 @@ The hypercharge quantization itself follows from anomaly cancellation (condition
 
 \begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
 
-\subsection{Proof: Number of Colors}\label{6-proof-number-of-colors}
+\subsection{Parity Closure for the Color Count}\label{6-proof-number-of-colors}
 
-\textbf{Theorem (N\_c = 3).} Under \(T_{\mathrm{ext}}\), the rank of the color factor is \(N_c = 3\).
+\textbf{Lemma (Parity closure for \(N_c\) once \(N_g=3\) is realized).} Under \(T_{\mathrm{ext}}\), if the realized branch has \(N_g = 3\), then the color count closes to \(N_c = 3\).
 
-\textbf{Proof.} The gauge group derivation (\S{}5) fixes the color factor as \(SU(3)\), i.e. \(N_c = 3\), through the minimal coupled-carrier argument (Lemma 5.2). We give here the independent confirmation from anomaly constraints plus MAR.
+\textbf{Proof.} The gauge group derivation (\S{}5) already identifies the realized color factor as \(SU(3)\) through the minimal coupled-carrier argument (Lemma 5.2). We record here the matching parity/MAR closure on the same realized branch, conditional on the generation count used below.
 
 \textbf{Step 1: Witten anomaly constrains N\_c once N\_g is fixed.}
 
@@ -298,7 +296,7 @@ With gauge structure \(SU(N_c) \times SU(2)_L \times U(1)_Y\), one left-handed q
 
 \[N_{\mathrm{doublets}} = N_g(N_c + 1).\]
 
-Using \(N_g = 3\) from Section 7, Witten\textquotesingle s global \(SU(2)\) anomaly (1982) requires the total number of \(SU(2)\) doublets to be even:
+Once the coupled realized branch has \(N_g = 3\), Witten\textquotesingle s global \(SU(2)\) anomaly (1982) requires the total number of \(SU(2)\) doublets to be even:
 
 \[3(N_c + 1) \equiv 0 \pmod{2} \quad \Longrightarrow \quad N_c \text{ is odd}.\]
 
@@ -308,15 +306,15 @@ This alone allows \(N_c \in \{1, 3, 5, 7, \ldots\}\).
 
 For \(N_c = 1\): \(SU(1)\) is trivial (no color dynamics). The fundamental representation is 1-dimensional and real, not complex. This violates Lemma 5.1 (no genuinely complex nonabelian charge type) and condition (iii) (cannot support chiral quarks).
 
-\textbf{Step 3: MAR selects N\_c = 3.}
+\textbf{Step 3: MAR closes N\_c = 3 on that branch.}
 
 Among the remaining candidates \(\{3, 5, 7, \ldots\}\), the SM-like quotient family has \(\chi_{\mathrm{cpl}} = 2N_c\) because the minimal coupled carrier is \(\mathbb{C}^{N_c} \otimes \mathbb{C}^2\). (The block-diagonal faithful representation \(\mathbb{C}^{N_c} \oplus \mathbb{C}^2\) has dimension \(N_c + 2\), but it is not coupled and is therefore irrelevant to MAR.) MAR\textquotesingle s complexity vector has \(N_c\) in the third slot, so lexicographic minimization selects \(N_c = 3\). \(\square\)
 
 \begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
 
-\subsection{Proof: Number of Generations}\label{7-proof-number-of-generations}
+\subsection{Proof: Number of Generations and Coupled Counting Closure}\label{7-proof-number-of-generations}
 
-\textbf{Theorem (N\_g = 3).} Under \(T_{\mathrm{ext}}\), the number of chiral generations is \(N_g = 3\).
+\textbf{Theorem (Coupled realized-branch counting closure).} Under \(T_{\mathrm{ext}}\), the realized branch has \(N_g = 3\); together with the parity closure from Section 6, this yields the counting consequences \(N_g = 3\) and \(N_c = 3\).
 
 \textbf{Proof.}
 
@@ -354,7 +352,7 @@ Combining: \(3 \leq N_g \leq 5\).
 
 \textbf{Step 3: MAR selects N\_g = 3.}
 
-Among the admissible candidates \(\{3, 4, 5\}\), MAR\textquotesingle s complexity vector has \(N_g\) in the fourth (last) slot. Lexicographic minimization selects \(N_g = 3\). Feeding that value back into Section 6 completes the Witten-parity closure \(N_c = 3\). \(\square\)
+Among the admissible candidates \(\{3, 4, 5\}\), MAR\textquotesingle s complexity vector has \(N_g\) in the fourth (last) slot. Lexicographic minimization selects \(N_g = 3\). Together with the parity closure from Section 6, this yields the realized-branch counting consequences \(N_g = 3\) and \(N_c = 3\). \(\square\)
 
 \begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
 
@@ -401,12 +399,12 @@ The gauge-sector chain established in this fragment is:
 
 \(+ \; [z]=0\) \(\xrightarrow{\text{Prop 6.1a}}\) DHR transportable, global gauge symmetry
 
-\(+ \;\text{apply MAR on the admissible class}\) \(\xrightarrow{\text{Thm (this doc)}}\) connected SM factors with the realized chain \(N_g = 3\) then \(N_c = 3\), and \(G_{\mathrm{phys}} = SU(3) \times SU(2) \times U(1)/\mathbb{Z}_6\)
+\(+ \;\text{apply MAR on the admissible class}\) \(\xrightarrow{\text{Thm (this doc)}}\) connected SM factors and \(G_{\mathrm{phys}} = SU(3) \times SU(2) \times U(1)/\mathbb{Z}_6\)
 
 \(\xrightarrow{\text{Thm 6.13}}\) hypercharges fixed \(\xrightarrow{\text{Cor.}}\) no gauge-mediated proton decay
 \end{quote}
 
-Under \(T_{\mathrm{ext}}\), the following are all derived results:
+Under \(T_{\mathrm{ext}}\), together with the imported admissible chiral matter package used throughout this fragment, the following are realized-branch consequences:
 
 \begin{enumerate}
 \def\labelenumi{\arabic{enumi}.}
@@ -425,7 +423,7 @@ Under \(T_{\mathrm{ext}}\), the following are all derived results:
   Hypercharge quantization in sixths
 \end{enumerate}
 
-This is the gauge-sector closure obtained from the extended axiom set on the stated admissible class. Later gravity, spectrum, and continuation branches require their own additional premises and authority surfaces. \(\square\)
+This is the conditional realized-branch selector result obtained from the extended axiom set on the stated admissible class. Later gravity, spectrum, and continuation branches require their own additional premises and authority surfaces. \(\square\)
 
 \begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
 

--- a/paper/tex_fragments/PAPER.tex
+++ b/paper/tex_fragments/PAPER.tex
@@ -4,9 +4,9 @@ OPH is an observer-centric reconstruction program for fundamental physics. Physi
 
 \subsection{Overview}\label{overview}
 
-The recovered core of the paper is the D1--D5 and D7--D9 chain: overlap-consistency normal form, collar and edge-center structure, the conditional Lorentz and Einstein branches, compact gauge reconstruction, and the realized Standard Model branch with exact hypercharge structure, \(N_g=3\), and \(N_c=3\). D6 is a separate input-dependent corollary tied to total screen capacity. D12 collects phenomenological continuations kept distinct from the recovered core.
+The recovered core of the paper is the D1--D5 and D7 chain: overlap-consistency normal form, collar and edge-center structure, the conditional Lorentz and Einstein branches, and compact gauge reconstruction in the bosonic internal-gauge sector. D6 is a separate input-dependent corollary tied to total screen capacity. D8--D10 are visible but non-core realized-branch extensions, and D12 collects phenomenological continuations kept distinct from the recovered core.
 
-The Lorentz/null-modular/Einstein chain is a scaling-limit statement with explicit fixed-cutoff control. The gauge chain reconstructs a compact group from a refinement-stable sector colimit and then specializes to the realized MAR-admissible branch. The worldsheet/string material and the flavor, neutrino, hadron, dark-sector, and spectroscopy branches are kept separate from the recovered core.
+The Lorentz/null-modular/Einstein chain is a scaling-limit statement with explicit fixed-cutoff control. The gauge chain reconstructs a compact group from a refinement-stable sector colimit in the bosonic branch, and only then passes to a separate visible realized-branch selector argument once an admissible chiral matter package is supplied. The worldsheet/string material and the flavor, neutrino, hadron, dark-sector, and spectroscopy branches are kept separate from the recovered core.
 
 Two external continuous inputs appear only where declared. The pixel area \(P \equiv a_{\rm cell}/\ell_P^2\) enters deferred quantitative branches, and the screen capacity \(N_{\mathrm{scr}} \equiv \log \dim \mathcal H_{\mathrm{tot}}\) enters the cosmological-capacity branch. They are implementation inputs, not additional axioms.
 
@@ -228,14 +228,14 @@ Node & Main-manuscript output & Immediate OPH ingredients & Standard mathematics
 \textbf{D5} & Theorem 5.1: Einstein branch & D3+D4 & Jacobson small-ball mathematics; null-to-tensor reconstruction modulo a metric term & fixed-cap stationarity and the locally Lorentzian \(d=4\) scaling regime & conditional scaling-limit theorem \\
 \textbf{D6} & capacity/\(\Lambda\) reduction statements & D5 leaves \(+\Lambda g_{ab}\) undetermined & de Sitter entropy relation and dimensional analysis & external input \(N_{\mathrm{scr}}\) and the screen-capacity identification & input-dependent corollary / estimate \\
 \textbf{D7} & Theorem 6.1: compact gauge reconstruction & Axioms 1--4 & Doplicher--Roberts / Tannaka reconstruction & rigid symmetric bosonic colimit, transportability, and fiber-functor premises & conditional structural theorem \\
-\textbf{D8} & Section 6.2: product gauge structure up to finite quotient & D7 + Axiom 5 (MAR) & compact Lie representation classification; Schur's lemma & connected admissible class, one connected abelian factor, and \([z]=0\) & realized-branch theorem \\
-\textbf{D9} & Theorem 6.13, Proposition 6.9, Theorem 6.14, Proposition 6.6: hypercharge lattice, the counting chain \(N_g=3\) then \(N_c=3\), and the \(\mathbb Z_6\) quotient & D8 & anomaly algebra; Witten anomaly; CKM CP counting & realized one-generation/one-Higgs package and MAR admissibility premises & realized-branch theorem/corollary chain \\
+\textbf{D8} & Section 6.2: product gauge structure up to finite quotient & D7 + Axiom 5 (MAR) & compact Lie representation classification; Schur's lemma & imported admissible chiral matter package with one Higgs, MAR, connected admissible class, one connected abelian factor, and \([z]=0\) & Phase II conditional realized-branch theorem \\
+\textbf{D9} & Theorem 6.13, Proposition 6.9, Theorem 6.14, Proposition 6.6: hypercharge lattice, the counting consequences \(N_g=3\) and \(N_c=3\), and the \(\mathbb Z_6\) quotient & D8 & anomaly algebra; Witten anomaly; CKM CP counting & realized one-generation/one-Higgs package and MAR admissibility premises & conditional realized-branch theorem/corollary chain \\
 \textbf{D12} & downstream flavor, dark-sector, baryogenesis, spectroscopy, and string branches & various subsets of D6 and D9 & branch-specific EFT and phenomenological manipulations & explicit additional ans\"atze & phenomenological continuation / program branch \\
 \end{longtable}
 }
 \endgroup
 
-In particular, D3--D5 are scaling-limit branches rather than fixed-cutoff matrix-algebra theorems; D7--D9 are realized-branch structural outputs in the bosonic internal-gauge sector; D6 is input-dependent; and D12 remains phenomenological.
+In particular, D3--D5 are scaling-limit branches rather than fixed-cutoff matrix-algebra theorems; D7 is the recovered-core bosonic gauge theorem; D8--D9 are visible realized-branch selector extensions requiring an imported chiral matter package; D6 is input-dependent; and D12 remains phenomenological.
 
 \begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
 \subsection{Information-Theoretic Tools}\label{2-information-theoretic-tools}
@@ -2429,7 +2429,7 @@ Theorem 6.1 yields \emph{some} compact \(G\). Axiom 5 (MAR, Minimal Admissible R
 
 See Part II of this manuscript for the complete formal statement, admissibility definitions, and proof.
 
-Here \(\chi_{\mathrm{cpl}}\) is the \textbf{coupled edge capacity}: the dimension of the minimal unitary carrier containing a common irreducible block on which the admissible pseudoreal and complex nonabelian charge types both act nontrivially. This is intentionally stronger than the abstract minimal faithful representation dimension. For \(S(U(3)\times U(2))\), the block-diagonal action on \(\mathbb{C}^3 \oplus \mathbb{C}^2\) is faithful of dimension \(5\), but it is not coupled and therefore does not enter MAR. The object minimized by MAR is the sector package \(\mathfrak S\), not the bare tensor category by itself. MAR is thus an explicit structural-economy selector on the admissible class, not a theorem derived from the earlier axioms.
+Here \(\chi_{\mathrm{cpl}}\) is the \textbf{coupled edge capacity}: the dimension of the minimal unitary carrier containing a common irreducible block on which the admissible pseudoreal and complex nonabelian charge types both act nontrivially. This is intentionally stronger than the abstract minimal faithful representation dimension. For \(S(U(3)\times U(2))\), the block-diagonal action on \(\mathbb{C}^3 \oplus \mathbb{C}^2\) is faithful of dimension \(5\), but it is not coupled and therefore does not enter MAR. The object minimized by MAR is the sector package \(\mathfrak S\), not the bare tensor category by itself. Because \(\mathfrak S\) already includes admissible light chiral matter and one Higgs doublet, MAR does not derive those ingredients; it selects among packages once supplied. MAR is thus an explicit structural-economy selector on the admissible class, not a theorem derived from the earlier axioms.
 
 \textbf{Note on {[}z{]}=0.} The loop-coherent gluing condition \([z]=0\) (Proposition 6.1a) is kept as an explicit premise of the full gauge-selection package \(T_{\mathrm{ext}}\), not hidden inside MAR. It ensures that the reconstructed compact group acts as a genuine global gauge symmetry. By Proposition 6.1a, this is equivalent to DHR transportability.
 
@@ -2520,13 +2520,13 @@ then coarse-graining acts on the finite set of multipliers rather than on an unc
 
 \textbf{Proof sketch.} Linearize the renormalization map on the finite-dimensional multiplier space around the selected branch. A relevant operator gives an unstable direction with scaling exponent \(y>0\). If \(\mathcal{O}\) is not fixed by symmetry and is not part of the retained constraint family, generic UV mismatch produces a nonzero component along that direction. Because \(y>0\), repeated coarse-graining amplifies the component and pushes the flow off the selected branch unless one fine-tunes it away at every scale. Turning on the relevant coupling generates a mass scale and gaps the IR. At fixed low energy density, the gapped phase has lower entropy density than the corresponding gapless or critical branch, so the MaxEnt selector disfavors it. QED.
 
-\textbf{Corollary 6.8 (chirality selector).} A gauge-invariant Dirac mass term is a relevant scalar. If both chiralities exist in conjugate representations, the mass term is allowed and will be generated under refinement unless symmetry-forbidden or explicitly retained as a protected constraint. Therefore the MaxEnt/refinement-stable branch selects chiral fermion content, or else an explicit protecting mechanism, as the natural way to keep light fermions without fine tuning. QED.
+\textbf{Corollary 6.8 (chirality selector on an assumed fermionic EFT branch).} A gauge-invariant Dirac mass term is a relevant scalar. If both chiralities exist in conjugate representations, the mass term is allowed and will be generated under refinement unless symmetry-forbidden or explicitly retained as a protected constraint. Therefore, on an assumed fermionic EFT branch, the MaxEnt/refinement-stable branch favors chiral fermion content, or else an explicit protecting mechanism, as the natural way to keep light fermions without fine tuning. This corollary is a naturalness statement inside that EFT language; it does not by itself derive fermionic statistics, a sign object, Weyl-sector structure, anomaly data, or the Standard Model chiral package. QED.
 
 \subsubsection{Generation number from CP violation and refinement stability (derived from MAR)}\label{64-generation-number-from-cp-violation-and-refinement-stability-derived-from-mar}
 
 Anomaly cancellation is generation-by-generation, so it does not fix the number of generations. The admissibility conditions constrain the window; MAR selects the minimum.
 
-\textbf{Proposition 6.9 (The number of generations is N\_g = 3).} Under (i) intrinsic CP violation in the quark sector, (ii) UV-completability of SU(2)\_L (asymptotic freedom at one loop), (iii) MaxEnt/refinement stability selecting minimal viable spectrum, and (iv) the derived N\_c = 3 from Theorem 6.14, the generation number is
+\textbf{Proposition 6.9 (The number of generations is N\_g = 3).} Under (i) intrinsic CP violation in the quark sector, (ii) UV-completability of SU(2)\_L (asymptotic freedom at one loop), (iii) MaxEnt/refinement stability selecting minimal viable spectrum, and (iv) the color-type admissibility requirement \(N_c \ge 3\), the generation number is
 
 \[
 N_g = 3.
@@ -2544,7 +2544,7 @@ N_g = 3.
 \item
   \textbf{MaxEnt + refinement stability} penalizes unnecessary unfixed flavor structure, selecting the minimal viable spectrum.
 \item
-  Use the derived N\_c = 3 from Theorem 6.14.
+  Use the color-type admissibility requirement \(N_c \ge 3\).
 \end{enumerate}
 
 \textbf{Step 1: CP violation lower bound.} The number of physical CP-violating phases in an N\_g \ensuremath{\times} N\_g CKM matrix is:
@@ -2579,7 +2579,7 @@ where the final \(-1/6\) is the contribution of one complex Higgs doublet. Asymp
 N_g(N_c + 1) < \frac{43}{2}.
 \]
 
-With N\_c = 3, we have N\_c + 1 = 4, so:
+Since the color-type admissibility requirement forces \(N_c \ge 3\), one has \(N_c + 1 \ge 4\), so:
 
 \[
 4 N_g < \frac{43}{2} \quad \Rightarrow \quad N_g \le 5.
@@ -2606,7 +2606,7 @@ QED.
 \item
   It is not a fit to a continuous number.
 \item
-  Under \(T_{\mathrm{ext}}\), this is a derived result, not conditional.
+  Under the imported one-generation/one-Higgs package plus the stated admissibility premises, this is a derived realized-branch consequence rather than part of the bosonic reconstruction theorem.
 \end{itemize}
 
 \subsubsection{Hilbert-space formulation of gluing data}\label{65-hilbert-space-formulation-of-gluing-data}
@@ -3313,8 +3313,8 @@ These IBM runs are best read as hardware benchmarks for the local OPH edge-secto
 
 This section states which node of the program has been proved, which standard mathematics is imported, and which extra physical premises or external inputs remain load-bearing. The documentary node labels D1--D12 match the ledger in Section~\ref{16-summary-complete-axiom-set}. The three-phase boundary is
 \[
-\text{Phase I}=(D1\text{--}D5)\cup(D7\text{--}D9),\qquad
-\text{Phase II}=D6\cup D10,\qquad
+\text{Phase I}=(D1\text{--}D5)\cup D7,\qquad
+\text{Phase II}=D6\cup(D8\text{--}D10),\qquad
 \text{Phase III}=D12.
 \]
 
@@ -3336,8 +3336,8 @@ Node & Representative outputs in this manuscript & Standard mathematics used & E
 \textbf{D5} & Theorem 5.1 rest-frame Einstein relation plus the conditional tensor upgrade of Corollary 5.1 & Jacobson small-ball mathematics; null-to-tensor reconstruction modulo a metric term & fixed-cap stationarity, the locally Lorentzian \(d=4\) scaling regime, and the all-directions/all-reference-states premise used in the tensor upgrade & Phase I conditional scaling-limit theorem/corollary \\
 \textbf{D6} & capacity/\(\Lambda\) statements and the separate capacity-based neutrino estimate & de Sitter entropy relation and dimensional analysis & external input \(N_{\mathrm{scr}}\) and the screen-capacity identification & Phase II input-dependent corollary / estimate \\
 \textbf{D7} & Theorem 6.1 compact gauge reconstruction & Doplicher--Roberts / Tannaka reconstruction & bosonic symmetric transportable colimit and fiber-functor premises; the refinement-stable qualifier is internal to the local finite-constraint MaxEnt/refinement branch & Phase I conditional structural theorem \\
-\textbf{D8} & product gauge structure up to finite quotient under MAR & compact Lie representation classification; Schur's lemma & MAR, connected admissible class, one connected abelian factor, and \([z]=0\) & Phase I realized-branch theorem \\
-\textbf{D9} & realized \(\SU(3)\times\SU(2)\times\U(1)/\mathbb Z_6\), exact hypercharges, the counting chain \(N_g=3\) then \(N_c=3\), and no gauge-mediated proton decay as a product-group corollary & anomaly algebra; Witten anomaly; CKM CP counting & realized one-generation/one-Higgs package and MAR admissibility premises & Phase I realized-branch theorem/corollary chain \\
+\textbf{D8} & product gauge structure up to finite quotient under MAR & compact Lie representation classification; Schur's lemma & imported admissible chiral matter package with one Higgs, MAR, connected admissible class, one connected abelian factor, and \([z]=0\) & Phase II conditional realized-branch theorem \\
+\textbf{D9} & realized \(\SU(3)\times\SU(2)\times\U(1)/\mathbb Z_6\), exact hypercharges, the counting consequences \(N_g=3\) and \(N_c=3\), and no gauge-mediated proton decay as a product-group corollary & anomaly algebra; Witten anomaly; CKM CP counting & realized one-generation/one-Higgs package and MAR admissibility premises & Phase II conditional realized-branch theorem/corollary chain \\
 \textbf{D10} & gauge-coupling numerical closure of the D10 calibration branch & RG running and matching conventions & external input \(P\), pixel closure, and the printed threshold conventions & Phase II calibration sector \\
 \textbf{D12} & Koide/charged leptons, textures, dark-sector, baryogenesis, spectroscopy, string/worldsheet, and other downstream continuations & branch-specific EFT and phenomenological manipulations & explicit additional ans\"atze beyond D6, D9, or D10 & Phase III phenomenological continuation / program branch \\
 \end{longtable}
@@ -3349,9 +3349,9 @@ Three reading rules follow from this ledger.
 \begin{enumerate}
 \def\labelenumi{\arabic{enumi}.}
 \item
-Phase I, the recovered core carried by this manuscript, is D1--D5 together with D7--D9. These are the structural or realized-branch claims defended at theorem/corollary level once all stated premises are included.
+Phase I, the recovered core carried by this manuscript, is D1--D5 together with D7. These are the structural claims defended at theorem level in the bosonic internal-gauge branch.
 \item
-Phase II contains the separate input-dependent capacity corollary D6 and the D10 calibration sector. Failure there does not by itself erase Phase I.
+Phase II contains the separate input-dependent capacity corollary D6, the visible realized-branch selector extension D8--D9, and the D10 calibration sector. Failure there does not by itself erase Phase I.
 \item
 Phase III contains D12 continuations only. Nothing in D12 should be cited as theorem-level unless and until its extra ans\"atze are replaced by proved premises.
 \item \textbf{Existence / strange-loop narratives}: self-simulation or strange-loop closure stories are interpretive epilogues only. The internally available ingredient is a theorem-usable OPH state-and-law habitat built from overlap-consistent patch states together with finite Axiom-3 law coordinates. The recovered core does \emph{not} derive an existence theorem, an OPH-internal closure map on an invariant admissible observer-supporting sector, or any uniqueness/stability result for such a map.
@@ -3369,9 +3369,9 @@ As a program target, OPH aims to recover the familiar low-energy effective-actio
 +
 \sum_i \frac{c_i}{M_*^{\Delta_i-4}}\mathcal O_i.
 \]
-Here \(\mathcal L_{\mathrm{SM}}^{\mathrm{realized\ branch}}\) denotes the realized \(\SU(3)\times\SU(2)\times\U(1)/\mathbb Z_6\) sector with the exact hypercharge lattice and the realized counting chain \(N_g=3\) then \(N_c=3\). This displayed action is the intended IR target of the program, not a new theorem node beyond the ledger: Phase I secures the conditional Einstein branch and the realized Standard Model structural chain, D6 supplies \(\Lambda\) only once the screen-capacity identification is adopted, and the higher-dimension operators absorb UV-sensitive or downstream corrections not fixed by the recovered core itself.
+Here \(\mathcal L_{\mathrm{SM}}^{\mathrm{realized\ branch}}\) denotes the intended realized \(\SU(3)\times\SU(2)\times\U(1)/\mathbb Z_6\) sector with the exact hypercharge lattice and the counting consequences \(N_g=3\) and \(N_c=3\). This displayed action is the intended IR target of the program, not a new theorem node beyond the ledger: Phase I secures the conditional Einstein branch and bosonic compact-gauge reconstruction, D8--D9 record the visible realized-branch selector extension once an admissible chiral matter package is supplied, D6 supplies \(\Lambda\) only once the screen-capacity identification is adopted, and the higher-dimension operators absorb UV-sensitive or downstream corrections not fixed by the recovered core itself.
 
-Symmetry-protected exact zeros such as the masslessness of the photon, gluons, and graviton, together with the absence of gauge-mediated proton decay, are corollaries inside Phase I. They do not define separate axiom-only nodes.
+Symmetry-protected exact zeros such as the masslessness of the photon, gluons, and graviton sit across the structural tiers already recorded in the ledger, while the absence of gauge-mediated proton decay belongs to the D9 realized-branch corollary rather than to Phase I. None of these items defines a separate axiom-only node.
 \subsubsection{Structural assessment}\label{82-structural-assessment}
 
 \begin{itemize}
@@ -3379,7 +3379,7 @@ Symmetry-protected exact zeros such as the masslessness of the photon, gluons, a
 \item
   \textbf{Dynamics}: The GR chain requires modular covariance plus the null-surface modular bridge (N1-N3). Section 5.2 carries the bridge through the derived positive null-translation stage on the OPH geometric scaling branch. The explicit remaining burdens are modular covariance, the downstream density upgrade, and the relativistic null-stress identification. Verifying those items in explicit UV regulators remains a target for future work.
 \item
-  \textbf{Gauge structure}: The gauge group is reconstructed from sector fusion, and the anomaly/gluing link is precise. Axiom 5 (MAR) fixes the SM factors; the CP/UV admissibility window and MAR give \(N_g = 3\), and Witten's parity constraint with that realized generation count gives \(N_c = 3\). Proposition 6.1a gives DHR transportability \(\Leftrightarrow [z]=0\). Justifying the refinement-stability selector for chirality in explicit models remains a target for future work.
+  \textbf{Gauge structure}: The gauge group is reconstructed from sector fusion in the bosonic branch, and the anomaly/gluing link is precise at the level of transportability. Axiom 5 (MAR) then acts only on an admissible sector package that already includes light chiral matter and one Higgs; on that visible realized-branch extension the CP/UV admissibility window and MAR give \(N_g = 3\), and Witten's parity constraint then gives \(N_c = 3\). Proposition 6.1a gives DHR transportability \(\Leftrightarrow [z]=0\). Justifying the refinement-stability selector for chirality in explicit models remains a target for future work.
 \item
   \textbf{Microscopic theory}: Quantum link models (Section 2.6) provide an explicit UV realization of R0/R1 and give EC + Markov collars automatically. What remains: (i) a microscopic derivation of Recoverable Generalized Entropy, and (ii) ensuring modular flow becomes geometric in the continuum limit (the modular-covariance / GB gap). The latter likely requires a holographic or relativistic regime, which is not automatic in generic lattice gauge systems.
 \item
@@ -3463,7 +3463,7 @@ Section~\ref{81-classification-of-results} fixes the three-phase boundary. The l
 \item \textbf{Calibration sector}: the D10 numerical implementation depends on supplement-backed running, matching, and threshold conventions.
 \end{itemize}
 
-Failures localize by tier. A failure in a Phase-III flavor, dark-sector, baryogenesis, spectroscopy, string, strong-CP, proton-spin, or similar continuation retracts that continuation only. A failure in D10 challenges the corresponding calibration sector. Only a failure in Phase I would overturn the recovered-core claim set.
+Failures localize by tier. A failure in a Phase-III flavor, dark-sector, baryogenesis, spectroscopy, string, strong-CP, proton-spin, or similar continuation retracts that continuation only. A failure in D10 challenges the corresponding calibration sector. A failure in D8--D9 retracts the visible realized-branch selector extension. Only a failure in Phase I would overturn the recovered-core claim set.
 
 \subsubsection{Comparison with other unification approaches}\label{85-comparison-with-other-unification-approaches}
 


### PR DESCRIPTION
- demote `D8/D9` from recovered-core outputs to conditional chiral-branch consequences
- separate the secured bosonic reconstruction from the admitted chiral/Yukawa package
- update the compact note and mirrored fragments to match the new claim boundary