### PR TITLE
fix: unify the cosmological-constant / screen-capacity package (issue #47)

### DIFF
--- a/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
+++ b/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
@@ -1840,7 +1840,7 @@ then
 \]
 \end{corollary}
 
-This is a structural aspect of the framework. The vacuum-energy problem is reorganized by separating local null data from the global capacity term.
+Proposition~\ref{prop:lambda} and Corollary~\ref{cor:lambda} are the intended local/global D6 package: local null-modular reconstruction leaves the Einstein equation determined only up to a metric term, and the global screen-capacity identification fixes the remaining constant. This is a structural aspect of the framework. The vacuum-energy problem is reorganized by separating local null data from the global capacity term.
 
 \section{Gauge Reconstruction and Standard Model Structure}
 
@@ -2128,7 +2128,7 @@ The resulting relation
 \[
 \Lambda=\frac{3\pi}{G N_{\mathrm{scr}}}
 \]
-fits naturally with a de Sitter static patch of finite entropy via $N_{\mathrm{scr}}=A_{\mathrm{dS}}/(4G)$. OPH is therefore formulated in a de Sitter-first language. The positive cosmological constant is tied to finite capacity rather than to a deformation of a negative-$\Lambda$ starting point.
+fits naturally with a de Sitter static patch of finite entropy via $N_{\mathrm{scr}}=A_{\mathrm{dS}}/(4G)$. This is the same D6 local/global split in prose: null-modular reconstruction says what local data cannot fix, and screen capacity supplies the missing global datum. OPH is therefore formulated in a de Sitter-first language. The positive cosmological constant is tied to finite capacity rather than to a deformation of a negative-$\Lambda$ starting point.
 
 \subsection{Factorization, gauge structure, and the string sector}
 

--- a/paper/tex_fragments/PAPER.tex
+++ b/paper/tex_fragments/PAPER.tex
@@ -2336,6 +2336,8 @@ Therefore \(\Lambda\) cannot be determined by local consistency. It must be fixe
 If the screen Hilbert space has finite dimension \(\dim(\mathcal{H}_{\rm tot})
 = \exp(S_{dS})\), then the natural semiclassical interpretation of that finite entropy is a cosmological horizon, and matching to GR via the entropy-area relation gives positive \(\Lambda\).
 
+This is one local/global theorem stack rather than a split story: the null-blindness statement says what local reconstruction cannot do, and the finite-capacity identification supplies the missing global datum.
+
 \textbf{What this "solves" vs what it assumes.}
 
 The model does \textbf{not} solve the classic "give me a unitary CFT on the boundary at infinity for dS" problem. It doesn\textquotesingle t aim there. Instead, it provides a coherent route to \textbf{patch holography} where de Sitter static patches are natural:

--- a/paper/tex_fragments/TECHNICAL_SUPPLEMENT.tex
+++ b/paper/tex_fragments/TECHNICAL_SUPPLEMENT.tex
@@ -858,7 +858,9 @@ For Schwarzschild, a sector transition \(d \to d'\) gives: \[\Delta E = k_B T_H 
 
 \begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
 
-\section{The Cosmological Constant Problem}\label{8-the-cosmological-constant-problem}
+\section{Cosmological Constant and Screen-Capacity Framework}\label{8-the-cosmological-constant-problem}
+
+This section is one local/global package rather than two disconnected remarks. The local null-modular reconstruction fixes the Einstein branch only up to a metric term \(\phi g_{ab}\), so it cannot determine \(\Lambda\) from local overlap data alone. The remaining constant enters only when one supplies the global screen-capacity identification, which then yields the D6 relation \(\Lambda = 3\pi/(G N_{\mathrm{scr}})\).
 
 \subsection{Vacuum Energy Blindness}\label{81-vacuum-energy-blindness}
 
@@ -887,6 +889,8 @@ The "huge zero-point energy" simply isn\textquotesingle t the thing determining 
 Equivalently, using de Sitter entropy: \[S_{dS} = \frac{A_{dS}}{4G} = \frac{3\pi}{G\Lambda} = N_{\mathrm{scr}} = \log(\dim \mathcal{H}_{\text{tot}})\]
 
 For observed \(\Lambda \approx 1.09 \times 10^{-52}\) m\(^{-2}\): \[N_{\mathrm{scr}} \sim 10^{122}\]
+
+Together with Proposition~8.2 and Theorem~8.3, this makes the intended theorematic split explicit: local null data determine the Einstein branch only modulo \(\Lambda g_{ab}\), and the global screen-capacity input fixes the remaining constant.
 
 \subsection{\texorpdfstring{No-Go for Local \(\Lambda\) Prediction}{No-Go for Local Lambda Prediction}}\label{84-no-go-for-local-ux3bb-prediction}
 


### PR DESCRIPTION
- Present the cosmological-constant branch in `TECHNICAL_SUPPLEMENT.tex` as one explicit local/global screen-capacity framework
- Sync the compact note and `PAPER.tex` so the null-blindness result and the finite-capacity identification are stated as one D6 theorem stack
- Make the local-versus-global scope explicit without changing the underlying claim boundary