### PR TITLE
fix: demote the dark-sector modular-anomaly branch to future work (issue #48)

### DIFF
--- a/book/chapter-13-desitter.md
+++ b/book/chapter-13-desitter.md
@@ -255,7 +255,7 @@ $$r_{dS} = \sqrt{\frac{3}{\Lambda}} \approx 1.66 \times 10^{26} \text{ m}$$
 
 Galaxy rotation anomalies are an IR phenomenon-they appear at large distances where accelerations are tiny. Any modification from the modular anomaly must be controlled by this scale.
 
-The natural acceleration scale, carrying the anomaly coefficient, is:
+A continuation-level acceleration benchmark, carrying the anomaly coefficient, is:
 
 $$a_0^{(\text{OPH})} = \frac{15}{8\pi^2} \cdot \frac{c^2}{r_{dS}}$$
 
@@ -263,44 +263,47 @@ Plugging in numbers:
 
 $$a_0^{(\text{OPH})} \approx 1.03 \times 10^{-10} \text{ m/s}^2$$
 
-This is within 15% of the empirical MOND acceleration scale $a_0 \sim 1.2 \times 10^{-10}$ $\text{m/s}^2$ that fits galaxy rotation curves.
+This lands near the empirical MOND acceleration scale $a_0 \sim 1.2 \times 10^{-10}$ $\text{m/s}^2$ that fits galaxy rotation curves, which is why the branch is interesting. But this proximity is not yet a derived galaxy-dynamics result.
 
-### What This Branch Suggests
+### What This Continuation Benchmarks
 
-If the modular anomaly is what we're calling "dark matter," then:
+One possible continuation ansatz is to identify the modular anomaly with part of the inferred dark sector. Under that extra ansatz:
 
-**A MOND-like scaling can emerge.** In the deep IR regime where $g < a_0$, the effective gravitational acceleration can take the form:
+**A MOND-like scaling could be postulated.** In the deep IR regime where $g < a_0$, one might write the effective gravitational acceleration as:
 
 $$g_{\text{obs}} \approx \sqrt{a_0 \cdot g_b}$$
 
-where $g_b$ is the Newtonian acceleration from baryons. For a galaxy, this gives $v \propto r^0$-flat rotation curves.
+where $g_b$ is the Newtonian acceleration from baryons. For a galaxy, this would give $v \propto r^0$-flat rotation curves in the ansatz.
 
-**The Baryonic Tully-Fisher relation has the right available scale.** The asymptotic rotation velocity would satisfy:
+**The Baryonic Tully-Fisher relation becomes a benchmark target.** The asymptotic rotation velocity would then satisfy:
 
 $$V^4 = G \cdot M_b \cdot a_0^{(\text{OPH})}$$
 
-This is the observed Tully-Fisher relation, with the normalization determined by screen capacity.
+This is the observed Tully-Fisher relation, with the normalization benchmark determined by screen capacity.
 
-**No new particles are required in this branch.** The "dark matter" would be an effective correction to gravity at large scales, not a new species of particle.
+**No new particles are required at the level of the ansatz.** The "dark matter" would be an effective correction to gravity at large scales, not a new species of particle.
 
 ### The Status
 
-This is a **program-level prediction**, not a proven derivation. What we have:
+This is a **future-work continuation**, not a proven derivation. What we have:
 
 - The modular anomaly term exists with a fixed coefficient
 - The de Sitter scale $r_{dS}$ is determined by screen capacity
 - The combination gives an acceleration scale in the right ballpark
 
-What we're assuming additionally:
+What remains missing:
 
-- That $T_{00}^{\text{anom}}$ dominates galaxy-scale phenomenology
-- That the deep-IR limit organizes into MOND-like scaling
+- A controlled nonrelativistic reduction from the anomaly term to galaxy and lensing observables
+- A derived source/response law selecting the MOND-like scaling rather than alternative IR behavior
+- Cluster and Bullet-Cluster phenomenology
+- Cosmological abundance and structure-formation analysis
+- Environment-dependence and stability checks
 
-But if this interpretation is correct, it would be remarkable: the same finite screen capacity that gives us the cosmological constant would also generate a dark-sector acceleration scale-not as a particle, but as an IR modification of gravity from modular imperfections.
+So the current claim is narrower: the same finite screen capacity that gives us the cosmological constant also supplies an IR benchmark scale for a possible dark-sector continuation. The continuation itself is still open.
 
-### Falsifiability
+### What A Future Closure Would Need To Face
 
-The prediction is sharp: $a_0^{(\text{OPH})} \approx 1.03 \times 10^{-10}$ $\text{m/s}^2$. If galaxy data definitively require a substantially different value, or if the acceleration scale varies with environment in ways incompatible with a universal $\Lambda$-derived scale, this interpretation fails.
+Any later closure would need to explain whether an acceleration scale near $a_0^{(\text{OPH})} \approx 1.03 \times 10^{-10}$ $\text{m/s}^2$ can coexist with galaxy, lensing, cluster, Bullet-Cluster, and cosmological data. At present the branch remains open.
 
 ---
 

--- a/book/chapter-15-relativity.md
+++ b/book/chapter-15-relativity.md
@@ -561,13 +561,13 @@ OPH connects this anomaly to the cosmological constant Λ. The only available la
 
 $$a_0 = \frac{15}{8\pi^2} c^2 \sqrt{\frac{\Lambda}{3}} \approx 1.0 \times 10^{-10} \text{ m/s}^2$$
 
-This is close to the observed MOND acceleration scale. The point of the branch is that galaxy-scale phenomenology and cosmology could be connected through the information structure of the universe.
+This lands near the empirical MOND acceleration scale. That numerical proximity motivates the continuation, but it does not yet derive a galaxy law.
 
-At high accelerations ($g \gg a_0$), standard gravity dominates. At low accelerations ($g \ll a_0$), the anomaly term becomes important, and gravity transitions to MOND-like behavior: $g \sim \sqrt{a_0 \cdot g_b}$ where $g_b$ is the Newtonian prediction from baryons.
+A MOND-like interpolation such as $g \sim \sqrt{a_0 \cdot g_b}$ at low acceleration can be used as a continuation ansatz, where $g_b$ is the Newtonian prediction from baryons. The repo does not currently derive that interpolation from the OPH core.
 
 ### What Remains Open
 
-The branch suggests why MOND-like galaxy scaling and a collisionless dark component could coexist, but the detailed cluster phenomenology, Bullet-Cluster behavior, and cosmological abundance are still open derivation targets. What is currently established is narrower: the anomaly term gravitates, the de Sitter scale supplies a natural IR acceleration scale, and a dark-sector interpretation is structurally available.
+The branch suggests one possible way MOND-like galaxy scaling and a collisionless dark component could coexist, but the detailed galaxy response law, lensing sector, cluster phenomenology, Bullet-Cluster behavior, cosmological abundance, and environment dependence are still open derivation targets. What is currently established is narrower: the anomaly term contributes additional gravitational stress, the de Sitter scale supplies an IR acceleration benchmark, and a dark-sector interpretation remains a future-work continuation rather than a theorem-level result.
 
 ## 15.14 Reverse Engineering Summary
 

--- a/book/prologue.md
+++ b/book/prologue.md
@@ -132,7 +132,7 @@ work out the consequences, the results are extraordinary:
 
 - **A conditional scaling-limit Einstein branch** emerges from entanglement equilibrium on the screen
 - **The Standard Model gauge structure** SU(3) x SU(2) x U(1)/Z₆ is derived rather than assumed under the MAR admissibility package
-- **A dark-sector branch** becomes structurally available from modular anomalies, not new particles
+- **A dark-sector continuation** is explored through modular anomalies, but MOND/RAR-scale phenomenology remains future work rather than a recovered-core result
 - **Why anything exists at all** is addressed through an interpretive strange-loop lane: the universe is treated as a self-referential timeless causal structure supported by OPH's state-and-law habitat, while the stronger closure-map and stability questions remain open
 
 No other framework in physics organizes all of this around structural axioms, explicit claim tiers, and a public separation between theorem-level structure, input-dependent corollaries, and weaker continuations.

--- a/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
+++ b/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
@@ -64,7 +64,7 @@ The standard model of particle physics and general relativity are successful eff
 \[
 \frac{\SU(3)\times\SU(2)\times\U(1)}{\mathbb Z_6},
 \]
-why the observed three generations and three colors are realized, why hypercharges take the observed rational values, why the electroweak and flavor scales are what they are, and why dark-sector phenomenology and the cosmological constant enter in the particular form observed.
+why the observed three generations and three colors are realized, why hypercharges take the observed rational values, what fixes the electroweak and flavor scales, and what the present framework can and cannot say about the cosmological constant and possible dark-sector continuations.
 
 This paper presents a single framework that addresses this list as a conditional reconstruction program. The framework is Observer-Patch Holography (OPH). Its starting point is an observer-centric organization of physical data: each observer has access only to a patch algebra, neighboring observers must agree on overlaps, and global physical law is recovered from the resulting consistency conditions. The same formal structure that produces schedule-independent overlap consistency then feeds a Lorentzian modular-phase classification, a Jacobson-type Einstein branch conditional on fixed-cap stationarity and the null-stress premise, compact gauge reconstruction in a bosonic internal-gauge sector, charge quantization, and the low-energy architecture selected by the admissibility conditions used in the gauge branch.
 
@@ -132,7 +132,7 @@ Node & Output & Immediate OPH ingredients & Standard mathematics used & Extra no
 \end{longtable}
 \endgroup
 
-Accordingly, the recovered-core structural program of the compact note is D1--D5 together with D7--D9. D6 is the separate Phase-II input-dependent corollary; D10 is the current Phase-II supplement-backed calibration sector; and D12 is the Phase-III continuation layer. The only external continuous inputs are \(N_{\mathrm{scr}}\) in D6 and \(P\) in D10, together with descendants built from those branches.
+Accordingly, the recovered-core structural program of the compact note is D1--D5 together with D7--D9. D6 is the separate Phase-II input-dependent corollary; D10 is the current Phase-II supplement-backed calibration sector; and D12 is the Phase-III continuation layer. The modular-anomaly dark-sector branch sits in D12: neither MOND/RAR-style response laws nor galaxy/cluster phenomenology are part of the compact note's theorem-level claim set. The only external continuous inputs are \(N_{\mathrm{scr}}\) in D6 and \(P\) in D10, together with descendants built from those branches.
 \section{Five Axioms, Two External Continuous Inputs in the Current Quantitative Implementation, and Technical Premises}\label{sec:premise-ledger}
 
 This section is the authoritative premise ledger and dependency map for the compact note. The OPH basis used below is exactly the five core axioms, the two external continuous inputs of the current quantitative implementation, and the theorem-local technical premises collected afterward. Older A1--A4 / B / MX / LR / R0--R1 packaging is retained elsewhere only as shorthand for pieces of this canonical package, not as a competing axiom basis. In the present version, the local finite-constraint MaxEnt/refinement branch already internalizes the quasi-local propagation and refinement-stability control that older packaging sometimes carried as separate regularity language, Theorem~\ref{thm:bw} fixes the cap generator and its \(2\pi\) normalization on the OPH Bisognano--Wichmann geometric branch without adding any separate cap-isotropy selector, and Corollary~\ref{cor:n2} derives the null half-sided modular pair inside the synchronized bridge. What remains genuinely theorem-external is the scaling-limit scope clause, the geometric-branch selection burden, the density-upgrade burden, fixed-cap stationarity, the bosonic/fiber-functor fork, the relativistic null-stress identification premise, and the vanishing obstruction premise where invoked.
@@ -2235,7 +2235,7 @@ The following do \emph{not} falsify Theorem~\ref{thm:master} if they fail in the
 \begin{enumerate}[leftmargin=2em]
 \item the uniform $\mathbb Z_6$ center-label ensemble and the associated $\varepsilon=1/6$ flavor ansatz;
 \item Koide/charged-lepton constructions, texture exponents, or capacity-level neutrino estimates;
-\item modular-anomaly dark-sector response laws or MOND/RAR-style scaling claims;
+\item modular-anomaly dark-sector response ans\"atze, including MOND/RAR-style scaling claims;
 \item baryogenesis estimates based on extra suppression-counting assumptions;
 \item proton-spin ans\"atze or proton-lifetime estimates beyond the structural exclusion of gauge-mediated decay;
 \item discrete-horizon spectroscopy templates;
@@ -2245,7 +2245,7 @@ These are all post-Phase-I, non-core branches. Some are Phase-II input-dependent
 
 \subsection{What the compact paper claims after scope-cleaning}
 
-After the present scope clean, the compact paper claims exactly this: observer-overlap consistency, together with the stated scaling-limit and categorical premises, recovers a conditional relativity branch and the realized Standard Model structural branch. The Phase-II capacity relation and the current Phase-II D10 calibration sector remain visible but secondary. Everything in Phase III is explicitly non-core.
+After the present scope clean, the compact paper claims exactly this: observer-overlap consistency, together with the stated scaling-limit and categorical premises, recovers a conditional relativity branch and the realized Standard Model structural branch. The Phase-II capacity relation and the current Phase-II D10 calibration sector remain visible but secondary. Everything in Phase III is explicitly non-core, including the modular-anomaly dark-sector branch, which remains future work rather than a theorem-level output.
 
 \section{Common Objections and Clarifications}
 

--- a/paper/tex_fragments/PAPER.tex
+++ b/paper/tex_fragments/PAPER.tex
@@ -2161,11 +2161,11 @@ This is extremely small, but achievable: with a macroscopic boundary (\(|\partia
 
 This is the concrete path from "axioms about screens" to "precision GR predictions with quantitative error control."
 
-\subsubsection{Dark matter as modular anomaly (program-level)}\label{515-dark-matter-as-modular-anomaly-program-level}
+\subsubsection{Dark-sector continuation from the modular anomaly (future-work benchmark)}\label{515-dark-matter-as-modular-anomaly-program-level}
 
-This subsection is a program-level continuation, not a recovered-core or Phase-II theorem. The formulas below record the normalization estimate obtained if the modular-anomaly term dominates the relevant deep-IR phenomenology; the dark-matter identification and RAR-like scaling law remain additional assumptions.
+This subsection is explicit future work, not a recovered-core or Phase-II theorem. The formulas below record the benchmark scale obtained if one adds a specific deep-IR response ansatz on top of the modular-anomaly term; neither the observational dark-matter identification nor MOND/RAR-like dynamics are derived in the present paper.
 
-The modular anomaly term \(T_{ab}^{\mathrm{anom}}\) derived in Section 5.9 provides a natural candidate for what is observationally interpreted as dark matter, without introducing new particle species.
+The modular anomaly term \(T_{ab}^{\mathrm{anom}}\) derived in Section 5.9 supplies one structural ingredient for a possible dark-sector continuation, without introducing new particle species.
 
 \textbf{The identification.} The anomalous stress-energy contribution
 
@@ -2174,7 +2174,7 @@ The modular anomaly term \(T_{ab}^{\mathrm{anom}}\) derived in Section 5.9 provi
 = \frac{15}{8\pi^2} \cdot \frac{\delta \langle K_C^{\mathrm{(anom)}} \rangle}{\ell^4}
 \]
 
-is "dark" by construction: it arises from information-theoretic/gravitational structure (modular Markov imperfections), not from Standard Model fields. It gravitates but does not couple electromagnetically. This is precisely what "dark matter" means observationally.
+is "dark" by construction: it arises from information-theoretic/gravitational structure (modular Markov imperfections), not from Standard Model fields. It gravitates but does not couple electromagnetically. These properties explain why the term is explored as a dark-sector ingredient, but they do not by themselves close the observational identification.
 
 \textbf{Connection to the cosmological constant.} The framework makes \(\Lambda\) a global capacity parameter:
 
@@ -2184,9 +2184,9 @@ is "dark" by construction: it arises from information-theoretic/gravitational st
 r_{dS} = \sqrt{\frac{3}{\Lambda}}.
 \]
 
-This introduces an unavoidable IR length scale \(r_{dS}\). Galaxy "dark matter" phenomenology is an IR phenomenon-it appears when accelerations are small and distances are large.
+This introduces an unavoidable IR length scale \(r_{dS}\). Any galaxy-scale continuation built from the anomaly term would therefore be an IR phenomenon, appearing only when accelerations are small and distances are large.
 
-\textbf{Emergent acceleration scale.} In the Newtonian/weak-field regime, any IR modification from \(T_{00}^{\mathrm{anom}}\) must:
+\textbf{Continuation-level acceleration benchmark.} If one assumes the relevant deep-IR response is controlled only by \(r_{dS}\), \(c\), and the fixed anomaly prefactor, then the benchmark scale must:
 
 \begin{enumerate}
 \def\labelenumi{\arabic{enumi}.}
@@ -2199,7 +2199,7 @@ This introduces an unavoidable IR length scale \(r_{dS}\). Galaxy "dark matter" 
   Carry non-tunable coefficients from the derivation
 \end{enumerate}
 
-The anomaly enters with prefactor \(\frac{15}{8\pi^2}\). The natural acceleration scale constructible from \((\Lambda, c)\) with this coefficient is:
+The anomaly enters with prefactor \(\frac{15}{8\pi^2}\). The corresponding benchmark acceleration scale constructible from \((\Lambda, c)\) is:
 
 \[
 \boxed{
@@ -2226,15 +2226,15 @@ a_0^{\mathrm{(OPH)}} \approx 1.03 \times 10^{-10} \text{ m/s}^2
 }
 \]
 
-For comparison, observational fits to galaxy regularities (RAR/MDAR/MOND phenomenology) quote \(a_0 \sim 1.2 \times 10^{-10}\) m/s\(^2\). The prediction lands within 15\% without introducing a new free parameter beyond screen capacity/\(\Lambda\).
+For comparison, observational fits to galaxy regularities (RAR/MDAR/MOND phenomenology) quote \(a_0 \sim 1.2 \times 10^{-10}\) m/s\(^2\). This numerical proximity is the benchmark motivating the continuation; it is not yet a derived prediction of galaxy dynamics.
 
-\textbf{Phenomenological consequences.} If \(T_{00}^{\mathrm{anom}}\) sources the inferred dark matter, the Newtonian limit becomes:
+\textbf{One illustrative continuation ansatz.} If one further assumes that \(T_{00}^{\mathrm{anom}}\) is the dominant deep-IR source and that the response organizes into a MOND/RAR-like law, the Newtonian limit could be written as:
 
 \[
 \nabla^2 \Phi = 4\pi G (\rho_b + \rho_{\mathrm{anom}}),
 \]
 
-i.e., baryons plus an effective extra density. The radial acceleration relation (RAR) takes the form:
+i.e., baryons plus an effective extra density. Under the same extra ansatz the radial acceleration relation (RAR) could be written as:
 
 \[
 g_{\mathrm{obs}} \approx g_b + \sqrt{a_0 \cdot g_b},
@@ -2242,7 +2242,7 @@ g_{\mathrm{obs}} \approx g_b + \sqrt{a_0 \cdot g_b},
 g_{\mathrm{DM}} := g_{\mathrm{obs}} - g_b \approx \sqrt{a_0 \cdot g_b}.
 \]
 
-With \(a_0 = a_0^{\mathrm{(OPH)}}\) fixed, this predicts:
+With \(a_0 = a_0^{\mathrm{(OPH)}}\) fixed, that same ansatz would imply:
 
 \textbf{(i) Baryonic Tully-Fisher relation.}
 
@@ -2269,7 +2269,7 @@ i.e., inferred dark mass grows linearly with radius, producing flat rotation cur
 \approx 0.25 \text{ kg/m}^2 \approx 120 \, M_\odot/\text{pc}^2.
 \]
 
-This is in the range of observed central halo surface densities.
+This lies in the range of observed central halo surface densities, but again only as a continuation-level benchmark rather than a derived halo theorem.
 
 \textbf{Status.} What is grounded in the framework developed here:
 
@@ -2279,24 +2279,27 @@ This is in the range of observed central halo surface densities.
   The modular anomaly term exists with fixed coefficient \(\frac{15}{8\pi^2}\)
 \item
   \(\Lambda\) and \(r_{dS}\) are determined by screen capacity
-\item
-  The anomaly acts as "effective extra gravity" in the Newtonian limit
 \end{itemize}
 
-What is an additional assumption (derivation target):
+What remains missing for theorem-level closure:
 
 \begin{itemize}
 \tightlist
 \item
-  That \(T_{00}^{\mathrm{anom}}\) is the dominant source of galaxy-scale "dark matter" phenomenology
+  A controlled nonrelativistic limit from the anomaly term to galaxy observables
 \item
-  That in the deep IR the anomaly organizes into RAR-like scaling with normalization inherited from the \(\frac{15}{8\pi^2}\) prefactor
+  A derived response law selecting the MOND/RAR functional rather than alternative IR behavior
+\item
+  Lensing, cluster, and Bullet-Cluster phenomenology
+\item
+  Cosmological abundance and structure-formation checks
+\item
+  Environment-dependence and stability control
 \end{itemize}
 
-This is best viewed as a \textbf{program-level derivation target} (like the \(\theta_{\mathrm{QCD}}\) program in Section 8.4): the framework contains the natural ingredients, and the precise prediction follows if those ingredients dominate the relevant phenomenology.
+This is best viewed as an explicit \textbf{future-work continuation}: the framework contains structural ingredients and an IR benchmark, but the precise galaxy-scale continuation has not yet been derived from the OPH core.
 
-\textbf{Falsifiability.} The prediction \(a_0^{\mathrm{(OPH)}} \approx 1.03 \times
-10^{-10}\) m/s\(^2\) is sharp. If galaxy data definitively require a different value (say, \(a_0 > 1.5 \times 10^{-10}\) m/s\(^2\)), or if the RAR normalization varies systematically with environment in ways incompatible with a universal \(\Lambda\)-derived scale, this interpretation would be contradicted.
+\textbf{Falsifiability.} If later work cannot supply the missing derivation steps, or if any resulting continuation is incompatible with galaxy, lensing, cluster, Bullet-Cluster, or cosmological data, then the modular-anomaly dark-sector continuation retracts. The recovered OPH core does not.
 
 \subsubsection{De Sitter holography: static patch vs boundary-at-infinity}\label{516-de-sitter-holography-static-patch-vs-boundary-at-infinity}
 

--- a/paper/tex_fragments/TECHNICAL_SUPPLEMENT.tex
+++ b/paper/tex_fragments/TECHNICAL_SUPPLEMENT.tex
@@ -905,9 +905,9 @@ For observed \(\Lambda \approx 1.09 \times 10^{-52}\) m\(^{-2}\): \[N_{\mathrm{s
 
 \begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
 
-\section{Dark Matter as Modular Anomaly}\label{9-dark-matter-as-modular-anomaly}
+\section{Dark-Sector Continuation from the Modular Anomaly}\label{9-dark-matter-as-modular-anomaly}
 
-Sections 9--13 mix two kinds of material: (i) brief reminders of upstream structural results proved elsewhere in the OPH authority ladder, and (ii) genuinely downstream benchmark branches. Only the latter --- dark-sector response laws, proton-spin bookkeeping, baryogenesis estimates, and Yukawa/Koide-style continuations beyond the proved structural core --- should be read here as Phase-III / deferred-continuation material unless a subsection explicitly states otherwise.
+Sections 9--13 mix two kinds of material: (i) brief reminders of upstream structural results proved elsewhere in the OPH authority ladder, and (ii) genuinely downstream benchmark branches. Only the latter --- dark-sector response laws, proton-spin bookkeeping, baryogenesis estimates, and Yukawa/Koide-style continuations beyond the proved structural core --- should be read here as Phase-III / deferred-continuation material unless a subsection explicitly states otherwise. For the dark-sector branch, the imported OPH ingredients are narrower than older rhetoric sometimes suggested: Section~9.2 supplies an anomalous stress-energy term with fixed coefficient, and D6 supplies the de Sitter scale once the screen-capacity input is made. A closed galaxy/cluster phenomenology package is still missing, so this section is explicit future work rather than theorem-level closure.
 
 \subsection{The Modular Additivity Defect}\label{91-the-modular-additivity-defect}
 
@@ -940,21 +940,30 @@ The coefficient \(15/(8\pi^2)\) comes from inverting the \(d=4\) geometric integ
   \textbf{Effectively classical:} Central structure implies classical labels
 \end{enumerate}
 
-\subsection{The MOND Acceleration Scale}\label{94-the-mond-acceleration-scale}
+\subsection{Acceleration-Scale Benchmark for the Continuation}\label{94-the-mond-acceleration-scale}
 
-\textbf{Corollary 9.2 (program-level):} The unique IR acceleration scale available to the modular-anomaly branch from \(\Lambda\) is \[a_0^{(\text{OPH})} := \frac{15}{8\pi^2} c^2 \sqrt{\frac{\Lambda}{3}} = \frac{15}{8\pi^2} \frac{c^2}{r_{dS}}\]
+If one tentatively identifies the imported D6 de Sitter scale with the only IR scale available to a modular-anomaly continuation, then a natural acceleration benchmark is \[a_0^{(\text{OPH})} := \frac{15}{8\pi^2} c^2 \sqrt{\frac{\Lambda}{3}} = \frac{15}{8\pi^2} \frac{c^2}{r_{dS}}\]
 
-\textbf{Numerical evaluation:} \[a_0^{(\text{OPH})} \approx 1.03 \times 10^{-10} \text{ m/s}^2\]
+\textbf{Numerical benchmark:} \[a_0^{(\text{OPH})} \approx 1.03 \times 10^{-10} \text{ m/s}^2\]
 
-Compare to observed: \(a_0^{(\text{obs})} \approx 1.2 \times 10^{-10}\) m/s\(^2\) (within 15\%).
+This lands near the empirical MOND scale \(a_0^{(\text{obs})} \approx 1.2 \times 10^{-10}\) m/s\(^2\), which is why the continuation is worth tracking. It does not yet derive galaxy dynamics, a MOND/RAR law, or an observational dark-matter identification from the OPH core.
 
-\subsection{Polarization Response (MOND-like Scaling)}\label{95-polarization-response-mond-like-scaling}
+\subsection{Illustrative MOND/RAR Ansatz and Open Completion Burden}\label{95-polarization-response-mond-like-scaling}
 
-\textbf{Uniqueness argument:} In the deep-IR regime, the only scales are \(a_0\) and \(g_b\) (Newtonian baryonic acceleration). Dimensional analysis + scale invariance forces: \[g_{\text{anom}} \propto \sqrt{a_0 \cdot g_b}\]
+A MOND/RAR-style response such as \[g_{\text{obs}} \approx g_b + \sqrt{a_0 g_b}\]
+or the cubic polarization functional \[S_{\text{pol}}[\varphi] = \int d^3x \left[-\frac{1}{12\pi G a_0}|\nabla\varphi|^3 - \rho_b \varphi\right]\]
+can be used as phenomenological bookkeeping for the continuation, but neither expression is derived from the OPH axioms or from the current D6/D9 stack alone.
 
-The cubic polarization functional: \[S_{\text{pol}}[\varphi] = \int d^3x \left[-\frac{1}{12\pi G a_0}|\nabla\varphi|^3 - \rho_b \varphi\right]\]
+What remains missing is a closed dark-sector dynamics package:
+\begin{enumerate}
+\item a controlled nonrelativistic limit linking \(T_{ab}^{\text{anom}}\) to galaxy observables;
+\item a derived source/response law selecting the MOND/RAR functional rather than alternative IR behavior;
+\item lensing, cluster, and Bullet-Cluster phenomenology;
+\item cosmological abundance and structure-formation checks;
+\item environment-dependence and stability bounds.
+\end{enumerate}
 
-yields the MOND/RAR form: \[g_{\text{obs}} \approx g_b + \sqrt{a_0 g_b}\]
+Accordingly the modular-anomaly dark-sector branch is explicit future work, not a theorem-level closure.
 
 \begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
 


### PR DESCRIPTION
- Demote the dark-sector modular-anomaly branch from quasi-closed MOND/dark-matter packaging to explicit future-work status across the technical supplement, wrapper paper, and compact note
- State the imported premises and missing closure burden explicitly, including the nonrelativistic reduction, derived response law, lensing/cluster checks, cosmological structure, and stability requirements
- Sync the book surfaces with the same narrower claim boundary so the dark-sector branch remains continuation-level rather than theorem-level