### PR TITLE
fix: demote D10 unification-package claims (issue #45)

### DIFF
--- a/book/chapter-14-standard-model.md
+++ b/book/chapter-14-standard-model.md
@@ -639,13 +639,13 @@ In the 1970s, physicists noticed something remarkable. If you run the couplings 
 
 But there was a problem. With just the Standard Model particle content, the three couplings don't quite meet. They miss each other. In the 1990s, physicists discovered that adding supersymmetric partners fixes this: with MSSM-like particle content, the couplings unify beautifully, predicting $\alpha_s(M_Z) \approx 0.117$, remarkably close to the measured value of $0.1177 \pm 0.0009$.
 
-Our framework does more than "inherit" this success. It *derives* the MSSM-like beta shifts from edge-mode structure. The key mechanism is the Peter-Weyl decomposition of $L^2(G)$: a representation $R$ corresponds to a block $V_R \otimes V_R^*$ of size $d_R^2$. Entropy, which selects the MaxEnt state, traces over one side, giving the familiar $d_R$ factor in $p_R \propto d_R e^{-t C_2(R)}$. Vacuum polarization loops run over both indices, restoring the second $d_R$. The effective multiplicity for RG running is therefore $N_{\text{eff}} = d \cdot p$.
+Our framework does not yet promote this to a theorem-level supersymmetric spectrum. The narrower current claim is that the edge-mode structure can reproduce MSSM-like one-loop beta shifts only on a declared D10 calibration package: external input $P$, the printed running/matching conventions, the printed threshold conventions, and, when the near-MSSM benchmark is quoted, an added fermionic-grading restriction to half-integer SU(2) sectors. The key mechanism is the Peter-Weyl decomposition of $L^2(G)$: a representation $R$ corresponds to a block $V_R \otimes V_R^*$ of size $d_R^2$. Entropy, which selects the MaxEnt state, traces over one side, giving the familiar $d_R$ factor in $p_R \propto d_R e^{-t C_2(R)}$. Vacuum polarization loops run over both indices, restoring the second $d_R$. The effective multiplicity for RG running is therefore $N_{\text{eff}} = d \cdot p$.
 
 At the unification-scale heat-kernel parameter $t_U \approx 1.64$, this gives:
 $$\Delta b_{\text{edge}} \approx (2.49,\ 4.38,\ 3.97)$$
-compared to the MSSM target $(2.50,\ 4.17,\ 4.00)$. The agreement is within 5% for all three coefficients, with **no fitted parameters**. The "MSSM-like spectrum" emerges from the structure of edge-mode entanglement, not from postulating superpartners.
+compared to the MSSM target $(2.50,\ 4.17,\ 4.00)$. The agreement is within 5% for all three coefficients only on that declared calibration branch. What emerges here is MSSM-like running behavior under stated premises, not a theorem that the realized OPH branch contains an MSSM particle spectrum.
 
-The real prediction comes from *how* unification happens.
+The sharper structural prediction concerns *how* any unification-like closure would happen.
 
 ### Why Protons Don't Decay
 
@@ -661,7 +661,7 @@ There's no larger group. No X and Y bosons. No leptoquark generators. Unificatio
 
 The prediction is stark: **gauge-mediated proton decay is forbidden**. That is the theorem-level statement.
 
-This is a unique experimental signature. Standard SUSY GUTs predict *both* precision unification *and* proton decay. Our model predicts unification *without* gauge-mediated proton decay because the full connected gauge group has only the product-group adjoint content and no mixed leptoquark generators. If Hyper-Kamiokande continues to see null results while precision measurements continue to favor unified couplings, that would be strong evidence for geometric unification instead of algebraic unification.
+This is a unique experimental signature. Standard SUSY GUTs predict *both* precision unification *and* proton decay. Our model instead combines a theorem-level structural statement with a separate calibration branch: the full connected gauge group has only the product-group adjoint content and no mixed leptoquark generators, so gauge-mediated proton decay is forbidden, while the D10 running story allows MSSM-like unification-style closure without simple-group embedding. If Hyper-Kamiokande continues to see null results while precision measurements continue to favor unified couplings, that would be evidence for geometric rather than algebraic unification.
 
 ## 14.20 What the Model Explains
 

--- a/book/chapter-18-synthesis.md
+++ b/book/chapter-18-synthesis.md
@@ -297,19 +297,20 @@ This has been confirmed to essentially exact precision in $\mathbb{Z}_2$ and
 $\mathbb{Z}_3$ models, where the extracted "modular time" $t$ agrees across
 different charge sectors to numerical noise level.
 
-**Peter-Weyl second-index mechanism for β-coefficients.** The MSSM-like beta
-coefficient shifts $\Delta b \approx (2.50, 4.17, 4.00)$ follow from the
-edge-sector heat-kernel distribution using a structural
-argument from the Peter-Weyl decomposition. The key insight: entropy (MaxEnt
-selection) traces over one side of the entanglement cut, giving the factor $d_R$
-in the probability $p_R \propto d_R e^{-t C_2(R)}$. But vacuum polarization loops
-run over both indices of the $V_R \otimes V_R^*$ block, restoring the second $d_R$.
-Therefore the effective multiplicity for RG running is $N_{\text{eff}} = d \cdot p$,
-not just $p$. At $t_U \approx 1.64$, this gives $\Delta b_{\text{edge}} \approx
-(2.49, 4.38, 3.97)$, matching the MSSM target to within 5% with **no fitted
-constants**. This reduces "MSSM-like spectrum" from an external assumption to
-a consequence of Peter-Weyl structure plus the distinction between entropy
-(one index) and vacuum polarization (both indices).
+**Peter-Weyl second-index mechanism for β-coefficients.** A narrower Phase II result:
+the edge-sector heat-kernel branch reproduces MSSM-like one-loop beta coefficient
+shifts only on a declared D10 calibration package consisting of external input $P$,
+the printed running/matching conventions, the printed threshold conventions, and,
+for the near-MSSM benchmark, an added fermionic-grading restriction to half-integer
+SU(2) sectors, using a structural argument from the Peter-Weyl decomposition. The
+key insight: entropy (MaxEnt selection) traces over one side of the entanglement
+cut, giving the factor $d_R$ in the probability $p_R \propto d_R e^{-t C_2(R)}$.
+But vacuum polarization loops run over both indices of the $V_R \otimes V_R^*$ block,
+restoring the second $d_R$. Therefore the effective multiplicity for RG running is
+$N_{\text{eff}} = d \cdot p$, not just $p$. At $t_U \approx 1.64$, this gives
+$\Delta b_{\text{edge}} \approx (2.49, 4.38, 3.97)$, matching the MSSM target to
+within 5% only on that calibration branch. This supports MSSM-like running behavior
+without promoting an MSSM particle spectrum into the recovered core.
 
 The main open directions are:
 

--- a/paper/tex_fragments/TECHNICAL_SUPPLEMENT.tex
+++ b/paper/tex_fragments/TECHNICAL_SUPPLEMENT.tex
@@ -945,7 +945,9 @@ with Friedmann equations: \[H^2 + \frac{k}{a^2} = \frac{8\pi G}{3}\rho + \frac{\
 
 \begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
 
-\section{Supersymmetry and Gauge Coupling Unification}\label{5-supersymmetry-and-gauge-coupling-unification}
+\section{Gauge-Coupling Closure on the D10 Calibration Branch}\label{5-supersymmetry-and-gauge-coupling-unification}
+
+This section belongs to the Phase II D10 calibration sector rather than to the Phase I recovered core. Its role is narrower than a theorem-level derivation of a supersymmetric particle spectrum: the comparison below depends on an explicitly declared calibration package consisting of external input \(P\), the printed running/matching conventions, the printed threshold conventions, and, where stated, an additional fermionic-grading restriction on the SU(2) edge sector. Within that declared package, the edge-sector heat-kernel construction reproduces MSSM-like one-loop running behavior without promoting superpartners to realized OPH matter content.
 
 \subsection{One-Loop Unification Algebra}\label{51-one-loop-unification-algebra}
 
@@ -971,7 +973,7 @@ Observed &, & \(0.1179 \pm 0.0010\) \\
 \end{longtable}
 }
 
-The SM prediction is catastrophically wrong; MSSM-like coefficients work.
+At one loop, the printed MSSM-style coefficients reproduce the observed closure far better than the plain SM coefficients. In this manuscript that comparison is the benchmark matched by the D10 calibration branch, not a theorem that OPH has already derived a supersymmetric UV spectrum.
 
 \subsection{Heat-Kernel Edge Sector Weights}\label{53-heat-kernel-edge-sector-weights}
 
@@ -1010,9 +1012,9 @@ where \(T_a(R)\) is the Dynkin index for gauge factor \(a\).
 
 At the unification diffusion parameter \(t_U \approx 1.64\): \[\Delta b \approx (2.49, 4.38, 3.97) \quad \text{vs MSSM} \quad (2.50, 4.17, 4.00)\]
 
-With fermionic grading (restricting to half-integer SU(2) sectors): \[\Delta b \approx (2.50, 4.17, 3.97)\]
+With an added D10 calibration assumption, namely a fermionic-grading restriction to half-integer SU(2) sectors: \[\Delta b \approx (2.50, 4.17, 3.97)\]
 
-matching MSSM within 1\%.
+The latter, grading-restricted value matches the MSSM-style one-loop benchmark within 1\% under that declared calibration package. This remains a D10 calibration result: it does not by itself promote the branch to a theorem-level derivation of full gauge unification or of an MSSM particle spectrum.
 
 \begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
 


### PR DESCRIPTION
- Rename the supplement section and D10 prose so the beta-shift / unification package is explicitly a Phase II calibration branch with a declared premise bundle.
- Update the two book summaries to describe MSSM-like running as a calibration benchmark rather than a theorem-level supersymmetric spectrum or full unification result.
- Keep the theorem-level product-group proton-decay exclusion separate from the D10 running branch, matching the compact note and PAPER framing already on upstream main.
