### PR TITLE
Issue 65: define repair on the quotient before lifting representatives

### DIFF
--- a/paper/reality_as_consensus_protocol.tex
+++ b/paper/reality_as_consensus_protocol.tex
@@ -43,17 +43,18 @@ global solution, and the obstruction is holonomic. On the abelian branch it is t
 edge data; on the genuinely noncentral branch it is a crossed-module \v{C}ech class.
 
 Gauge symmetry enters as invariance under changes of hidden local representation that preserve
-overlap data. Under gauge-covariant repair dynamics, the normal-form map descends to the gauge
-quotient, so physical uniqueness is a quotient statement. Classical records are described by a
-finite closure system whose least common fixed point is independent of schedule. These results
-form the patch-net formulation used in the broader OPH literature.
+overlap data. When the repair step is read only on that overlap-invariant quotient, the
+normal-form map descends to the gauge quotient, so physical uniqueness is a quotient statement.
+Classical records are described by a finite closure system whose least common fixed point is
+independent of schedule. These results form the patch-net formulation used in the broader OPH
+literature.
 
 This paper proves four core results:
 
 \begin{enumerate}
 \item \textbf{Asynchronous confluence.} Under termination and local confluence, every initial state has a unique normal form, independent of update schedule (Theorem~\ref{thm:confluence}).
 \item \textbf{Cycle obstruction.} For affine overlap constraints over an abelian group, global consistency holds if and only if the holonomy vanishes on every cycle (Theorem~\ref{thm:holonomy}). The parity triangle gives the minimal frustrated example, and Theorem~\ref{thm:higherdefects} extends the same logic to the crossed-module higher-gauge defect hierarchy used later in OPH.
-\item \textbf{Gauge quotient.} Under gauge-covariant dynamics, the normal-form map descends to the quotient. Gauge-invariant observables are strictly unique on the quotient, even though microscopic representatives need not be unique (Theorem~\ref{thm:gauge}).
+\item \textbf{Gauge quotient.} When local repair is induced on the overlap-invariant quotient, the normal-form map descends to that quotient. Gauge-invariant observables are strictly unique there, even though microscopic representatives need not be unique (Theorem~\ref{thm:gauge}).
 \item \textbf{Record-layer convergence.} Commuting closure operators on a finite lattice converge to the least common fixed point under any asynchronous schedule that applies each operator at least once (Theorem~\ref{thm:crdt}).
 \end{enumerate}
 
@@ -250,22 +251,42 @@ Let $\Gamma = \prod_{i\in V}\Gamma_i$ act on $\Sigma$ componentwise. The action 
 \qquad
 \forall\, x\in S_i,\ \forall\, \gamma_i\in \Gamma_i.
 \]
-Gauge changes alter hidden local representations but do not alter overlap data. Assume gauge covariance:
-\[
-T_i^\lambda(\gamma\cdot s)=\gamma\cdot T_i^\lambda(s)
-\qquad
-\forall\, i,\ \forall\, \gamma\in\Gamma,\ \forall\, s\in\Sigma.
-\]
+Gauge changes alter hidden local representations but do not alter overlap data.
 \end{definition}
 
-Gauge transformations change hidden local representations while leaving overlap data fixed.
+Gauge transformations change hidden local representations while leaving overlap data fixed. Write
+\[
+q:\Sigma\to \Sigma/\Gamma,
+\qquad
+q(s)=[s],
+\]
+for the gauge-orbit map. A \textbf{physical repair law} is a family of local maps
+\[
+\overline T_i^\lambda:\Sigma/\Gamma\to \Sigma/\Gamma
+\]
+on the overlap-invariant quotient. A \textbf{representative repair family} is any choice of lifts
+\[
+T_i^\lambda:\Sigma\to\Sigma
+\]
+such that
+\[
+q\circ T_i^\lambda
+=
+\overline T_i^\lambda\circ q.
+\]
+This is the finite patch-net form of saying that the repair step is defined first on
+overlap-invariant physical data and only then lifted to hidden representatives. The separate OPH
+problem of deriving the physical repair law itself from recovery dynamics remains upstream; the
+point here is only that no extra gauge-covariance axiom is needed once repair is formulated on the
+quotient.
 
 \begin{theorem}[Gauge quotient theorem]\label{thm:gauge}
-Under the gauge action of Definition~\ref{def:gauge} and the hypotheses of Theorem~\ref{thm:confluence},
+Under the gauge action of Definition~\ref{def:gauge}, any representative lift of a physical repair
+law as just defined, and the hypotheses of Theorem~\ref{thm:confluence},
 \[
-\operatorname{nf}_\lambda(\gamma\cdot s)
+q\bigl(\operatorname{nf}_\lambda(\gamma\cdot s)\bigr)
 =
-\gamma\cdot \operatorname{nf}_\lambda(s)
+q\bigl(\operatorname{nf}_\lambda(s)\bigr)
 \qquad
 \forall\, \gamma\in\Gamma,\ \forall\, s\in\Sigma.
 \]
@@ -278,9 +299,24 @@ Hence the normal-form map descends to the quotient:
 \end{theorem}
 
 \begin{proof}
-Suppose $s\to_i t$, so $t=T_i^\lambda(s)\neq s$. Gauge covariance gives $T_i^\lambda(\gamma\cdot s) = \gamma\cdot T_i^\lambda(s) = \gamma\cdot t$, so $\gamma\cdot s\to_i \gamma\cdot t$. The gauge action sends rewrite sequences to rewrite sequences: $s\to^* t$ implies $\gamma\cdot s\to^* \gamma\cdot t$.
-
-Let $t=\operatorname{nf}_\lambda(s)$. Then $T_i^\lambda(t)=t$ for all $i$, so $T_i^\lambda(\gamma\cdot t) = \gamma\cdot T_i^\lambda(t) = \gamma\cdot t$, meaning $\gamma\cdot t$ is also normal. Since $\gamma\cdot s$ rewrites to $\gamma\cdot t$, uniqueness gives $\operatorname{nf}_\lambda(\gamma\cdot s) = \gamma\cdot\operatorname{nf}_\lambda(s)$.
+Suppose $s\to_i t$, so $t=T_i^\lambda(s)\neq s$. If $s'=\gamma\cdot s$, then
+\[
+q\bigl(T_i^\lambda(s')\bigr)
+=
+\overline T_i^\lambda\bigl(q(s')\bigr)
+=
+\overline T_i^\lambda\bigl(q(s)\bigr)
+=
+q\bigl(T_i^\lambda(s)\bigr).
+\]
+Thus gauge-equivalent inputs induce the same repaired orbit, and by induction the orbit reached
+after any repair sequence depends only on the initial orbit. Every maximal repair sequence from
+$s$ ends at $\operatorname{nf}_\lambda(s)$ by Theorem~\ref{thm:confluence}, so the terminal orbit
+$q(\operatorname{nf}_\lambda(s))$ depends only on $q(s)=[s]$. This makes
+\[
+[s]\longmapsto [\operatorname{nf}_\lambda(s)]
+\]
+well-defined on $\Sigma/\Gamma$.
 \end{proof}
 
 \begin{corollary}[Gauge-invariant law]\label{cor:gaugeinv}
@@ -288,7 +324,23 @@ If $M:\Sigma\to Y$ is gauge-invariant ($M(\gamma\cdot s)=M(s)$ for all $\gamma$)
 \end{corollary}
 
 \begin{proof}
-$M(\operatorname{nf}_\lambda(\gamma\cdot s)) = M(\gamma\cdot\operatorname{nf}_\lambda(s)) = M(\operatorname{nf}_\lambda(s))$.
+Because $M$ is gauge-invariant, it factors through the orbit map: $M=\overline M\circ q$ for some
+$\overline M:\Sigma/\Gamma\to Y$. Theorem~\ref{thm:gauge} gives
+\[
+q\bigl(\operatorname{nf}_\lambda(\gamma\cdot s)\bigr)
+=
+q\bigl(\operatorname{nf}_\lambda(s)\bigr),
+\]
+hence
+\[
+M\bigl(\operatorname{nf}_\lambda(\gamma\cdot s)\bigr)
+=
+\overline M\!\left(q\bigl(\operatorname{nf}_\lambda(\gamma\cdot s)\bigr)\right)
+=
+\overline M\!\left(q\bigl(\operatorname{nf}_\lambda(s)\bigr)\right)
+=
+M\bigl(\operatorname{nf}_\lambda(s)\bigr).
+\]
 \end{proof}
 
 \begin{corollary}[Inert ancillary refinement does not change physical law]\label{cor:ancilla}

--- a/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
+++ b/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
@@ -397,21 +397,74 @@ A global solution exists if and only if the signed sum of $b_e$ vanishes on ever
 Summing the edge equations around a cycle gives necessity. For sufficiency, fix a root and define each $x_v$ by summing labels along a path from the root to $v$. Vanishing cycle sums make this independent of the chosen path.
 \end{proof}
 
-\begin{proposition}[Gauge Quotient]\label{prop:gauge}
-Suppose a local gauge group $\Gamma=\prod_i \Gamma_i$ acts on $\Sigma$ while leaving all interface data invariant, and the repair maps satisfy
+\begin{definition}[Physical repair law and representative lift]\label{def:physicalrepair}
+Suppose a local gauge group $\Gamma=\prod_i \Gamma_i$ acts on $\Sigma$ while leaving all interface
+data invariant. Write
 \[
-T_i^\lambda(\gamma\cdot s)=\gamma\cdot T_i^\lambda(s).
+q:\Sigma\to\Sigma/\Gamma,
+\qquad
+q(s)=[s].
 \]
-Then
+A physical repair law is a family of local maps
 \[
-\nf_\lambda(\gamma\cdot s)=\gamma\cdot \nf_\lambda(s).
+\overline T_i^\lambda:\Sigma/\Gamma\to\Sigma/\Gamma
+\]
+on the overlap-invariant quotient. A representative repair family is any family
+\[
+T_i^\lambda:\Sigma\to\Sigma
+\]
+with
+\[
+q\circ T_i^\lambda=\overline T_i^\lambda\circ q.
+\]
+\end{definition}
+
+\begin{proposition}[Representative lifts descend to the quotient]\label{prop:repairquot}
+For any representative repair family of Definition~\ref{def:physicalrepair},
+\[
+q\bigl(T_i^\lambda(\gamma\cdot s)\bigr)=q\bigl(T_i^\lambda(s)\bigr)
+\qquad
+\forall\, i,\ \forall\, \gamma\in\Gamma,\ \forall\, s\in\Sigma.
+\]
+In particular the repair relation descends to \(\Sigma/\Gamma\) without any extra
+gauge-covariance axiom.
+\end{proposition}
+
+\begin{proof}
+Because \(q(\gamma\cdot s)=q(s)\),
+\[
+q\bigl(T_i^\lambda(\gamma\cdot s)\bigr)
+=
+\overline T_i^\lambda\bigl(q(\gamma\cdot s)\bigr)
+=
+\overline T_i^\lambda\bigl(q(s)\bigr)
+=
+q\bigl(T_i^\lambda(s)\bigr).
+\]
+So gauge-equivalent inputs induce the same repaired physical state.
+\end{proof}
+
+\begin{proposition}[Gauge Quotient]\label{prop:gauge}
+Under Definition~\ref{def:physicalrepair}, Proposition~\ref{prop:repairquot}, and
+Theorem~\ref{thm:confluence}, the normal-form map descends to the quotient:
+\[
+\overline{\nf}_\lambda:\Sigma/\Gamma\to\Sigma/\Gamma,
+\qquad
+[s]\mapsto [\nf_\lambda(s)].
 \]
 Hence gauge-invariant observables are unique on the quotient.
 \end{proposition}
 
 \begin{proof}
-Gauge covariance maps repair sequences to repair sequences. Since the normal form is unique by Theorem~\ref{thm:confluence}, the normal form of $\gamma\cdot s$ must be $\gamma\cdot \nf_\lambda(s)$.
+By Proposition~\ref{prop:repairquot}, every repair step has quotient image determined only by the
+current orbit. Iterating, the quotient image of any repair sequence depends only on the initial
+orbit. Since every maximal repair sequence from \(s\) terminates at the unique normal form
+\(\nf_\lambda(s)\) by Theorem~\ref{thm:confluence}, the terminal orbit \([\nf_\lambda(s)]\)
+depends only on \([s]\). This makes \(\overline{\nf}_\lambda\) well-defined.
 \end{proof}
+
+This removes only the extra gauge-covariance axiom. Deriving the physical repair law itself from
+OPH recovery dynamics remains a separate upstream burden.
 
 \begin{definition}[Ancilla stabilization]\label{def:ancillastab}
 Fix a finite-cutoff OPH realization
@@ -478,15 +531,31 @@ Under the OPH axiom language, the UV invariant determined by the theory is the c
 \end{corollary}
 
 \begin{proof}
-Proposition~\ref{prop:gauge} fixes the schedule-independent physical branch on the quotient, while Proposition~\ref{prop:ancillauv} shows that inert ancillary refinements leave every OPH observable invariant. So the physical branch is fixed only modulo \(\sim_{\mathrm{OPH}}\), not at the level of one microscopic representative.
+Propositions~\ref{prop:repairquot} and \ref{prop:gauge} fix the schedule-independent physical
+branch on the quotient, while Proposition~\ref{prop:ancillauv} shows that inert ancillary
+refinements leave every OPH observable invariant. So the physical branch is fixed only modulo
+\(\sim_{\mathrm{OPH}}\), not at the level of one microscopic representative.
 \end{proof}
 
-These three results encode much of the eventual physical interpretation. Objectivity becomes confluence, gauge symmetry becomes quotient invariance, and stable defects are represented by nontrivial overlap holonomy classes.
-The physically relevant uniqueness statement is therefore quotient uniqueness together with ancilla-stable equivalence: OPH fixes a unique gauge-invariant physical branch modulo boundary redundancy, implementation hiding, and inert ancillary stabilization, not a unique microscopic regulator presentation.
+These three results encode much of the eventual physical interpretation. Objectivity becomes
+confluence, gauge symmetry becomes quotient invariance induced by the physical overlap algebra, and
+stable defects are represented by nontrivial overlap holonomy classes. The physically relevant
+uniqueness statement is therefore quotient uniqueness together with ancilla-stable equivalence: OPH
+fixes a unique gauge-invariant physical branch modulo boundary redundancy, implementation hiding,
+and inert ancillary stabilization, not a unique microscopic regulator presentation.
 
 \section{Collars, Edge Centers, and Generalized Entropy}
 
-The fixed-point picture explains why overlap consistency produces gauge quotients, but the gravity and consensus arguments later use a more specific collar fact: after edge-center completion, interior observables become insensitive to compatible exterior substitutions, and modular additivity becomes exact in the Markov normal form. The point of this section is therefore twofold. First, at fixed regulator scale, we derive the collar block decomposition from overlap consistency itself on the ordinary or central-defect branch and then state its genuinely noncentral higher-gauge replacement. Second, we state precisely when the approximate recoverability premise of Axiom~\ref{ax:entropy} is allowed to converge to the exact HJPW normal form used by the later spatial and null collar theorems.
+The fixed-point picture explains why overlap consistency produces gauge quotients: once repair is
+read on the physical overlap algebra, descent to the quotient is automatic. The gravity and
+consensus arguments later use a more specific collar fact: after edge-center completion, interior
+observables become insensitive to compatible exterior substitutions, and modular additivity becomes
+exact in the Markov normal form. The point of this section is therefore twofold. First, at fixed
+regulator scale, we derive the collar block decomposition from overlap consistency itself on the
+ordinary or central-defect branch and then state its genuinely noncentral higher-gauge replacement.
+Second, we state precisely when the approximate recoverability premise of Axiom~\ref{ax:entropy} is
+allowed to converge to the exact HJPW normal form used by the later spatial and null collar
+theorems.
 
 The sharp claim boundary is as follows. Small conditional mutual information always gives a constructive recovered comparison state with \(O(\varepsilon^{1/2})\) observable error. It does \emph{not} by itself give a universal one-shot trace-norm bound to an exact Markov state. The exact Markov normal form is recovered either when \(I(A:D\mid B)=0\) holds literally, or for a controlled family on one fixed finite-dimensional collar model, or after pullback to such a model, where \(\varepsilon\to0\). On that fixed collar one gets a collar-dependent modulus \(\delta^{\mathrm M}_{A:B:D}(\varepsilon)\to0\) measuring distance to the exact Markov set, and this is the error that must be carried into later exact splice or modular-additivity identities.
 

--- a/paper/tex_fragments/PAPER.tex
+++ b/paper/tex_fragments/PAPER.tex
@@ -301,6 +301,12 @@ A(R)=\widetilde{\mathcal A}(R)^{G_{\partial R}}
 \]
 
 This is the fixed-cutoff realized presentation used throughout the collar analysis.
+When the consensus paper later speaks of quotient repair, the physical repair law is defined on
+this fixed-point / overlap-invariant data and any representative-level map is only a lift of that
+quotient update. Descent to the gauge quotient is therefore built into the physical-algebra
+formulation, not added later as a separate covariance axiom on hidden representatives. This does
+not by itself derive the physical repair law from OPH recovery dynamics; that remains a separate
+upstream task.
 
 \textbf{Theorem 2.3 (EC from regulated overlap gluing).} For a collar \(B_\delta\) around a cap boundary \(\Sigma\), there is a canonical decomposition
 

--- a/paper/tex_fragments/TECHNICAL_SUPPLEMENT.tex
+++ b/paper/tex_fragments/TECHNICAL_SUPPLEMENT.tex
@@ -22,6 +22,17 @@ The supplement follows the canonical premise scheme of the main manuscript. The 
 
 \textbf{Fixed-cutoff realized presentation.} On a finite regulator cellulation, each regulator cell \(x\) carries a finite-dimensional factor \(\mathfrak h_x\), and local patch algebras are finite type-I algebras. Gauge-as-gluing is realized as a compact boundary redundancy action on cut data, so physical algebras are fixed-point algebras of the corresponding boundary action. This is the realized regulator form of Axiom 1 plus overlap consistency; it is not a separate premise layer.
 
+\textbf{Repair descent on the physical algebra.} In the consensus package, the physical repair law
+is defined on that overlap-invariant physical data rather than on hidden representatives. In the
+finite-patch-net notation, if \(q:\Sigma\to\Sigma/\Gamma\) is the quotient by boundary redundancy
+and \(\overline T_i\) is the physical quotient update, a representative-level map \(T_i\) is only
+required to be a lift satisfying \(q\circ T_i=\overline T_i\circ q\). Therefore
+\(q(T_i(\gamma\cdot s))=q(T_i(s))\) for gauge-equivalent inputs. Quotient descent is thus forced by
+the same overlap-invariant algebraic structure that defines the physical algebra; strict
+representative-level covariance of a chosen lift is implementation bookkeeping, not an extra
+theorem-level premise. This does not yet derive the physical repair law itself from recoverability
+dynamics; that remains the separate upstream burden of the consensus branch.
+
 \textbf{Local finite-constraint MaxEnt branch.} Axiom 3 states that at scale \(\ell_{\mathrm{UV}}\) the realized state maximizes entropy subject to a finite set of gauge-invariant local constraints
 \[
 \mathcal C_{\ell_{\mathrm{UV}}}=\{O_a(x)\}_{a=1}^{N_{\mathrm{con}}},


### PR DESCRIPTION
## Summary
- define the physical repair law on `\Sigma/\Gamma` in the consensus and compact-note surfaces
- treat representative-level repair maps only as lifts and prove quotient descent for those lifts
- synchronize the long-form and supplement text to the same quotient-first theorem boundary

## Issue boundary
- This closes issue `#65` at the intended theorem boundary: gauge covariance is no longer a free extra hypothesis.
- The separate upstream burden of deriving the physical repair law itself from OPH recovery dynamics remains issue `#62` and is stated explicitly in the text.

## Changed files
- `paper/reality_as_consensus_protocol.tex`
- `paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex`
- `paper/tex_fragments/PAPER.tex`
- `paper/tex_fragments/TECHNICAL_SUPPLEMENT.tex`

## Verification
- `task/patched/issue65/patch.diff` applied cleanly in a fresh clone and the changed file set matches that artifact.
- TeX compilation was not run because `latexmk`, `pdflatex`, `xelatex`, `lualatex`, and `tectonic` are unavailable in this environment.