### PR TITLE
feat: paper: classify reconciliation complexity, stability, and universality

### DIFF
--- a/paper/observers_are_all_you_need.tex
+++ b/paper/observers_are_all_you_need.tex
@@ -225,6 +225,10 @@ bounds, and a closed checkpoint/restoration package.
 fixes the physical UV branch only modulo implementation hiding and inert ancillary refinement; the
 UV burden is the continuum BW/geometric lift and the refinement-limit transportable-sector
 lift.
+\item \textbf{The consensus lane is exact but not overpromoted.} Technically, on each fixed finite
+patch net the normal form is a finite-state decidable object, approximate stability is only
+carried by the local splice and record error controls, and no universality theorem for a uniform
+family of growing patch nets and repair laws is part of the current paper stack.
 \item \textbf{The string/worldsheet lane remains conditional.} Technically, it is carried only as
 a continuation of the OPH heat-kernel edge-sector theorem, not as part of the recovered core.
 \end{enumerate}

--- a/paper/reality_as_consensus_protocol.tex
+++ b/paper/reality_as_consensus_protocol.tex
@@ -80,7 +80,10 @@ parenthesization-independent union-collar glue used for the local diamond. What 
 that step is repair completeness and, on the Petz branch, the support/CPTP clause stated later in
 Proposition~\ref{prop:petz-cptp}.
 
-We also define a fitness functional over the space of candidate reconciliation laws and prove that replicator dynamics monotonically increases mean fitness (Theorem~\ref{thm:replicator}). This gives a clean mathematical model for the selection of physical law.
+We also define a fitness functional over a finite candidate space of reconciliation laws and prove
+that replicator dynamics monotonically increases mean fitness (Theorem~\ref{thm:replicator}). This
+gives a clean mathematical model for finite-candidate law selection, not a universality theorem or
+a literal cosmological dynamics claim.
 
 The results here are exact theorems about a computational model. The companion OPH manuscript develops the broader physics branches conditionally and keeps structural theorems, scaling-limit branches, calibration-sector outputs, and phenomenological continuations distinct~\cite{OPH}.
 
@@ -837,18 +840,46 @@ clean law-selection meta-model. The conditional relativity chain and the realize
 structural chain remain the recovered core. The capacity relation is separate and input-dependent.
 Downstream phenomenology requires additional premises beyond the consensus results proved here.
 
-Six directions stand out as immediate next steps:
+\paragraph{Complexity status.}
+On a fixed finite patch net, the accepted reconciliation dynamics is a finite-state asynchronous
+rewrite system on \(\Sigma\). Under Theorem~\ref{thm:confluence}, every accepted repair run has at
+most \(|\Phi(\Sigma)|-1\le |\Sigma|-1\) nontrivial steps, because each accepted move strictly
+lowers \(\Phi\) and the value set \(\Phi(\Sigma)\) is finite. Exact normal-form computation is
+therefore decidable by direct iteration of accepted local repairs. What this paper does
+\emph{not} prove is a uniform polynomial-time bound, a sharper complexity-class placement for
+families of growing patch nets, or any hardness lower bound.
+
+\paragraph{Approximate-stability status.}
+The theorem-grade consensus statement is exact on the declared fixed-cutoff branch. Approximate
+control is presently collar-local: Theorem~\ref{thm:splice} gives the exact-Markov modulus
+\(\delta^{\mathrm M}_{A:B:D}(\varepsilon)\to0\) on one fixed finite-dimensional collar model and
+the one-shot recovery comparison bound \(2\sqrt{1-e^{-\varepsilon}}\le 2\sqrt{\varepsilon}\),
+while Theorem~\ref{thm:crdt} gives the \((\varepsilon,\delta_{\mathrm{rec}})\) repeated-read
+stability bound for approximate record projectors. The current corpus does \emph{not} prove a
+global noisy-consensus theorem asserting that arbitrarily long asynchronous approximate repair
+sequences converge to a unique approximate quotient normal form with uniformly controlled
+accumulated error.
+
+\paragraph{Expressive-power status.}
+The law-selection model of Theorem~\ref{thm:replicator} is a finite-candidate monotonicity result,
+not a universality theorem. For each fixed patch net the current theorem package proves a
+finite-state exact reconciliation mechanism rather than an unbounded universal machine. A genuine
+universality claim would require an explicit uniform family of patch nets and repair laws that
+simulates arbitrary circuits or machines with stated encoding overhead and robustness under
+asynchronous schedules. No such theorem is supplied here.
+
+With that status split fixed, six directions stand out as immediate next steps:
 
 \begin{enumerate}
-\item \textbf{Computational complexity.} What is the complexity of computing $\operatorname{nf}_\lambda(s)$? The finite-valued Lyapunov termination bound from the touched-overlap descent of \(\Phi\) is a worst-case measure, but typical instances may converge much faster. Is there a polynomial bound for natural classes of patch nets?
-
 \item \textbf{Coarse-graining.} When does reconciliation commute with renormalization? If you coarse-grain the patch net and then reconcile, do you get the same result as reconciling first and then coarse-graining? The conditions under which these operations commute would connect the discrete model to continuum field theory.
 
 \item \textbf{Defect classification and refinement-limit transportability.} The fixed-cutoff hierarchy extends from abelian frustrations to crossed-module classes \(q\in \check H^2(N,H\to G)\). The remaining task is to connect those higher-gauge defect sectors to the refinement-stable transportable sector category used in the broader compact-gauge reconstruction lane.
 
 \item \textbf{Observable-level confluence beyond the declared fixed-cutoff physical algebra.} Theorem~\ref{thm:obsconfluence} closes the fixed-cutoff quantum-lift statement when microscopic representatives differ by gauge relabelings globally or by sector/higher-gauge relabelings on the same declared quotient-local glued state. The remaining question is whether an analogous observable theorem survives on broader refinement-stable branches where the union-collar compatibility is only approximate or where the physical observable algebra itself changes under refinement.
 
-\item \textbf{Recovery-channel control.} The fixed-cutoff collar branch already expresses local repair through exact splice or Petz/Fawzi--Renner recovery, commits candidate moves only under the touched-overlap local-fit contract that yields Lyapunov descent of \(\Phi\), and derives the local diamond from support-local disjoint commutation together with parenthesization-invariant union-collar gluing on the physical quotient. What remains is to prove on natural refinement-stable branches that these accepted recovery moves are repair-complete for overlap consistency, preserve support-local disjoint commutation and nested-collar restriction compatibility, including the support/CPTP clause on the Petz branch, and keep the union-collar package stable under refinement or branch changes.
+\item \textbf{Global approximate-consensus stability.} Theorem~\ref{thm:splice} and Theorem~\ref{thm:crdt} already supply the collar-local perturbative controls carried by the present paper. What remains is a multi-step theorem showing that approximate recovery moves are repair-complete for overlap consistency, preserve support-local disjoint commutation and nested-collar restriction compatibility, satisfy the support/CPTP clause on the Petz branch where needed, and converge under long asynchronous schedules to a unique approximate quotient normal form with controlled accumulated error.
+
+\item \textbf{Expressive power / universality.} A universality claim would require an explicit uniform family of patch nets and repair laws that simulates arbitrary circuits or machines with stated encoding overhead and robustness under asynchronous schedules. The current paper supplies no such construction, so universality remains an external possibility rather than a theorem-grade output.
 
 \item \textbf{Scaling-limit bridge to the downstream gravity/gauge stack.} Under what additional regularity conditions does the consensus protocol emit the prime geometric cap pair and support ordered cut-pair rigidity on that extracted limit, so that the D3--D5 gravity chain and the D7--D9 gauge/matter chain become available? This is also the point at which the broader Phase-II and Phase-III branches must remain disciplined: dark-sector, baryogenesis, spectroscopy, and string/worldsheet topics require extra premises beyond what this paper itself proves.
 \end{enumerate}

--- a/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
+++ b/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
@@ -79,6 +79,12 @@ is recovered in the bosonic compact-gauge branch once the MAR admissibility pack
 \item The fixed-cutoff topological UV package closes on the ordinary branch, the central-defect branch, and the genuinely noncentral branch through a compact crossed-module higher-gauge collar theorem; the remaining UV-side burdens are the continuum BW/geometric lift and the refinement-limit compact-gauge premises.
 \end{enumerate}
 
+On that same fixed-cutoff consensus surface, the status split is sharp: normal-form computation is
+a finite-state decidable problem with the Lyapunov step bound from the consensus paper, the only
+present approximate-stability inputs are the collar-local splice and record estimates carried
+there, and no universality theorem for a uniform family of growing patch nets and repair laws is
+claimed in this paper.
+
 \section{Overview of Results}
 
 This section summarizes the claim tiers used throughout. The labels \(D1\)--\(D12\) are internal
@@ -3001,10 +3007,15 @@ after transport to each fixed local collar model. Only after that can local weak
 
 Second, one needs ordered cut-pair rigidity on that realized limit. That stage would collapse the remaining cap-preserving conformal freedom to the unique BW hyperbolic subgroup, after which the modular KMS condition fixes the \(2\pi\) normalization. Ordered cut-pair rigidity remains symbolic until the realized scaling-limit geometric cap pair exists. Until those two objects are internalized, every stronger BW / vacuum / canonical identification remains explicitly theorem-external shorthand for the geometric-subnet branch of Theorem~\ref{thm:bw}, not a derived OPH theorem.
 
-This is analogous to ordinary lattice field theory: one computes at finite regulator in a type-I algebra and then asks which continuum algebraic phase the scaling limit realizes. OPH's additional structural point is that the realized state-side branch is controlled under refinement. The open problem is to identify which scaling-limit observer algebra/state pair the realized branch produces and then to prove BW rigidity on that pair.
+This is analogous to ordinary lattice field theory: one computes at finite regulator in a type-I algebra and then asks which continuum algebraic phase the scaling limit realizes. The additional structural point here is that the realized state-side branch is controlled under refinement. The open problem is to identify which scaling-limit observer algebra/state pair the realized branch produces and then to prove BW rigidity on that pair.
 \subsection{UV branch and scaling-limit scope}
 
 At fixed cutoff, Axiom~\ref{ax:maxent} yields a quasi-local finite-range interacting branch, and Propositions~\ref{prop:gauge} and \ref{prop:ancillauv} show that the physical normal form is unique only modulo quotient-level OPH-stable equivalence, while the terminal expectation functionals on the declared fixed-point / quotient-local physical algebras are already schedule-independent on that carrier even when microscopic representatives differ by gauge labels globally or by sector labels on one regional quotient-local glued state. The invariant fixed by the axiom language is the class \([\mathfrak U]_{\mathrm{OPH}}\) of the physical branch modulo implementation hiding and inert ancillary stabilization, not a unique microscopic representative. The genuinely noncentral topological case is also closed at fixed cutoff by the higher-gauge package of Theorems~\ref{thm:hgdatum}--\ref{thm:hgtransport} and Proposition~\ref{prop:hginteracting}, so the fixed-cutoff topological UV surface is closed on the ordinary, central-defect, and crossed-module branches alike. Beyond fixed cutoff, the continuum modular/geometric lift remains the geometric-subnet extraction-plus-rigidity problem under \textbf{T2}, and the transportable bosonic gauge lift still carries Assumption~\ref{ass:gaugeprem} when invoked.
+The consensus paper also classifies that D1 lane explicitly: on each fixed finite patch net,
+normal-form computation is finite-state and decidable with the Lyapunov step bound, the current
+approximate-stability results are only the collar-local splice and record controls, and no
+universality theorem for a uniform family of growing patch nets and repair laws is part of the
+emitted theorem surface.
 
 \subsection{Why is charge quantization possible without a simple GUT?}
 

--- a/paper/tex_fragments/OBSERVERS_SYNTHESIS_SECTIONS.tex
+++ b/paper/tex_fragments/OBSERVERS_SYNTHESIS_SECTIONS.tex
@@ -6,10 +6,11 @@ schedule-independent quotient normal form together with the induced terminal exp
 functionals on the declared physical observable algebras. This section records the fixed-point,
 defect, and gauge-quotient statements in that language.
 
-The consensus lane also carries a simple law-selection model: once one equips candidate repair
-rules with a fitness functional, replicator dynamics gives a clean toy picture in which more
-successful reconciliation laws dominate a competing pool. That selection picture is useful for the
-overall framework picture, but it is not part of the recovered-core gravity/gauge theorem surface.
+The consensus lane also carries a simple finite-candidate law-selection model: once one equips
+candidate repair rules with a fitness functional, replicator dynamics gives a clean toy picture in
+which more successful reconciliation laws dominate a competing pool. That selection picture is
+useful for the overall synthesis picture, but it is not part of the recovered-core gravity/gauge
+theorem surface and it is not a universality claim.
 
 \paragraph{Theorem (Asynchronous confluence).}
 On a finite patch net with local recovery-derived repair maps, if normal forms are exactly the
@@ -70,6 +71,10 @@ unchanged.
 \paragraph{Extended derivation.}
 The full consensus, gauge-quotient, and operator-record theorem package is developed in
 \emph{Reality as a Consensus Protocol: The Fixed-Point Computation That Implements Physics}~\cite{ophconsensus}.
+On that fixed-cutoff surface the status split is explicit: exact normal-form computation is
+finite-state and decidable, approximate stability is only collar-local through the splice and
+record estimates, and no universality theorem for a uniform family of growing patch nets and
+repair laws is claimed.
 
 \section{Particle-Spectrum Branch}
 
@@ -304,7 +309,8 @@ The state of the OPH suite is:
 \item The fixed-cutoff collar, higher-gauge, and consensus theorem packages are part of
 the closed finite-regulator surface. The genuinely noncentral topological branch is not
 fixed-cutoff gap, and the quotient-level repair normal form is explicit on the finite patch-net
-surface.
+surface. The consensus lane is classified there as a finite-state exact theorem package rather
+than as a universality claim.
 \item The screen-microphysics lane has an explicit regulated reference architecture together
 with closed measurement/Born-rule and checkpoint/restoration packages. Its remaining open fronts
 are packet-level quotient closure where a declared observable family is meant to carry an

--- a/paper/tex_fragments/PAPER.tex
+++ b/paper/tex_fragments/PAPER.tex
@@ -5,6 +5,10 @@ OPH is an observer-centric reconstruction program for fundamental physics. Physi
 \subsection{Overview}\label{overview}
 
 The recovered core of the paper is the D1--D5 and D7--D9 chain: overlap-consistency normal form, collar and edge-center structure, the conditional Lorentz and Einstein branches, compact gauge reconstruction, and the realized Standard Model branch with exact hypercharge structure, \(N_g=3\), and \(N_c=3\). Here and throughout the synthesis, labels such as D1--D12 are internal documentary node labels for the OPH derivation ledger; the local key appears in Section~\ref{16-summary-complete-axiom-set}, the SM/GR derivation paper \emph{Recovering Relativity and the Standard Model from the OPH Package Rooted in Observer Consistency} gives the same ledger in shorter form~\cite{ophcompact}, and the public paper ledger has no separate D11 row. D6 is a separate input-dependent corollary tied to total screen capacity. D12 collects phenomenological continuations kept distinct from the recovered core.
+Within D1, the consensus paper now classifies the fixed-cutoff status sharply: exact
+normal-form computation is finite-state and decidable, approximate stability is only collar-local
+through the splice and record estimates, and no theorem-grade universality claim is made for a
+uniform family of growing patch nets and repair laws.
 
 The Lorentz/null-modular/Einstein chain is a scaling-limit statement with explicit fixed-cutoff control. The gauge chain reconstructs a compact group from the transportable refinement-directed sector colimit supplied by \textbf{T6} and then specializes to the realized MAR-admissible branch. The worldsheet/string material and the flavor, neutrino, hadron, dark-sector, and spectroscopy branches are kept separate from the recovered core.
 
@@ -317,6 +321,10 @@ even when microscopic representative lifts differ by gauge labels globally or by
 inside one quotient-local glued state.
 Stability of that compatibility package under
 refinement or branch change is a separate question.
+The same consensus surface is classified explicitly as a finite-state exact theorem package:
+decidable normal-form computation with the Lyapunov step bound, collar-local approximate
+stability only through the splice and record controls, and no universality theorem for a uniform
+family of growing patch nets and repair laws.
 
 \textbf{Theorem 2.3 (EC from regulated overlap gluing).} For a collar \(B_\delta\) around a cap boundary \(\Sigma\), there is a canonical decomposition
 


### PR DESCRIPTION
#72 

This PR closes the status gap in
`papers.reality.c.12-classify-complexity-and-universality-of-reconciliation`.

The consensus paper already proved exact fixed-cutoff confluence, local splice/recovery control,
and the finite-candidate replicator monotonicity model, but its discussion still left the
complexity, approximate-stability, and expressive-power status too open-ended.

This change makes that boundary explicit:
- the consensus discussion now states the exact fixed-cutoff classification directly: normal-form
  computation is a finite-state decidable problem with the Lyapunov step bound, approximate
  stability is only collar-local through the splice and record estimates, and no universality
  theorem for growing patch families is claimed;
- the remaining open fronts are tightened accordingly, especially the distinction between
  collar-local perturbative control and a still-missing global noisy-consensus theorem, and between
  finite-candidate law-selection monotonicity and a still-missing uniform simulation theorem;
- the compact, master, and observer-facing summary surfaces are synced so they no longer gesture
  more broadly than the consensus paper itself.

Net effect: the paper stack now presents reconciliation as a sharp finite-state exact theorem
package with explicit local stability controls and explicit remaining gaps, rather than leaving its
computational status or universality as rhetorical overhang.