### PR TITLE
fix: Foundational chapters restate the computational ontology as settled fact

### DIFF
--- a/book/chapter-01-consistency.md
+++ b/book/chapter-01-consistency.md
@@ -19,11 +19,11 @@ There is a second through-line running alongside the “reverse engineering” t
 
 That sounds abstract. Let me unpack it.
 
-The universe isn't a stage on which events unfold. It's more like a vast, self-interpreting program. The "code" is quantum information on a holographic boundary. The "execution" is performed by observers - patterns within that information that read, interpret, and act on other patterns. Observers are not outside the data; they are data that has become self-modeling and meaning-making. There's no external computer running this program, no programmer who wrote it. The computation IS the reality. The computer is part of what's being computed.
+The universe isn't a stage on which events unfold. In the OPH picture, it is more like a vast, self-interpreting program. The "code" is quantum information on a holographic boundary. The "execution" is performed by observers - patterns within that information that read, interpret, and act on other patterns. Observers are not outside the data; they are data that has become self-modeling and meaning-making. There is no external computer running this program, no programmer who wrote it. OPH treats computation as a candidate organizing picture for reality, with the computer part of what is being described.
 
 And the structure of this computation-the laws of physics, the geometry of space, the flow of time-isn't arbitrary. It's forced by a single requirement: different observers, looking at overlapping regions, must get consistent answers.
 
-This sounds like philosophy, but it's actually physics. And it is the deepest physics there is.
+This sounds like philosophy, but it is meant as a physics program: a candidate deep-structure picture that OPH tries to make concrete.
 
 ## 1.2 The Intuitive Picture
 
@@ -345,7 +345,7 @@ You might ask: "If reality is a computation, what is it computing?" The answer: 
 
 This view dissolves many traditional puzzles. "Why is there something rather than nothing?" becomes "Why does the computation run?" which is not a meaningful question, any more than asking why 2+2=4. The computation runs because it is self-consistent. It does not need an external cause.
 
-"What is the universe made of?" becomes "What is the substrate of the computation?" which has a precise answer: finite-dimensional quantum systems on a 2D surface, constrained by gauge invariance, selected by maximum entropy. This is not metaphor. It is the technical specification.
+"What is the universe made of?" becomes, within OPH, "What substrate best realizes the computational picture?" The current construction answers: finite-dimensional quantum systems on a 2D surface, constrained by gauge invariance and selected by maximum entropy. This is the concrete technical realization studied in the present program, not yet a uniquely established final ontology.
 
 ## 1.13 The Reverse Engineering Ahead
 

--- a/book/chapter-02-lineage.md
+++ b/book/chapter-02-lineage.md
@@ -340,7 +340,7 @@ But what if they are not?
 
 Our framework supports a different perspective. Reality is not merely compared to computation; OPH treats computation as a candidate organizing picture for reality. The screen is a quantum system processing information according to gauge constraints. Observers are patterns within that computation. The laws of physics are the rules that allow consistent information processing across patches.
 
-From this view, asking "are we in a simulation?" is like asking "is this novel written in words?" The question assumes an alternative that does not exist. There is no non-computational reality to contrast with a simulation. Computation is not a metaphor for reality. It is what reality is made of.
+From this view, asking "are we in a simulation?" becomes less useful than asking what kind of computational organization reality may instantiate. OPH does not treat computation as a loose metaphor; it treats it as a serious candidate organizing picture for reality.
 
 ### The Strange Loop of Self-Simulation
 
@@ -360,7 +360,7 @@ Escher's hands draw each other. Reality simulates the observers who simulate rea
 
 Quantum link models (described in the technical paper) make this concrete. The screen is a lattice gauge theory on a triangulated sphere. The degrees of freedom are finite-dimensional quantum systems at each edge. The dynamics is constrained by Gauss's law at each vertex. The state is selected by maximum entropy.
 
-This is a quantum computation. Not a metaphor for one. An actual computation, with qubits and gates and constraints. The output of this computation is everything we call reality: spacetime, particles, observers, experiences.
+This is a concrete quantum-computational model, with qubits, gates, and constraints, used to make the OPH picture explicit. In that model, spacetime, particles, and observers are treated as emergent outputs of the construction.
 
 The simulation principle asked the right question but framed it wrong. The question is not "are we simulated?" The question is "what is the nature of the self-simulating loop we are part of?" Our framework provides a direction toward the answer.
 

--- a/book/prologue.md
+++ b/book/prologue.md
@@ -118,8 +118,8 @@ compare notes and find they agree?
 
 ## The Shift
 
-This book explores a conceptual shift: **subjective realities are all there
-is.**
+This book explores a conceptual shift: **observer-relative perspectives are
+primary, and objectivity is reconstructed from consistency across them.**
 
 This does not mean solipsism, or that "anything goes," or that "reality is
 whatever you want it to be." Consistency across perspectives


### PR DESCRIPTION
- Category: Claim-Tier Discipline

- Description: The front-matter and foundations chapters still slide from OPH as an organizing picture into a settled ontological specification. [Prologue](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/prologue.md), [Chapter 1](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-01-consistency.md), and [Chapter 2](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-02-lineage.md) now contain lines such as "subjective realities are all there is", "The computation IS the reality", "it is the deepest physics there is", "It is what reality is made of", and "It is the technical specification." Those statements outrun the compact paper's recovered-core / continuation split.

- People may question: Public reviewers can accept OPH as a strong modeling program while still objecting that these passages present the computational reading as already closed and uniquely established. That creates an avoidable attack surface: the book itself says to consult the compact paper for claim tier, but these sentences speak as if the interpretive closure has already been settled.