### PR TITLE
feat: paper: tighten cross-paper wording and claim-surface narration

### DIFF
--- a/paper/appendix_B_bft_qecc_extensions.tex
+++ b/paper/appendix_B_bft_qecc_extensions.tex
@@ -341,7 +341,7 @@ requires (B1) and (B2) explicitly and does not follow from fairness alone).
         Theorems~\ref{thm:qbft-safety} and~\ref{thm:quantitative-convergence}.
   \item \textbf{\#72}\enspace Communication complexity
         (upgrades Conjecture~\ref{conj:comm-complexity}).
-  \item \textbf{\#73}\enspace Re-export repair map into OPH language.
+  \item \textbf{\#73}\enspace Re-export repair map into the companion framework notation.
   \item \textbf{\#113}\enspace Construct topological encoding map for
         Claim~\ref{claim:qecc-mincut}.
 \end{itemize}

--- a/paper/deriving_the_particle_zoo_from_observer_consistency.tex
+++ b/paper/deriving_the_particle_zoo_from_observer_consistency.tex
@@ -126,7 +126,7 @@ hand.'' Hadrons come one layer later still: once color is realized and confined,
 are the composite readout channels of the quark/gluon sector rather than separate fundamental
 inputs.
 
-The role of the pixel constant \(P\) is also important to state clearly. In OPH, \(P\) does not
+The role of the pixel constant \(P\) is also important to state clearly. Here, \(P\) does not
 decide whether the photon exists, whether there are three colors, or whether quarks come in three
 generations. Those structural facts belong to the gauge-and-matter branch fixed before
 calibration. What \(P\) does is set the shared quantitative scale on which the realized particle
@@ -170,7 +170,7 @@ Before the hard derivation chapters, it helps to say in plain but still technica
 the OPH particle derivation is trying to do. The basic picture is not ``put particles on a
 sphere.'' The picture is: start with a network of observer patches on a screen \(S^2\), ask how
 their local descriptions can fail to glue perfectly, and then study which persistent obstruction
-patterns survive repair, transport, and refinement. In OPH, those persistent patterns
+patterns survive repair, transport, and refinement. Those persistent patterns
 are what eventually harden into gauge sectors, flavor structure, and particle families.
 
 \subsection{Step 1: local observer patches do not automatically agree}
@@ -497,9 +497,9 @@ one mixing angle per sector, but to infer one universal pixel constant \(P\) fro
 calibration family and then demand that the same \(P\) drive all downstream bosonic, quark,
 lepton, neutrino, and hadronic branches.
 
-One clarification matters. The OPH formulation carries the
+One clarification matters. The broader formulation carries the
 screen-capacity input \(N_{\mathrm{scr}}\) in its cosmological branch. So the claim here is
-not that every continuous number appearing anywhere in the full OPH framework has disappeared. The
+not that every continuous number appearing anywhere in the broader paper stack has disappeared. The
 claim is narrower and more interesting: the particle-spectrum reverse-engineering derivation is
 organized around one common nontrivial scale input \(P\), instead of a long particle-by-particle
 parameter list.
@@ -2974,7 +2974,7 @@ In the supplement, the same statement appears as the L\"uders update on the reco
 the synthesis paper \emph{Observers Are All You Need}~\cite{ophsynthesis}, this fixed-cutoff Born/L\"uders package is imported as theorem-bearing
 rather than interpretive rhetoric.
 
-This directly answers the particle-state question in OPH language. Measurements give particles
+This directly answers the particle-state question in the present framework. Measurements give particles
 actual states by conditioning the observer-accessible state on the central record algebra. A
 detector click, a stable overlap-sector readout, or a pointer value does not merely announce a
 pre-existing classical label; it defines the conditioned state for subsequent observer-accessible
@@ -3067,8 +3067,8 @@ under CP, but that observation is not yet a baryogenesis theorem.
 
 The D10 appendix below contains the dedicated gauge-coupling calibration discussion
 unification. Its main point is not that supersymmetry has been mathematically ruled out in every
-possible OPH extension. Its point is narrower and more relevant to this paper: the present
-OPH branch does not \emph{need} a supersymmetric partner spectrum in order to explain why
+possible extension of the program. Its point is narrower and more relevant to this paper: the present
+branch does not \emph{need} a supersymmetric partner spectrum in order to explain why
 unification-like running might appear.
 
 At one loop, the integrated D10 appendix records the familiar fact that Standard Model beta-function
@@ -3088,7 +3088,7 @@ features could arise from edge-sector structure rather than MSSM particle conten
 \end{enumerate}
 
 So if the paper asks ``why is there no supersymmetry in the derived spectrum?'', the best
-technical answer is: because the realized OPH branch stops at the Standard
+technical answer is: because the realized branch stops at the Standard
 Model content, and the existing unification discussion is trying to reproduce the relevant
 running behavior geometrically, without extending the particle content to a full
 supersymmetric multiplet structure.

--- a/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
+++ b/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
@@ -2841,7 +2841,7 @@ The string-theory relation is similarly reversed. The edge partition function
 \[
 Z_{\mathrm{edge}}(t)=\sum_R d_R^2 e^{-t C_2(R)}
 \]
-is the closed partition function obtained after gluing the open-edge weights $p_R(t)\propto d_R e^{-tC_2(R)}$. Peter--Weyl identifies this sum with the compact-group heat kernel at the identity, \(Z_{\mathrm{edge}}(t)=K_t(1)\), and the Chapman--Kolmogorov law gives the corresponding collar-sewing rule. If a large-$N_{\mathrm{edge}}$ regime exists, with $N_{\mathrm{edge}}$ distinct from the physical color rank $N_c=3$, its free energy admits a genus expansion. Within OPH this is read as a conditional effective reorganization of edge degrees of freedom, not as a derived critical-superstring completion. Any further lift to critical superstring structure would additionally require worldsheet supersymmetry, critical dimension, modular invariance, and GSO projection beyond the OPH axiom chain.
+is the closed partition function obtained after gluing the open-edge weights $p_R(t)\propto d_R e^{-tC_2(R)}$. Peter--Weyl identifies this sum with the compact-group heat kernel at the identity, \(Z_{\mathrm{edge}}(t)=K_t(1)\), and the Chapman--Kolmogorov law gives the corresponding collar-sewing rule. If a large-$N_{\mathrm{edge}}$ regime exists, with $N_{\mathrm{edge}}$ distinct from the physical color rank $N_c=3$, its free energy admits a genus expansion. Here this is read as a conditional effective reorganization of edge degrees of freedom, not as a derived critical-superstring completion. Any further lift to critical superstring structure would additionally require worldsheet supersymmetry, critical dimension, modular invariance, and GSO projection beyond the OPH axiom chain.
 
 \begingroup
 \footnotesize

--- a/paper/screen_microphysics_and_observer_synchronization.tex
+++ b/paper/screen_microphysics_and_observer_synchronization.tex
@@ -166,7 +166,7 @@ Microscopic screen picture
 
 The simulator-facing question is therefore not ``what is the final microscopic UV completion?'' It is
 ``can one finite local screen model realize the OPH patch, edge, record, and synchronization
-interfaces well enough to be testable?'' In OPH, the physically meaningful
+interfaces well enough to be testable?'' The physically meaningful
 uniqueness statement is quotient-level implementation hiding together with inert ancillary
 stabilization, not uniqueness of one screen-register presentation.
 
@@ -311,7 +311,7 @@ stable shared observable family on overlaps is sufficient.
 
 \section{Records and the Observer Criterion}
 
-The word ``observer'' should be used operationally. In OPH language, an observer is an
+The word ``observer'' should be used operationally. Here, an observer is an
 internal pattern with patch access and records. In a finite screen model, that can be stated
 more sharply.
 
@@ -1649,7 +1649,7 @@ existing access model for a record-bearing internal subsystem.
 
 \subsection{Architecture-level content}
 
-Relative to that imported framework, the new content is at the architecture level rather than at the full OPH-completion level.
+Relative to that imported framework, the new content is at the architecture level rather than at the full completion level.
 \begin{enumerate}[leftmargin=2em]
 \item It selects one finite gauge-register or quantum-link style reference architecture for a
 cellulated screen, explicitly as a working model rather than as the unique OPH UV completion.

--- a/paper/tex_fragments/COMPACT_TECHNICAL_SUPPLEMENT_PORT.tex
+++ b/paper/tex_fragments/COMPACT_TECHNICAL_SUPPLEMENT_PORT.tex
@@ -16,7 +16,7 @@ group:
 \]
 \end{theorem}
 
-\begin{theorem}[Geometric modular flow on caps on the OPH Bisognano--Wichmann branch]
+\begin{theorem}[Geometric modular flow on caps on the Bisognano--Wichmann branch]
 Assume the OPH axioms, the derived fixed-cutoff collar package, the controlled scaling-limit
 scope clause \textbf{T2}, and the branch condition \textbf{T1} that the realized refinement-stable
 scaling branch for caps and their conformal images lies in the Bisognano--Wichmann geometric
@@ -71,17 +71,17 @@ Vacuum-energy contributions therefore lie in the kernel of the null map
 \end{lemma}
 
 \begin{proposition}[Structural separation]
-Within OPH:
+Within the structural split used here:
 \begin{enumerate}[leftmargin=2em]
 \item local modular/null data fix \(T_{ab}\) only up to \(\phi g_{ab}\); and
 \item \(\Lambda\) is fixed by global screen capacity, not by local null data.
 \end{enumerate}
 So the large vacuum-energy bookkeeping of EFT is not itself the local quantity determining
-curvature on the OPH branch.
+curvature on this branch.
 \end{proposition}
 
 \begin{theorem}[No local \(\Lambda\) prediction]
-Within OPH's null-modular reconstruction:
+Within the null-modular reconstruction used here:
 \begin{enumerate}[leftmargin=2em]
 \item all \(T_{kk}\) data are unchanged under \(T_{ab}\to T_{ab}+\phi g_{ab}\);
 \item therefore \(\Lambda\) cannot be fixed by local overlap consistency alone; and
@@ -159,7 +159,7 @@ equivalently the derived nonabelian adjoint is
 (8,1,0)\oplus(1,3,0).
 \]
 There are therefore no gauge generators in mixed representations \((3,2,\pm 5/6)\), i.e. no
-simple-GUT \(X,Y\) bosons on the realized OPH branch. The structural claim is exactly
+simple-GUT \(X,Y\) bosons on the realized branch. The structural claim is exactly
 \[
 \tau_p^{(\mathrm{gauge})}=\infty,
 \]

--- a/paper/tex_fragments/MICROPHYSICS_MEASUREMENT_SUPPLEMENT_PORT.tex
+++ b/paper/tex_fragments/MICROPHYSICS_MEASUREMENT_SUPPLEMENT_PORT.tex
@@ -147,7 +147,7 @@ must have the form
 for some density operator \(\rho\).
 
 \paragraph{\textbf{Corollary 3.5 (Born uniqueness on the fixed-cutoff record surface).}}
-Within OPH's fixed-cutoff type-I regulator presentation, Born's rule is the unique
+Within the fixed-cutoff type-I regulator presentation used here, Born's rule is the unique
 overlap-consistent probability assignment on the record algebra.
 
 \paragraph{\textbf{Proposition 3.6 (Luders update).}}

--- a/paper/tex_fragments/OBSERVERS_APPENDICES.tex
+++ b/paper/tex_fragments/OBSERVERS_APPENDICES.tex
@@ -194,7 +194,7 @@ has a fixed point by Brouwer. If, moreover, \(\Phi\) is a contraction for some m
 starting point by Banach's contraction theorem.
 
 \begin{proof}
-On that fixed-cutoff realized presentation, the OPH branch identifies each chosen patch algebra
+On that fixed-cutoff realized presentation, each chosen patch algebra is identified
 with a finite-dimensional type-I presentation modulo compact boundary redundancy, so each \(M_i\)
 and \(M_i^*\) is finite-dimensional. Hence \(E\) is finite-dimensional and all relevant locally
 convex topologies coincide. The habitat theorem above shows that \(X_{\mathcal O}\) is nonempty,
@@ -292,7 +292,7 @@ uniqueness and stability for such a map.
 
 \subsection{Observer as Algebraic Pattern}
 
-In OPH, an observer is represented by
+Here, an observer is represented by
 \[
 O=(P,\mathcal{A}(P),\rho,R),
 \]

--- a/paper/tex_fragments/OBSERVERS_TECHNICAL_SUPPLEMENT_PORT.tex
+++ b/paper/tex_fragments/OBSERVERS_TECHNICAL_SUPPLEMENT_PORT.tex
@@ -90,7 +90,7 @@ The AMPS-style information trilemma assumes:
 \item late radiation \(B\) entangled with early radiation \(R\) (unitarity), and
 \item monogamy of entanglement.
 \end{enumerate}
-The false assumption on the OPH branch is the naive tensor factorization
+The false assumption in this setting is the naive tensor factorization
 \[
 \mathcal H \stackrel{?}{=}
 \mathcal H_{\mathrm{inside}}\otimes


### PR DESCRIPTION
Following finishing #64 

This PR is a quick `/paper` review-fix pass. The main problem was not new theorem breakage, but a
scattered set of leftover narrative phrases and branch-label wording that made some technical
surfaces read less sharply than the current corpus actually supports.

This change keeps the math and claim tiers intact while tightening presentation:
- removes leftover “In OPH …”, “OPH language”, “full OPH”, and similar narration from theorem and
  supplement prose where the framework label was doing stylistic work rather than technical work;
- keeps the bridge wording mechanism-first on the live surfaces, especially in the microphysics,
  particle, compact-supplement, and observer-appendix texts;
- cleans a few awkward branch-title phrases so they describe the actual branch or structural split
  rather than project-brand narration;
- refreshes one roadmap item in the BFT/QECC appendix so it refers to companion-framework notation
  rather than “OPH language”.

Net effect: the `/paper` stack reads more like one coherent technical corpus and less like a set of
companion notes with leftover internal narration. No claim tier is widened here; this is a wording,
surface-consistency, and presentation-discipline pass.