### PR TITLE
fix: Chapters 3-5 mix the Bekenstein bound with the area / holographic bound

### DIFF
--- a/book/chapter-03-screen.md
+++ b/book/chapter-03-screen.md
@@ -402,7 +402,7 @@ The holographic principle makes sharp, testable predictions:
 
 **1. Area law vs. volume law**: If the holographic principle is correct, entanglement entropy in gravitational systems must scale with area, not volume. Tensor network models that respect the holographic bound produce area-law scaling. Generic quantum field theory states produce volume-law scaling. This is a discriminating test.
 
-**2. The Bekenstein bound is saturated by black holes**: No system can have entropy exceeding $S = A/(4\ell_P^2)$. Black holes saturate this bound-they are maximally entropic for their size. Any violation identifies a measurement contradiction with the model.
+**2. Black holes saturate the gravitational area law**: Black holes realize $S = A/(4\ell_P^2)$ and are maximally entropic for their size in this gravitational sense. Any clear violation of the associated entropy bounds would identify a measurement contradiction with the model.
 
 **3. Information is finite**: The observable universe contains at most $\sim 10^{122}$ bits. This is enormous but finite. Any evidence of truly infinite information content would contradict holography.
 

--- a/book/chapter-04-entropy.md
+++ b/book/chapter-04-entropy.md
@@ -204,7 +204,7 @@ Points deep inside A are entangled with other inside points, not the outside. Th
 
 ### The Connection to Holography
 
-The Bekenstein bound says maximum entropy scales with area. The area law of entanglement says actual entropy (in ground states) scales with area too.
+Black-hole entropy bounds point toward area scaling, while the area law of entanglement says actual entropy (in ground states) scales with area too.
 
 This is not coincidence. Gravitational entropy bounds and entanglement area laws point in the same structural direction, even though they arise in different settings.
 

--- a/book/chapter-05-algebra.md
+++ b/book/chapter-05-algebra.md
@@ -263,7 +263,7 @@ In finite-dimensional language, this is equality of reduced density matrices on 
 
 ### The Question Budget
 
-Observers cannot ask infinitely many questions. Every measurement costs energy and time. The Bekenstein bound says maximum information scales with surface area.
+Observers cannot ask infinitely many questions. Every measurement costs energy and time. In the holographic setting used here, maximum accessible information scales with boundary area.
 
 A patch with boundary area A can support at most about A/(4ℓ_P²) bits of information-the effective Hilbert space dimension is bounded by $e^{A/4\ell_P^2}$.
 


### PR DESCRIPTION
- Category: Technical Accuracy

- Description: [Chapter 3](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-03-screen.md), [Chapter 4](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-04-entropy.md), and [Chapter 5](https://github.com/muellerberndt/observer-patch-holography/blob/main/book/chapter-05-algebra.md) use "Bekenstein bound" as if it were the same thing as the black-hole / holographic area bound. The text correctly gives the Bekenstein formula `S \le 2\pi R E / \hbar c` in Chapter 3, but later says the Bekenstein bound is saturated by `S = A/(4\ell_P^2)` and repeatedly paraphrases it as "maximum entropy scales with area" or "maximum information scales with surface area."

- People may question: This is a standard distinction. The Bekenstein bound depends on energy and size; the black-hole entropy formula and holographic area scaling are related but not identical statements. Mixing them makes the exposition vulnerable on a basic technical definition.