### PR TITLE
Refine book wording and foundations framing

### DIFF
--- a/book/chapter-01-consistency.md
+++ b/book/chapter-01-consistency.md
@@ -227,7 +227,7 @@ A symmetry says "this thing looks the same from different perspectives."
 
 **Gauge symmetry**: You use one mathematical description, I use another. As long as they're related by a gauge transformation, we make the same physical predictions. This lets different mathematical formalisms agree on reality.
 
-In the OPH reading, broad observer agreement strongly favors these symmetries. If the laws changed arbitrarily depending on location, orientation, or frame, consistency would become much harder to maintain.
+Broad observer agreement strongly favors these symmetries. If the laws changed arbitrarily depending on location, orientation, or frame, consistency would become much harder to maintain.
 
 ### Noether's Theorem: The Consistency-Conservation Link
 
@@ -239,7 +239,7 @@ In 1918, Emmy Noether proved one of the most beautiful theorems in physics: **Ev
 
 This is the bookkeeping of agreement. It is more than mathematics.
 
-If energy could just appear or disappear, observers at different times would tell incompatible stories. Conservation laws are the constraints that keep stories aligned. OPH treats them as deeply connected to consistency once the relevant symmetries are in place.
+If energy could just appear or disappear, observers at different times would tell incompatible stories. Conservation laws are the constraints that keep stories aligned once the relevant symmetries are in place.
 
 ## 1.8 Horizons: The Limits of Agreement
 
@@ -326,7 +326,7 @@ Every observer is finite. You only access a specific patch-bounded by horizons, 
 If you look at a star and I look at the same star, we have to agree on what we see. Where patches overlap, physics must be consistent. As we'll see, that single constraint shapes almost everything.
 
 **Principle 3: Area Bound**
-You cannot pack infinite information into a finite region. Black-hole entropy and related bounds strongly motivate an area-sensitive information limit and a holographic, boundary-first reading.
+You cannot pack infinite information into a finite region. Black-hole entropy and related bounds strongly motivate an area-sensitive information limit and a holographic boundary description.
 
 **Principle 4: Conditional Local Recovery**
 Under the relevant Markov and recovery conditions developed later, overlap data can sometimes be used to reconstruct more of the whole system than is obvious from a single local view.

--- a/book/chapter-02-lineage.md
+++ b/book/chapter-02-lineage.md
@@ -230,7 +230,7 @@ Quantum field theory provides a modern analogue to Aristotle's emphasis on form 
 
 Particles are not fundamental objects. They are excitations of fields-ripples in an underlying substrate. An electron is not a tiny ball. It is a stable vibration of the electron field.
 
-And now, with the information-theoretic view, we see the ultimate revenge of Aristotle. The universe is best read here not as little hard atoms alone, but as structured information-relations, distinctions, and quantum degrees of freedom.
+And now, with the information-theoretic view, we see the ultimate revenge of Aristotle. The universe is best read not as little hard atoms alone, but as structured information-relations, distinctions, and quantum degrees of freedom.
 
 What we call "particles" are patterns of information on the holographic screen. The pattern is real; the "stuff" is emergent.
 
@@ -292,7 +292,7 @@ Hofstadter argued that consciousness itself is a strange loop, a pattern that pe
 
 This has profound implications for our model. If reality is computational, and observers are patterns within that computation that model reality, then we have a strange loop: reality contains observers that understand reality.
 
-But Hofstadter and related strange-loop thinkers argue for something deeper: the loop may not just *exist* within reality; it may be part of how reality closes on itself. On that reading, self-reference is not merely possible but structurally important.
+But strange-loop thinkers argue for something deeper: the loop may not just *exist* within reality; it may be part of how reality closes on itself. Self-reference becomes not merely possible but structurally important.
 
 We will return to this idea in Chapter 18, where we consider the possibility that reality evolves toward producing observers capable of understanding and simulating it, closing the loop of self-creation.
 
@@ -338,9 +338,9 @@ But what if they are not?
 
 ### The Right Question
 
-Our framework supports a different perspective. Reality is not merely compared to computation; OPH treats computation as a candidate organizing picture for reality. The screen is a quantum system processing information according to gauge constraints. Observers are patterns within that computation. The laws of physics are the rules that allow consistent information processing across patches.
+Our framework supports a different perspective. Reality is not merely compared to computation; computation becomes a serious candidate organizing picture for reality. The screen is a quantum system processing information according to gauge constraints. Observers are patterns within that computation. The laws of physics are the rules that allow consistent information processing across patches.
 
-From this view, asking "are we in a simulation?" becomes less useful than asking what kind of computational organization reality may instantiate. OPH does not treat computation as a loose metaphor; it treats it as a serious candidate organizing picture for reality.
+From this view, asking "are we in a simulation?" becomes less useful than asking what kind of computational organization reality may instantiate. Computation is not being used here as a loose metaphor; it is being treated as a serious candidate organizing picture for reality.
 
 ### The Strange Loop of Self-Simulation
 
@@ -350,7 +350,7 @@ If reality is computational, then observers can evolve within that computation, 
 
 This would be the strange loop: **reality evolves observers who discover how reality works and build simulations of it, closing the loop of self-creation**.
 
-On this speculative continuation, we are not programs running on someone else's hardware. We are patterns within a self-simulating system. The simulation would run through us, through our understanding, and through our eventual construction of the very computational substrate that gives rise to us.
+In this speculative continuation, we are not programs running on someone else's hardware. We are patterns within a self-simulating system. The simulation would run through us, through our understanding, and through our eventual construction of the very computational substrate that gives rise to us.
 
 This is the book's most speculative thread. It is not needed for the physics developed so far, but it gives the story a striking philosophical closure.
 
@@ -405,10 +405,10 @@ This is not coincidence. The intuitive picture-objective 3D reality independent 
 
 The philosophers gave us hints. Now we need the machinery.
 
-The key claim moving forward is that black-hole entropy and holographic arguments push strongly toward a boundary-first description rather than naive volume bookkeeping. The holographic principle suggests that 3D physics may admit an encoding on 2D surfaces.
+The key claim moving forward is that black-hole entropy and holographic arguments push strongly toward a boundary-first description rather than naive volume counting. The holographic principle suggests that 3D physics may admit an encoding on 2D surfaces.
 
-In the next chapter, we make this concrete. We introduce the **holographic screen** as the boundary-first bookkeeping surface used in this program. We explain *why* a region's boundary is the natural place to organize the accessible data.
+In the next chapter, we make this concrete. We introduce the **holographic screen** as the surface on which the accessible data is organized. We explain *why* a region's boundary is the natural place to do that.
 
-This isn't meant as loose metaphor. It is the bookkeeping picture the next chapter develops and defends.
+This isn't meant as loose metaphor. It is the organizing picture the next chapter develops and defends.
 
 The reverse engineering continues.

--- a/book/chapter-03-screen.md
+++ b/book/chapter-03-screen.md
@@ -74,7 +74,7 @@ The entropy of a black hole is proportional to its surface area, measured in Pla
 
 **The lesson**: The intuitive picture-that information content scales with the size of a container-is fundamentally wrong. Black-hole entropy and related bounds push strongly toward a boundary-sensitive description.
 
-**The first-principles reframing**: The 3D world we experience may not be the fundamental level. In the holographic reading developed here, the bulk is emergent and reconstructed from boundary data.
+**The first-principles reframing**: The 3D world we experience may not be the fundamental level. The bulk may be emergent and reconstructed from boundary data.
 
 ## 3.3 Entropy for Normal People
 
@@ -120,7 +120,7 @@ Shannon's entropy is closely related to the Gibbs/Shannon form, while Boltzmann'
 
 And in 1961, Rolf Landauer showed that erasing information costs energy-at least $k_B T \ln 2$ per bit. Information is physical. Bits are thermodynamic objects.
 
-This is why the Bekenstein-Hawking formula is so important. It connects information (entropy) to geometry (area) and strongly motivates a boundary-first bookkeeping picture.
+This is why the Bekenstein-Hawking formula is so important. It connects information (entropy) to geometry (area) and strongly points toward a boundary description.
 
 ## 3.4 The Holographic Principle
 
@@ -146,7 +146,7 @@ This is weird. It means the interior of a region is somehow redundant. All the i
 
 In the early 1990s, Gerard 't Hooft and Leonard Susskind took this reasoning to its logical conclusion.
 
-If the maximum information in a region scales with surface area, then **a boundary-first description becomes a very strong candidate for the fundamental bookkeeping**. On that reading, the three-dimensional interior is not fundamental-it is emergent, reconstructed from boundary data.
+If the maximum information in a region scales with surface area, then **a boundary-first description becomes a very strong candidate for the fundamental organization of the data**. On that reading, the three-dimensional interior is not fundamental-it is emergent, reconstructed from boundary data.
 
 't Hooft called this the **holographic principle**, by analogy with holograms. A hologram is a two-dimensional film that encodes a three-dimensional image. When you illuminate it, you see depth that isn't really there-the depth is computed from the 2D pattern.
 
@@ -316,7 +316,7 @@ This definition of observers resolves several puzzles:
 
 **No external reference frame**: Observers are internal to the system, so there's no need for an external "God's-eye view."
 
-**Measurement is physical**: When an observer measures something, correlations form between subsystems within the horizon data and stable records are created. In the OPH reading, that record formation captures the main physical content behind textbook collapse language.
+**Measurement is physical**: When an observer measures something, correlations form between subsystems within the horizon data and stable records are created. That record formation captures the main physical content behind textbook collapse language.
 
 **Consistency follows from structure**: In the constructive screen picture, if two observers are modeled as patterns in the same underlying state, their reduced descriptions must agree on overlaps. The more general gluing story is subtler and is developed later.
 
@@ -421,7 +421,7 @@ Let's trace the reverse engineering explicitly.
 
 **The hint**: Black hole entropy scales with area, and gravitational entropy bounds point toward boundary-limited information.
 
-**The lesson**: A boundary-first description becomes a strong candidate. On that reading, the boundary is primary and the bulk is emergent.
+**The lesson**: A boundary-first description becomes a strong candidate. The boundary is primary and the bulk emergent.
 
 **The first-principles reframing**:
 
@@ -451,7 +451,7 @@ In the finite-resolution screen picture used here, continuous space is an effect
 ## 3.13 Where We Go Next
 
 We have established that:
-- Gravitational entropy bounds and holographic arguments push strongly toward horizon/boundary-sensitive bookkeeping rather than naive volume counting
+- Gravitational entropy bounds and holographic arguments push strongly toward horizon-sensitive information organization rather than naive volume counting
 - In the symmetric light-cone constructions used here, the effective screens are spherical as a consequence of causality
 - The amount of information is finite, bounded by area
 - Entanglement patterns on the screen create emergent 3D geometry

--- a/book/chapter-04-entropy.md
+++ b/book/chapter-04-entropy.md
@@ -106,13 +106,13 @@ We exist in a brief window when entropy is high enough for complexity but low en
 
 **The hint**: The microscopic laws are time-symmetric. Irreversibility is statistical, not fundamental. The arrow traces to the low-entropy initial condition.
 
-**The reframing**: Here is where our model offers something surprising. The Past principle is usually taken as a brute fact-an unexplained initial condition. But the OPH viewpoint suggests a possible consistency-based explanation for why low-entropy beginnings are structurally important.
+**The reframing**: Here is where our model offers something surprising. The Past principle is usually taken as a brute fact-an unexplained initial condition. But this picture suggests a possible consistency-based explanation for why low-entropy beginnings are structurally important.
 
 Consider: for observers to exist at all, they must be able to form consistent records. Records require entropy gradients-you can only write information by pushing entropy somewhere else. A universe in thermal equilibrium has no observers, no records, no consistency-checking, no reality in the sense we've been developing.
 
 The MaxEnt principle tells us to assign the maximum-entropy state *given our constraints*. But what are the constraints? If one of them is "observers exist to apply MaxEnt," then equilibrium states are ruled out by construction. The very act of asking "what state should I assign?" presupposes a questioner embedded in an entropy gradient.
 
-This doesn't derive the specific low entropy of the Big Bang from pure logic. But it does suggest that the Past principle is not an arbitrary input; it is structurally important in the OPH reading. A universe with durable observers checking for consistency appears to require a significant departure from equilibrium. The low-entropy past can then be read as a structural precondition for the consistency-building present, not yet as a fully derived theorem of the framework.
+This doesn't derive the specific low entropy of the Big Bang from pure logic. But it does suggest that the Past principle is not an arbitrary input; it is structurally important in this picture. A universe with durable observers checking for consistency appears to require a significant departure from equilibrium. The low-entropy past can then be read as a structural precondition for the consistency-building present, not yet as a fully derived theorem of the framework.
 
 ## 4.4 Information is Physical
 
@@ -140,7 +140,7 @@ This sounds technical. It's revolutionary. It means **information is physical**.
 
 In 1867, Maxwell imagined a demon operating a door between two gas chambers. By selectively letting fast molecules through one way and slow molecules the other, the demon could create a temperature difference without work-seemingly violating the Second Law.
 
-The modern resolution is subtler than one sentence, but Landauer-style memory erasure is a central part of it: the demon must observe and remember each molecule's velocity, and resetting that memory carries a thermodynamic cost that preserves the Second Law bookkeeping.
+The modern resolution is subtler than one sentence, but Landauer-style memory erasure is a central part of it: the demon must observe and remember each molecule's velocity, and resetting that memory carries a thermodynamic cost that preserves the Second Law.
 
 **The hint**: Information processing has thermodynamic costs. You cannot observe, remember, or compute for free.
 
@@ -338,10 +338,10 @@ Let's trace the logic explicitly.
 2. The information they can access is bounded by their patch area
 3. Entanglement patterns on the screen determine both entropy and geometry
 4. The consistency process that makes observations agree costs energy and generates entropy
-5. In the OPH reading, durable observers and records require entropy gradients, so a robust arrow of time becomes structurally important
+5. Durable observers and records require entropy gradients, so a robust arrow of time becomes structurally important
 6. The Past principle may be structurally favored by consistency constraints, even though the specific low-entropy beginning is not yet derived from OPH alone
 
-On this reading, the universe appears to require a special low-entropy state for any of this to work. But this need not be left as an unexplained miracle. Consistency constraints require observers, observers require records, records require entropy gradients, and entropy gradients point back toward a low-entropy past. OPH therefore offers a consistency-based reason to view the Past principle as structurally motivated, even though the exact initial condition is not yet derived from the framework alone.
+This suggests that the universe required a special low-entropy state for any of this to work. But this need not be left as an unexplained miracle. Consistency constraints require observers, observers require records, records require entropy gradients, and entropy gradients point back toward a low-entropy past. The Past principle is therefore structurally motivated here, even though the exact initial condition is not yet derived from the framework alone.
 
 ## 4.11 Summary: The Entropy Budget
 
@@ -349,7 +349,7 @@ On this reading, the universe appears to require a special low-entropy state for
 
 2. **The Second Law is statistics**: High-entropy states dominate because there are more of them.
 
-3. **The arrow of time is cosmological**: It traces to the low-entropy Big Bang. OPH offers a consistency-based reason to regard such low-entropy beginnings as structurally important because observers need entropy gradients to form records.
+3. **The arrow of time is cosmological**: It traces to the low-entropy Big Bang. Low-entropy beginnings are structurally important here because observers need entropy gradients to form records.
 
 4. **Information is physical**: Landauer's principle says erasing a bit costs energy.
 

--- a/book/chapter-05-algebra.md
+++ b/book/chapter-05-algebra.md
@@ -66,7 +66,7 @@ Heisenberg started with observations (spectral lines) and reverse-engineered the
 
 ### Why Non-Commutativity Is Not Arbitrary
 
-Here is the OPH reading developed in this chapter: non-commutativity is part of what makes overlap consistency nontrivial.
+The working idea in this chapter is that non-commutativity is part of what makes overlap consistency nontrivial.
 
 Consider the overlap condition. When two observers compare notes, they must agree on their shared observables. In a commutative world-where all measurements are compatible-the problem is much closer to the classical marginal setting. Pre-existing values can often be assigned more straightforwardly, especially on simple overlap structures, but compatibility is not automatic on arbitrary overlap graphs.
 
@@ -74,7 +74,7 @@ But the Quantum Marginal Problem shows this doesn't work. Pairwise-consistent ma
 
 Here's the deeper point: **non-commutativity is what makes the quantum consistency problem especially hard.** If measurements all commuted, the overlap conditions would be much closer to the classical case. Physics could still have rich laws and dynamics, but it would miss the specifically quantum constraint structure highlighted here.
 
-Non-commutativity creates a tension between local freedom and global consistency. In the OPH reading, specific patterns of entanglement help resolve that tension and are part of what we read as physical law. OPH interprets quantum non-commutativity as deeply connected to the difficulty of global consistency instead of treating it as an arbitrary extra feature.
+Non-commutativity creates a tension between local freedom and global consistency. Specific patterns of entanglement can help resolve that tension and are part of what we read as physical law. On this view, quantum non-commutativity is deeply connected to the difficulty of global consistency instead of being treated as an arbitrary extra feature.
 
 ## 5.3 The Order of Questions
 
@@ -170,7 +170,7 @@ An observable is represented by a Hermitian operator A. The possible measurement
 
 $$P(a) = |\langle a|\psi\rangle|^2$$
 
-In the standard textbook projection-postulate picture, an ideal measurement updates the state to the eigenstate corresponding to the measured value.
+In the standard textbook update rule, an ideal measurement updates the state to the eigenstate corresponding to the measured value.
 
 ### The Density Matrix
 

--- a/book/chapter-06-overlap.md
+++ b/book/chapter-06-overlap.md
@@ -150,11 +150,11 @@ Now apply the overlap consistency condition. Any assignment where patches disagr
 
 **Reality is the collection of local states that survives the consistency filter.**
 
-The hardness of the Quantum Marginal Problem tells us the filter is doing real work. The constraints are genuinely restrictive. This helps explain why overlap consistency is a nontrivial structural requirement rather than a vacuous one. In the OPH reading, that hardness is part of why the allowed state-space is highly structured rather than arbitrary.
+The hardness of the Quantum Marginal Problem tells us the filter is doing real work. The constraints are genuinely restrictive. This helps explain why overlap consistency is a nontrivial structural requirement rather than a vacuous one. It also suggests that the allowed state-space is highly structured rather than arbitrary.
 
-And here is the key insight: in the OPH reading, overlap conditions favor allowing correlations that exceed classical bounds. Bell-violating correlations are then interpreted as part of the quantum structure that helps keep patches consistent without a large hidden-variable bookkeeping overhead.
+And here is the key insight: overlap conditions favor allowing correlations that exceed classical bounds. Bell-violating correlations can then be read as part of the quantum structure that helps keep patches consistent without a large hidden-variable overhead.
 
-In a universe built on observer agreement, the nonlocal correlations that so troubled Einstein are not inexplicable. OPH treats them as structurally natural rather than accidental.
+In a universe built on observer agreement, the nonlocal correlations that so troubled Einstein are not inexplicable. They become part of the consistency structure rather than an unexplained add-on.
 
 ## 6.4 Defining the Overlap
 
@@ -353,15 +353,15 @@ Classical objectivity is quantum redundancy. The facts everyone agrees on are th
 
 Let's step back and consider the big picture.
 
-We've been building toward a radical view of reality. OPH does not begin by requiring a single, global "state of the universe." A useful mathematical analogy is a sheaf-like gluing picture in which local data are stitched together by consistency conditions.
+We've been building toward a radical view of reality. We do not begin by requiring a single, global "state of the universe." A useful mathematical analogy is a sheaf-like gluing picture in which local data are stitched together by consistency conditions.
 
 ### The Internet Analogy
 
 Think of the internet. There's no single file called "The Internet" stored somewhere. There are billions of computers, each with its own memory. They communicate via protocols. When my computer sends a packet to yours, we "agree" on the content. The "internet" is the emergent consistency of all these local interactions.
 
-Reality need not be organized for us as a single quantum state observed from a God's-eye view. Instead, it can be treated as a collection of local states-one for each observer-constrained to agree on overlaps.
+Reality need not be organized for us as a single quantum state observed from a God's-eye view. It can instead be treated as a collection of local states-one for each observer-constrained to agree on overlaps.
 
-When a global state exists, great. But we don't require one. Local states satisfying consistency conditions are enough for physics.
+When a global state exists, that is useful. But we do not require one. Local states satisfying consistency conditions are enough for physics.
 
 ### Living Without a Global Wavefunction
 
@@ -441,15 +441,15 @@ Summary of this chapter:
 
 | Intuitive Picture | Surprising Hint | First-Principles Reframing |
 |---|---|---|
-| Correlations come from shared causes or hidden variables | Bell's theorem: quantum correlations violate Bell inequalities, exceeding what any local hidden variable theory permits | In OPH, consistency conditions across observer patches make Bell-violating correlations structurally natural rather than accidental |
+| Correlations come from shared causes or hidden variables | Bell's theorem: quantum correlations violate Bell inequalities, exceeding what any local hidden variable theory permits | Consistency conditions across observer patches make Bell-violating correlations structurally natural rather than accidental |
 
-**The key reverse engineering insight**: We started with the intuition that distant correlations must have local explanations. Bell's theorem revealed that nature permits correlations that exceed classical bounds. OPH reads this as evidence that a consistency-built reality naturally favors genuinely quantum correlation structure rather than classical hidden-variable bookkeeping.
+**The key reverse engineering insight**: We started with the intuition that distant correlations must have local explanations. Bell's theorem revealed that nature permits correlations that exceed classical bounds. This points toward a consistency-built reality that naturally favors genuinely quantum correlation structure rather than classical hidden-variable stories.
 
-**Why Bell violations matter here**: This deserves emphasis. The Quantum Marginal Problem is QMA-complete-checking whether local states are globally consistent is computationally hard. This hardness is a feature, not a bug. It shows that overlap consistency is a real constraint, and OPH interprets Bell-violating correlations as part of the quantum structure that helps satisfy it.
+**Why Bell violations matter here**: This deserves emphasis. The Quantum Marginal Problem is QMA-complete-checking whether local states are globally consistent is computationally hard. This hardness is a feature, not a bug. It shows that overlap consistency is a real constraint, and Bell-violating correlations may be part of the quantum structure that helps satisfy it.
 
-OPH treats Bell-violating correlations as part of the quantum structure that can help satisfy overlap conditions with less classical pre-coordination. Einstein wanted particles to carry "instruction sets" from their common past. But instruction sets create combinatorial explosions as you add more observers. On this reading, entanglement that exceeds classical bounds is more parsimonious and reduces the bookkeeping burden.
+Bell-violating correlations can be seen as part of the quantum structure that helps satisfy overlap conditions with less classical pre-coordination. Einstein wanted particles to carry "instruction sets" from their common past. But instruction sets create combinatorial explosions as you add more observers. Entanglement that exceeds classical bounds is more parsimonious and reduces the bookkeeping burden.
 
-Put differently: OPH treats Bell-violating correlations as an efficient part of the quantum bookkeeping needed to maintain consistency across patches.
+Put differently: Bell-violating correlations can be read as an efficient part of the quantum structure needed to maintain consistency across patches.
 
 **Additional lessons**:
 
@@ -467,7 +467,7 @@ Put differently: OPH treats Bell-violating correlations as an efficient part of 
 
 7. **Quantum Darwinism**: Classical objectivity emerges when quantum information gets redundantly copied into the environment, making it accessible through multiple overlapping channels.
 
-8. **Reality as a Sheaf-Like Gluing Picture**: OPH need not begin from a single global state; it can instead be organized as local states glued together by consistency conditions-like the internet, not like a centralized database.
+8. **Reality as a Sheaf-Like Gluing Picture**: The framework need not begin from a single global state; it can instead be organized as local states glued together by consistency conditions-like the internet, not like a centralized database.
 
 ---
 

--- a/book/prologue.md
+++ b/book/prologue.md
@@ -66,7 +66,7 @@ is just... there.
 
 **Information can't be destroyed.** Throw something into a black hole, and
 modern quantum-gravity arguments suggest the information is not simply
-erased. It is thought to be encoded in horizon bookkeeping, though the
+erased. It is thought to be encoded at the horizon, though the
 detailed recovery story remains subtle.
 
 **Black holes put information under pressure.** Throw something into a black
@@ -75,7 +75,7 @@ is not simply lost, even though the detailed recovery story remains subtle
 and framework-dependent.
 
 **Holography is a major clue.** The information needed to describe a volume
-of space may admit a boundary-first encoding. The three-dimensional
+of space may be encoded on its boundary. The three-dimensional
 world can then be read as an emergent bulk description.
 
 If a human engineer wrote a program with these specifications, we'd assume


### PR DESCRIPTION
## Summary

Focused cleanup of the book files (prologue and Chapters 1-6).

The goal was not to rewrite the book, but to tighten places where the wording was easier to attack than necessary on public review. The edits keep the OPH framing strong while smoothing several statements that were too categorical, historically stronger than the cited ideas support, or unnecessarily awkward in prose.