### PR TITLE
fix: replace the compact-gauge proof sketch with a full proof (issue #25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ OPH is a reconstruction program for fundamental physics. Spacetime, gauge struct
 
 - A finite-resolution theorem package for observer patches, collars, overlap repair, higher gauge structure, records, and checkpoint/restoration.
 - A conditional route to Lorentzian geometry, modular time, Jacobson-type Einstein dynamics, and de Sitter static-patch cosmology on the extracted prime geometric subnet; the remaining UV/BW scaffold is geometric cap-pair realization on that subnet plus ordered cut-pair rigidity, with the eventual fixed-local-collar modular-transport common floor as the smallest lower blocker.
-- A compact gauge route to the realized Standard Model quotient `SU(3) x SU(2) x U(1) / Z_6`, together with the exact hypercharge lattice and the realized counting chain `N_g = 3`, `N_c = 3`.
+- A conditional compact gauge route in the bosonic branch to the realized Standard Model quotient `SU(3) x SU(2) x U(1) / Z_6`, together with the exact hypercharge lattice and the realized counting chain `N_g = 3`, `N_c = 3`.
 - A particle program with exact structural massless carriers, theorem-grade electroweak closure, a quantitative Higgs/top stage, exact non-hadron mass sidecars, and explicit continuation lanes for flavor and hadrons.
 - A concrete screen-microphysics architecture that puts measurement, records, and observers inside the physics.
 

--- a/book/chapter-14-standard-model.md
+++ b/book/chapter-14-standard-model.md
@@ -377,7 +377,7 @@ Technically, the Hilbert space decomposes:
 
 $$\mathcal{H}_{collar} = \bigoplus_\alpha (\mathcal{H}_{left}^\alpha \otimes \mathcal{H}_{right}^\alpha)$$
 
-The labels alpha are the edge charges. They correspond to representations of the boundary gauge group.
+The labels alpha are the edge charges. In the bosonic gauge branch they become the sector labels from which the reconstructed boundary gauge group is recovered.
 
 ### Fusion Rules Define the Group
 
@@ -385,7 +385,7 @@ When you concatenate collars, edge charges fuse. The fusion rules:
 
 $$\alpha \otimes \beta = \bigoplus_\gamma N_{\alpha\beta}^\gamma \, \gamma$$
 
-define a tensor category. The Tannaka-Krein reconstruction theorem says, roughly, that if you know exactly how the charges combine, you can reconstruct the symmetry group they came from. So the fusion table is not a side detail. It is enough to recover the gauge group itself.
+define a tensor category. The Tannaka-Krein reconstruction theorem says, roughly, that once the transportable small-region sector category carries the needed rigid, symmetric, bosonic fiber-functor structure, the way the charges combine reconstructs the symmetry group they came from. So the fusion table is not a side detail, but the full theorem uses the transportable sector package rather than a single fixed-cutoff list by itself.
 
 The gauge group isn't put in by hand. It's reconstructed from how charges combine.
 
@@ -559,7 +559,7 @@ Here is the chain of reasoning. Our Assumption D states that when two observer p
 
 When you have a boundary between patches-say, a collar region around the edge of a cap-the Hilbert space of that collar decomposes into sectors. In the formal derivation this is called edge-center completion: the boundary splits into sectors, each sector carries a charge label, and those labels combine when collars are joined.
 
-These fusion rules define a mathematical structure called a tensor category. A key result, established by Tannaka-Krein reconstruction (and its physics version, the Doplicher-Roberts theorem), is that any such tensor category with the right properties is equivalent to the representation category of some compact group G. In other words, the fusion rules of edge sectors reconstruct a gauge group.
+These fusion rules define a mathematical structure called a tensor category. A key result, established by Tannaka-Krein reconstruction (and its physics version, the Doplicher-Roberts theorem), is that any such transportable tensor category with the right rigid, symmetric, bosonic fiber-functor properties is equivalent to the representation category of some compact group G. In other words, the transportable edge-sector package reconstructs a gauge group.
 
 For the Standard Model, this reconstructed group includes a U(1) factor, the gauge group of electromagnetism. The key point: this U(1) is the redundancy structure of how patches identify their overlaps. It is built into the structure of observer consistency.
 
@@ -653,7 +653,7 @@ Traditional Grand Unified Theories achieve unification by embedding the Standard
 
 But Super-Kamiokande has been watching for proton decay since 1996. The current limit is $\tau_p > 10^{34}$ years, a thousand times longer than predicted. The simplest GUTs are dead.
 
-Our model takes a different path. The gauge group isn't embedded in anything larger. Tannaka-Krein reconstruction builds the gauge group directly from edge-sector fusion rules, yielding the *product* structure:
+Our model takes a different path. The gauge group isn't embedded in anything larger. Tannaka-Krein reconstruction builds the gauge group directly from the transportable edge-sector category defined by those fusion rules, yielding the *product* structure:
 
 $$G_{\mathrm{phys}} = \mathrm{SU}(3) \times \mathrm{SU}(2) \times \mathrm{U}(1) / \mathbb{Z}_6$$
 

--- a/book/chapter-18-synthesis.md
+++ b/book/chapter-18-synthesis.md
@@ -204,7 +204,7 @@ Under the bridge assumptions above, the model yields:
 
 1. **Lorentz kinematics** on the extracted prime geometric subnet from geometric modular flow on caps
 2. **Einstein's equation** on the stated scaling branch via entanglement equilibrium, promoted to a tensor equation by patch consistency
-3. **The Standard Model gauge group** $SU(3) \times SU(2) \times U(1)/\mathbb{Z}_6$, reconstructed from edge-sector fusion rules and a minimality principle
+3. **The Standard Model gauge group** $SU(3) \times SU(2) \times U(1)/\mathbb{Z}_6$, reconstructed from the transportable bosonic edge-sector package and a minimality principle
 4. **Three generations, three colors**: fixed by anomaly cancellation and the minimality principle
 5. **Massless gauge bosons and graviton**: forced by emergent gauge and diffeomorphism invariance, which forbid mass terms
 6. **A particle story with clear landmarks**: photon, gluons, graviton, W, and Z are fixed; the Higgs, top quark, and several quark masses sit on explicit quantitative lanes; the weighted-cycle neutrino branch carries an emitted theorem-grade absolute family; charged leptons, the remaining three-object quark extension beyond the selected continuation branch, and hadrons are the hard remaining pieces
@@ -438,7 +438,7 @@ These results are developed within the framework; the frontier lies in tightenin
 
 **Geometric meaning of the cap area operator**: The localized "area term" coming from quantum error correction should match the familiar minimal-surface geometry of holography.
 
-**Transportable charge sectors**: The charge sectors used to rebuild a full field description need to remain well-behaved in the small-region limit. That is the continuity requirement behind the gauge reconstruction.
+**Transportable charge sectors**: The charge sectors used to rebuild a full field description need to remain well-behaved in the small-region limit and carry the rigid symmetric bosonic fiber-functor structure used by the gauge-reconstruction theorem.
 
 **Matter selection**: Chirality, three generations, and the overall Standard Model counting come from requiring a theory that is consistent, ultraviolet-safe, and as economical as possible.
 

--- a/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
+++ b/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
@@ -2312,15 +2312,40 @@ Assume therefore that in the EFT regime there is a directed system \((\mathsf{Se
 for the directed colimit retaining the transportable sectors and intertwiners that persist in that system, with objectwise finite-dimensional fibers. This is the category on which Doplicher--Roberts / Tannaka reconstruction is applied. The theorem below is neutral about whether \(\mathsf{Sect}_\infty\) is trivial or nontrivial: if \textbf{T6} furnished only the tensor unit, the reconstructed compact group would be the trivial group.
 
 \begin{theorem}[Conditional compact gauge reconstruction in the bosonic branch]\label{thm:compactgauge}
-Assume Axioms~\ref{ax:screen}--\ref{ax:entropy}, the relevant parts of Assumption~\ref{ass:technical}, and that the transportable edge-sector colimit furnished by \textbf{T6} in the EFT regime is a rigid symmetric \(C^*\)-tensor category with a faithful bosonic fiber functor to finite-dimensional Hilbert spaces. Then
+Assume Axioms~\ref{ax:screen}--\ref{ax:entropy}, the relevant parts of Assumption~\ref{ass:technical}, and let
 \[
-\mathsf{Sect}_\infty\simeq \mathrm{Rep}(G)
+\mathcal F:\mathsf{Sect}_\infty\to\mathsf{Hilb}_{\mathrm{fd}}
 \]
-for a compact group $G$ uniquely determined up to isomorphism.
+be the faithful bosonic fiber functor furnished by \textbf{T6} in the EFT regime. If \(\mathsf{Sect}_\infty\) is a rigid symmetric \(C^*\)-tensor category, then
+\[
+G:=\mathrm{Aut}_\otimes(\mathcal F)
+\]
+is a compact group and
+\[
+\mathsf{Sect}_\infty\simeq \mathrm{Rep}(G).
+\]
+In particular \(G\) is uniquely determined up to isomorphism.
 \end{theorem}
 
-\begin{proof}[Proof sketch]
-The theorem begins only once the directed system of transportable sectors and its objectwise finite-dimensional fiber functor are given; those data are part of \textbf{T6}, not consequences of the local-Gibbs or Dobrushin-type collar estimates. Each fixed-cutoff category has only finitely many simple blocks, but the transportable colimit \(\mathsf{Sect}_\infty\) can have infinitely many simple objects while still carrying objectwise finite-dimensional fibers. In the bosonic EFT branch, symmetry and rigidity place the category in the Doplicher--Roberts/Tannakian reconstruction class, and the faithful bosonic fiber functor identifies it with \(\mathrm{Rep}(G)\) for a compact group \(G\) \cite{dr89,dr90}.
+\begin{proof}
+The theorem begins only once the directed system of transportable sectors and its objectwise finite-dimensional fiber functor are given; those data are part of \textbf{T6}, not consequences of the local-Gibbs or Dobrushin-type collar estimates. Fix a small skeleton of \(\mathsf{Sect}_\infty\), which does not change the tensor category or the fiber functor up to equivalence. For every object \(X\), any monoidal natural automorphism \(\eta\in\mathrm{Aut}_\otimes(\mathcal F)\) has a unitary component \(\eta_X\in U(\mathcal F(X))\) because \(\mathcal F\) is a \(^*\)-functor to finite-dimensional Hilbert spaces. Hence there is an injective map
+\[
+\mathrm{Aut}_\otimes(\mathcal F)\hookrightarrow \prod_{X}U(\mathcal F(X)),\qquad
+\eta\mapsto (\eta_X)_X.
+\]
+For each intertwiner \(f:X\to Y\), naturality imposes the closed relation \(\mathcal F(f)\eta_X=\eta_Y\mathcal F(f)\). For each pair \(X,Y\), the monoidal structure isomorphism \(J_{X,Y}:\mathcal F(X)\otimes\mathcal F(Y)\xrightarrow{\sim}\mathcal F(X\otimes Y)\) imposes the closed relation
+\[
+\eta_{X\otimes Y}=J_{X,Y}\,(\eta_X\otimes\eta_Y)\,J_{X,Y}^{-1},
+\qquad
+\eta_{\mathbf 1}=\mathrm{id}_{\mathbb C}.
+\]
+Therefore \(\mathrm{Aut}_\otimes(\mathcal F)\) is a closed subgroup of the compact product \(\prod_X U(\mathcal F(X))\), so \(G=\mathrm{Aut}_\otimes(\mathcal F)\) is compact.
+
+The remaining hypotheses required by Doplicher--Roberts / Tannaka reconstruction are now exactly checked on the OPH sector category: \(\mathsf{Sect}_\infty\) is rigid, symmetric, and \(C^*\) by assumption, and \(\mathcal F\) is a faithful bosonic fiber functor with finite-dimensional values by \textbf{T6}. The standard reconstruction theorem therefore applies to the pair \((\mathsf{Sect}_\infty,\mathcal F)\) and yields a symmetric \(C^*\)-tensor equivalence
+\[
+\mathsf{Sect}_\infty \simeq \mathrm{Rep}(G),
+\]
+where an object \(X\) is sent to the representation \(g\mapsto g_X\) on \(\mathcal F(X)\) and morphisms are sent to the corresponding intertwiners \cite{dr89,dr90}. If the same category were also equivalent to \(\mathrm{Rep}(G')\) through another faithful bosonic fiber functor, then composing the two reconstruction equivalences would give a symmetric tensor equivalence \(\mathrm{Rep}(G)\simeq \mathrm{Rep}(G')\) compatible with the forgetful fiber functors. Applying the same reconstruction theorem to either side identifies the two automorphism groups of the fiber functor, so \(G\cong G'\). Thus the reconstructed compact group is unique up to isomorphism.
 \end{proof}
 
 If a fermionic sign object is present, the correct reconstruction statement is super-Tannakian rather than purely Tannakian. The compact note does not prove that fermionic/chiral extension; it works only in the bosonic internal-gauge branch.

--- a/paper/tex_fragments/GAUGE_GROUP_DERIVATION.tex
+++ b/paper/tex_fragments/GAUGE_GROUP_DERIVATION.tex
@@ -130,9 +130,13 @@ The proof proceeds in five steps. Steps 1--4 determine the connected gauge group
 
 \textbf{From:} the canonical OPH package together with the fixed-cutoff realized presentation.
 
-At each cutoff one has a finite tensor category of transportable edge charges. The local MaxEnt/refinement package controls the realized state branch across cutoffs, but it does not by itself prove that transportable sectors persist nontrivially in the refinement limit. The reconstruction therefore uses the transportable directed-colimit premise \(T6\): assume a directed system of transportable edge-sector categories with objectwise finite-dimensional fibers, and write its colimit as \(\mathsf{Sect}_\infty\). By Theorem 6.1 (Tannaka/DR reconstruction~\cite{tannaka38,krein49,dr89,dr90}), there exists a compact group \(G\), unique up to isomorphism, with \(\mathsf{Sect}_\infty \simeq \mathrm{Rep}(G)\).
+At each cutoff one has a finite tensor category of transportable edge charges. The local MaxEnt/refinement package controls the realized state branch across cutoffs, but it does not by itself prove that transportable sectors persist nontrivially in the refinement limit. The reconstruction therefore uses the transportable directed-colimit premise \(T6\): assume a directed system of transportable edge-sector categories with objectwise finite-dimensional fibers, write its colimit as \(\mathsf{Sect}_\infty\), and let \(\mathcal F\) be the faithful bosonic fiber functor supplied there. By Theorem 6.1 (Tannaka/DR reconstruction~\cite{tannaka38,krein49,dr89,dr90}), the checked rigid/symmetric/\(C^*\) hypotheses on \(\mathsf{Sect}_\infty\) yield a compact group
+\[
+G=\mathrm{Aut}_\otimes(\mathcal F),
+\]
+unique up to isomorphism, with \(\mathsf{Sect}_\infty \simeq \mathrm{Rep}(G)\).
 
-The premise \([z] = 0\) ensures that this reconstruction is global: charges are DHR-transportable, so the compact group acts as a genuine gauge symmetry, not merely a local labeling (Proposition 6.1a). \(\square\)
+On the central branch, the premise \([z] = 0\) is then the explicit loop-coherence condition under which those transported sectors glue globally, so the reconstructed compact group acts as a genuine gauge symmetry rather than as local bookkeeping only (Proposition 6.1a). \(\square\)
 
 \subsubsection{Step 2: The gauge group must be a product}\label{step-2-the-gauge-group-must-be-a-product}
 

--- a/paper/tex_fragments/PAPER.tex
+++ b/paper/tex_fragments/PAPER.tex
@@ -2507,17 +2507,31 @@ This gives a tensor category \(\mathsf{Sect}_\infty\) of edge charges:
   symmetric braiding in the EFT regime (no anyonic statistics in 3+1D).
 \end{itemize}
 
-Let \(\mathcal F: \mathsf{Sect}_\infty \to \mathsf{Hilb}_{\mathrm{fd}}\) be the fiber functor that sends each sector to its edge multiplicity space. The fibers are finite-dimensional objectwise even though \(\mathsf{Sect}_\infty\) can have infinitely many simple objects. The theorem begins only once that transportable colimit and its fiber functor are given; those data are not consequences of Axiom 3 alone.
+Let \(\mathcal F: \mathsf{Sect}_\infty \to \mathsf{Hilb}_{\mathrm{fd}}\) be the bosonic fiber functor that sends each sector to its edge multiplicity space. The fibers are finite-dimensional objectwise even though \(\mathsf{Sect}_\infty\) can have infinitely many simple objects. The theorem begins only once that transportable colimit and its fiber functor are given; those data are not consequences of Axiom 3 alone.
 
-\textbf{Theorem 6.1 (Tannaka/DR reconstruction).} If \(\mathsf{Sect}_\infty\) is a rigid symmetric \(C^*\) tensor category with a faithful fiber functor \(\mathcal F\), then there exists a compact group \(G\), unique up to isomorphism, such that \(\mathsf{Sect}_\infty \simeq \mathrm{Rep}(G)\). Moreover,
+\textbf{Theorem 6.1 (Tannaka/DR reconstruction).} If \(\mathsf{Sect}_\infty\) is a rigid symmetric \(C^*\) tensor category with a faithful bosonic fiber functor \(\mathcal F\), then
 
 \[
-G = \mathrm{Aut}_\otimes(\mathcal F)
+G := \mathrm{Aut}_\otimes(\mathcal F)
 \]
 
-is a compact subgroup of a product of unitary groups.
+is a compact group and \(\mathsf{Sect}_\infty \simeq \mathrm{Rep}(G)\). In particular \(G\) is unique up to isomorphism, and this group is a compact subgroup of a product of unitary groups.
 
-\textbf{Proof sketch.} Define \(G\) as the group of monoidal natural automorphisms of \(\mathcal F\). This is compact because it is closed in a product of unitary groups. By Tannaka-Krein/DR reconstruction, objects and morphisms of \(\mathsf{Sect}_\infty\) are recovered as finite-dimensional representations and intertwiners of \(G\). The MaxEnt/local-Gibbs/collar-mixing package is not used in this step to prove existence or nontriviality of the transportable colimit; it only supplies the earlier fixed-cutoff collar control. QED.
+\textbf{Proof.} The MaxEnt/local-Gibbs/collar-mixing package is not used here to prove existence or nontriviality of the transportable colimit; those data are supplied by the directed-colimit premise \textbf{T6}. Fix a small skeleton of \(\mathsf{Sect}_\infty\). For every object \(X\), a monoidal natural automorphism \(\eta \in \mathrm{Aut}_\otimes(\mathcal F)\) has a unitary component \(\eta_X \in U(\mathcal F(X))\), so
+
+\[
+\mathrm{Aut}_\otimes(\mathcal F) \hookrightarrow \prod_X U(\mathcal F(X)), \qquad \eta \mapsto (\eta_X)_X.
+\]
+
+For each intertwiner \(f:X\to Y\), naturality gives the closed relation \(\mathcal F(f)\eta_X=\eta_Y\mathcal F(f)\). For each pair \(X,Y\), the monoidal structure isomorphism \(J_{X,Y}\) of \(\mathcal F\) gives the closed relation
+
+\[
+\eta_{X\otimes Y}=J_{X,Y}\,(\eta_X\otimes\eta_Y)\,J_{X,Y}^{-1},
+\qquad
+\eta_{\mathbf 1}=\mathrm{id}_{\mathbb C}.
+\]
+
+Hence \(G=\mathrm{Aut}_\otimes(\mathcal F)\) is a closed subgroup of the compact product \(\prod_X U(\mathcal F(X))\), so \(G\) is compact. The remaining DR/Tannaka hypotheses are exactly the stated ones: \(\mathsf{Sect}_\infty\) is rigid, symmetric, and \(C^*\), and \(\mathcal F\) is a faithful bosonic fiber functor with finite-dimensional values. Therefore the Doplicher--Roberts/Tannaka reconstruction theorem applies and gives a symmetric \(C^*\)-tensor equivalence \(\mathsf{Sect}_\infty \simeq \mathrm{Rep}(G)\) \cite{dr89,dr90}. If another compact group \(G'\) gave the same category through a faithful bosonic fiber functor, the induced symmetric tensor equivalence \(\mathrm{Rep}(G)\simeq\mathrm{Rep}(G')\) compatible with the forgetful functors would identify both groups as the automorphism group of the same fiber functor. Thus \(G\cong G'\), so the reconstruction is unique up to isomorphism. QED.
 
 \textbf{Corollary 6.1 (field algebra reconstruction, conditional).} If in the small-region limit the edge sectors are localized and transportable in the DHR sense (i.e., charges can be moved between patches without changing their fusion), then there exists a field algebra \(\mathcal F\) and a compact group \(G\) such that \(\mathcal A = \mathcal F^G\). This is the Doplicher--Roberts reconstruction of local gauge symmetry from sectors. QED.
 
@@ -2969,7 +2983,7 @@ The model requires photons and gravitons.
 \item
   Theorem 2.3 (edge-center completion) decomposes collar Hilbert spaces into sectors labeled by boundary gauge representations.
 \item
-  Theorem 6.1 (Tannaka/DR reconstruction) recovers a compact gauge group G from the fusion rules of these edge sectors.
+  Theorem 6.1 (Tannaka/DR reconstruction) recovers a compact gauge group G from the transportable bosonic edge-sector category defined by these fusion rules.
 \item
   Corollary 6.1 (conditional on DHR transportability) reconstructs a field algebra with G as a local gauge symmetry.
 \item

--- a/paper/tex_fragments/TECHNICAL_SUPPLEMENT.tex
+++ b/paper/tex_fragments/TECHNICAL_SUPPLEMENT.tex
@@ -8,7 +8,7 @@ The quantitative branches discussed in this paper use two external inputs (\(P\)
 
 This document collects the mathematical derivations and stated premises used in the OPH paper suite. The Lorentz/null-modular/Einstein and compact-gauge statements are scaling-limit / categorical results under explicit regularity hypotheses; these hypotheses are properties of the EFT phase or UV completion under discussion, not fixed-cutoff matrix-algebra theorems.
 
-\textbf{Scope convention.} Statements about Lorentz recovery, modular flow, and the Einstein branch are scaling-limit / EFT statements rather than literal fixed-cutoff type-I claims. Statements about gauge reconstruction refer to the refinement-stable directed colimit of fixed-cutoff sector categories, not to the finite block list at one regulator scale.
+\textbf{Scope convention.} Statements about Lorentz recovery, modular flow, and the Einstein branch are scaling-limit / EFT statements rather than literal fixed-cutoff type-I claims. Statements about gauge reconstruction refer to the refinement-stable directed colimit of fixed-cutoff sector categories together with the explicit rigid/symmetric bosonic fiber-functor premises of \(T4\)--\(T6\), not to the finite block list at one regulator scale.
 
 \begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
 
@@ -1219,7 +1219,7 @@ This section separates three distinct claim types:
 
 If \(H_\partial = H_\partial^{(1)} + H_\partial^{(2)} + H_\partial^{(3)}\) with \([H_\partial^{(i)}, H_\partial^{(j)}] = 0\): \[p(R_1, R_2, R_3) \propto \prod_{i=1}^3 d_{R_i} e^{-t_i C_2(R_i)}\]
 
-Applied to the refinement-stable edge-sector colimit, Tannaka-Krein reconstruction~\cite{tannaka38,krein49,dr89,dr90} first yields some compact group \(G\). Under the MAR admissibility package, and once the admissible class includes one connected abelian charge factor, the connected Lie realization selected by MAR is \(SU(3) \times SU(2) \times U(1)\) (up to finite quotient).
+Applied to the refinement-stable edge-sector colimit together with the rigid symmetric \(C^*\)-tensor and faithful bosonic fiber-functor premises of the compact-gauge theorem, Tannaka-Krein reconstruction~\cite{tannaka38,krein49,dr89,dr90} first yields some compact group \(G\). Under the MAR admissibility package, and once the admissible class includes one connected abelian charge factor, the connected Lie realization selected by MAR is \(SU(3) \times SU(2) \times U(1)\) (up to finite quotient).
 
 Under the stated gauge-selection hypotheses, the explicit MAR selector picks this product structure on the admissible class: the minimal coupled carrier \(\mathbb{C}^3 \otimes \mathbb{C}^2\) enforces commuting color and weak actions, which implies the additive boundary Laplacian. See the gauge-branch derivation in the main OPH trunk for the complete proof.
 


### PR DESCRIPTION
- Upgrade Theorem 6.1 from a proof sketch to a checked Tannaka/DR proof by defining `G := Aut_\otimes(F)`, proving compactness, and stating uniqueness under the explicit bosonic `T4`-`T6` package
- Sync the gauge-derivation, supplement, README, and book surfaces so they refer to the transportable bosonic edge-sector category rather than fixed-cutoff fusion data alone
- Keep the theorem boundary explicit: the compact group is reconstructed from the transportable bosonic sector package, not derived internally from OPH alone
