### PR TITLE
fix: demote D10 electroweak closure claims (issue #33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ OPH is a reconstruction program for fundamental physics. Spacetime, gauge struct
 - A finite-resolution theorem package for observer patches, collars, overlap repair, higher gauge structure, records, and checkpoint/restoration.
 - A conditional route to Lorentzian geometry, modular time, Jacobson-type Einstein dynamics, and de Sitter static-patch cosmology on the extracted prime geometric subnet; the remaining UV/BW scaffold is geometric cap-pair realization on that subnet plus ordered cut-pair rigidity, with the eventual fixed-local-collar modular-transport common floor as the smallest lower blocker.
 - A compact gauge route to the realized Standard Model quotient `SU(3) x SU(2) x U(1) / Z_6`, together with the exact hypercharge lattice and the realized counting chain `N_g = 3`, `N_c = 3`.
-- A particle program with exact structural massless carriers, theorem-grade electroweak closure, a quantitative Higgs/top stage, exact non-hadron mass sidecars, and explicit continuation lanes for flavor and hadrons.
+- A particle program with exact structural massless carriers, a forward-emitted Phase II electroweak calibration branch with target-free public `W/Z` rows plus a compare-only exact frozen pair, a quantitative Higgs/top stage, exact non-hadron mass sidecars, and explicit continuation lanes for flavor and hadrons.
 - A concrete screen-microphysics architecture that puts measurement, records, and observers inside the physics.
 
 **Overall theorem and derivation stack**
@@ -31,7 +31,7 @@ OPH is a reconstruction program for fundamental physics. Spacetime, gauge struct
 ### Theorem-grade and structural hits
 
 - Exact structural zeros for the photon, gluons, and graviton.
-- Electroweak closure on the D10 calibration chain, with target-free public `W/Z` rows and an exact frozen pair
+- Electroweak output on the D10 calibration branch, with target-free public `W/Z` rows and an exact frozen compare-only pair
   `W = 80.377 GeV`, `Z = 91.18797809193725 GeV`.
 - A quantitative Higgs/top stage downstream of the electroweak core, with a closed one-scalar forward seed carrying the public rows
   `H = 125.218922 GeV`, `t = 172.388646 GeV`.

--- a/README_FR.md
+++ b/README_FR.md
@@ -13,7 +13,7 @@ L'OPH est un programme de reconstruction. Espace-temps, structure de jauge, part
 - Un paquet théorématique à cutoff fixe pour les patches d'observateurs, les collerettes, la réparation de recouvrement, la jauge supérieure, les enregistrements et le checkpoint/restauration.
 - Une voie conditionnelle vers la géométrie lorentzienne, le temps modulaire, la dynamique d'Einstein de type Jacobson et la cosmologie de Sitter en patch statique sur le sous-réseau géométrique premier extrait ; le scaffold UV/BW restant est la réalisation de la paire de caps géométrique sur ce sous-réseau puis la rigidité des paires de coupures ordonnées, avec le plancher commun éventuel de transport modulaire sur collerette locale fixe comme plus petit bloqueur inférieur.
 - Une voie de jauge compacte vers le quotient réalisé du Modèle Standard `SU(3) x SU(2) x U(1) / Z_6`, avec le réseau exact des hypercharges et la chaîne de comptage réalisée `N_g = 3`, `N_c = 3`.
-- Un programme particules avec porteurs structurels exactement sans masse, fermeture électrofaible de rang théorème, étage quantitatif Higgs/top, sidecars exacts non hadroniques et voies de continuation explicites pour la saveur et les hadrons.
+- Un programme particules avec porteurs structurels exactement sans masse, une branche de calibration électrofaible de Phase II émise vers l'avant avec lignes publiques `W/Z` target-free plus une paire gelée exacte utilisée seulement comme validation compare-only, un étage quantitatif Higgs/top, des sidecars exacts non hadroniques et des voies de continuation explicites pour la saveur et les hadrons.
 - Une architecture microphysique d'écran concrète qui met mesure, enregistrements et observateurs à l'intérieur de la physique.
 
 **Pile générale des théorèmes et dérivations**
@@ -31,7 +31,7 @@ L'OPH est un programme de reconstruction. Espace-temps, structure de jauge, part
 ### Résultats théorématiques et structurels
 
 - Zéros structurels exacts pour le photon, les gluons et le graviton.
-- Fermeture électrofaible sur la chaîne de calibration D10, avec lignes publiques target-free pour `W/Z` et paire gelée exacte
+- Sortie électrofaible sur la branche de calibration D10, avec lignes publiques `W/Z` target-free et paire gelée exacte utilisée seulement comme validation compare-only
   `W = 80.377 GeV`, `Z = 91.18797809193725 GeV`.
 - Étage quantitatif Higgs/top en aval du coeur électrofaible, avec une graine forward scalaire unique fermée qui porte les lignes publiques
   `H = 125.218922 GeV`, `t = 172.388646 GeV`.

--- a/paper/deriving_the_particle_zoo_from_observer_consistency.tex
+++ b/paper/deriving_the_particle_zoo_from_observer_consistency.tex
@@ -605,7 +605,7 @@ running/matching surface and thereby fixes the source basis
 \((\alpha_{2,m_Z},\alpha_{Y,m_Z},\eta_{\mathrm{source}},v)\). The target-free
 source-only repair theorem emits one coherent quintet
 \((W,Z,\alpha_{\mathrm{em}}^{-1},\sin^2\theta_W,v)\) from that calibrated basis. The
-derivation also includes two explicit validation surfaces beneath the public theorem output: the
+derivation also includes two explicit validation surfaces beneath the public branch output: the
 exact current-carrier chart and the freeze-once coherent repair surface. The same tiered logic is
 useful later in the paper because flavor and neutrino derivations do have open theorem objects,
 whereas the electroweak calibration lane does not.
@@ -1030,7 +1030,7 @@ declared D10 running/matching surface, thereby fixing the source basis
 \]
 and only then emit the repaired electroweak quintet forward from that calibrated basis. The
 active public \(W/Z\) rows are therefore not obtained by re-inserting the target masses after
-calibration; they are forward outputs of the closed D10 calibration theorem.
+calibration; they are forward outputs of the D10 Phase-II calibration branch.
 
 The public reported rows are
 \[

--- a/paper/observers_are_all_you_need.tex
+++ b/paper/observers_are_all_you_need.tex
@@ -165,7 +165,9 @@ checkpoint/restoration packages. On the continuum side, OPH gives a conditional
 Lorentzian/Jacobson-type gravity branch and a conditional compact-gauge route whose realized
 low-energy output is the Standard Model quotient above with the exact hypercharge lattice and the
 counting chain \(N_g=3\) then \(N_c=3\). On the particle side, the structural massless carriers
-are fixed, the electroweak lane is closed at theorem level, the Higgs/top stage is emitted on its
+are fixed, the electroweak lane survives as a forward-emitted non-core Phase-II calibration
+branch with target-free public \(W/Z\) rows and a compare-only frozen validation pair, the
+Higgs/top stage is emitted on its
 secondary branch, and the neutrino lane matches the observed mixing/hierarchy pattern while
 leaving one reduced normalization invariant open; the charged-lepton, quark, and hadron lanes keep
 their remaining closure objects explicit. The main external burden is the continuum/BW lift on the
@@ -193,7 +195,9 @@ record package, and the checkpoint/restoration package are theorem-bearing on th
 surfaces. The Lorentz/null-modular/Einstein chain and compact gauge reconstruction remain
 conditional continuum or categorical branches. The particle lane is the most tiered part of
 the suite: the structural carrier skeleton and realized Standard Model branch are fixed, the
-electroweak stage is closed, the Higgs/top stage is a secondary quantitative branch, the neutrino
+electroweak stage remains a non-core Phase-II calibration branch with target-free public
+\(W/Z\) rows and a compare-only frozen validation pair, the Higgs/top stage is a secondary
+quantitative branch, the neutrino
 lane is shape-accurate with one reduced normalization invariant open, and the
 charged-lepton, quark, and hadron lanes remain explicitly unfinished for different reasons.
 
@@ -222,9 +226,10 @@ Technically, compact gauge reconstruction and the realized
 \(\SU(3)\times\SU(2)\times\U(1)/\mathbb Z_6\) branch follow under the stated transportability and
 categorical premises, with the realized counting chain \(N_g=3\) then \(N_c=3\).
 \item \textbf{The particle lane has real outputs and a nonuniform closure profile.}
-Technically, the structural carriers are exact, the electroweak stage is closed, the Higgs/top
-stage is quantitatively emitted on a secondary branch, and the charged-lepton, quark, neutrino,
-and hadron lanes carry named remaining closure objects.
+Technically, the structural carriers are exact, the electroweak stage remains on a non-core
+Phase-II calibration branch with target-free public \(W/Z\) rows and a compare-only frozen
+validation pair, the Higgs/top stage is quantitatively emitted on a secondary branch, and the
+charged-lepton, quark, neutrino, and hadron lanes carry named remaining closure objects.
 \item \textbf{The screen-microphysics lane is explicit and concrete.} Technically, it
 contains an explicit regulated reference architecture, sharpened patch-net and edge-sector
 branches, a closed fixed-cutoff Born-rule package, and a closed checkpoint/restoration package.

--- a/paper/tex_fragments/TECHNICAL_SUPPLEMENT.tex
+++ b/paper/tex_fragments/TECHNICAL_SUPPLEMENT.tex
@@ -953,7 +953,7 @@ At one loop, if couplings unify at \((M_U, \alpha_U)\): \[\alpha_i^{-1}(M_Z) = \
 
 Define \(A_i := \alpha_i^{-1}(M_Z)\), \(L := \ln(M_U/M_Z)\). Eliminating \(\alpha_U\): \[L = \frac{2\pi}{b_1 - b_2}(A_1 - A_2)\]
 
-The consistency relation for \(\alpha_s\) (a consistency check when all three couplings calibrate $P$; a genuine prediction in the two-input mode): \[A_3^{\text{pred}} = \frac{b_3 - b_2}{b_1 - b_2}A_1 + \frac{b_1 - b_3}{b_1 - b_2}A_2\]
+The consistency relation for \(\alpha_s\) on the D10 lane (a consistency check when all three couplings calibrate $P$; in the two-input mode a forward-emitted Phase-II calibration output rather than a recovered-core prediction): \[A_3^{\text{pred}} = \frac{b_3 - b_2}{b_1 - b_2}A_1 + \frac{b_1 - b_3}{b_1 - b_2}A_2\]
 
 \subsection{SM vs MSSM Coefficients}\label{52-sm-vs-mssm-coefficients}
 


### PR DESCRIPTION
- Sync README, README_FR, the synthesis paper, the particle paper, and the technical supplement to describe D10 as a Phase II calibration branch rather than theorem-grade electroweak closure.
- Keep the public W/Z rows as forward-emitted D10 branch outputs and treat the exact frozen electroweak pair as compare-only validation.
- Leave the compact note and PAPER fragment unchanged because upstream main already carries the demoted D10 framing recorded in the issue 33 artifact.
