### PR TITLE
paper/compact: tighten the BW cap-modular theorem boundary

### DIFF
--- a/paper/observers_are_all_you_need.tex
+++ b/paper/observers_are_all_you_need.tex
@@ -166,8 +166,8 @@ the consensus/fixed-point formulation together with observable-level quotient co
 declared physical algebras, the
 record-algebra / Born-L\"uders package with its quantitative stability surface, and the
 checkpoint/restoration package are theorem-bearing on their stated finite
-surfaces. The Lorentz/null-modular/Einstein chain and compact gauge reconstruction remain
-conditional continuum or categorical branches. The particle lane is the most tiered part of
+surfaces. The Lorentz/null-modular/Einstein chain remains a conditional scaling-limit branch,
+and compact gauge reconstruction remains a conditional categorical branch. The particle lane is the most tiered part of
 the suite: the structural carrier skeleton and realized Standard Model branch are fixed, the
 electroweak stage remains a forward-emitted non-core Phase-II calibration branch whose internal
 transmutation data are fixed from \(P\), with target-free public \(W/Z\) rows and a compare-only
@@ -201,8 +201,10 @@ quotient, and repair completeness holds on the stated finite patch-net branch. M
 representative lifts may still differ by gauge or sector relabelings inside one declared
 quotient-local glued state without changing the resulting observable values on those algebras.
 \item \textbf{Relativity appears as a controlled continuum branch.}
-Technically, the Lorentz/null-modular/Einstein chain is a refinement/scaling-limit branch with
-explicit canonical technical premises.
+Technically, the Lorentz/null-modular/Einstein chain is a refinement/scaling-limit branch that
+depends on the \textbf{T2} scaling-limit scope clause, the theorem-local realized geometric
+cap-pair extraction plus ordered cut-pair rigidity on the extracted prime geometric subnet, and
+the fixed-cap stationarity step where the Einstein branch is invoked.
 \item \textbf{The Standard Model gauge skeleton appears as a constrained consistency output.}
 Technically, compact gauge reconstruction and the realized
 \(\SU(3)\times\SU(2)\times\U(1)/\mathbb Z_6\) branch follow under the stated transportability and

--- a/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
+++ b/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
@@ -54,7 +54,7 @@ why the observed three generations and three colors are realized, why hypercharg
 
 This paper presents a conditional reconstruction program based on Observer-Patch Holography (OPH). Physical data are organized patchwise: each observer has access only to a patch algebra, neighboring observers must agree on overlaps, and the reconstruction is driven by those consistency conditions. Under the five axioms and the additional branch premises stated below, the same formal structure that produces schedule-independent overlap consistency then feeds a Lorentzian modular-phase classification, a Jacobson-type Einstein branch conditional on fixed-cap stationarity and the null modular bridge together with the bounded-interval projective branch, compact gauge reconstruction in a bosonic internal-gauge sector, charge quantization, and the low-energy architecture selected by the admissibility conditions used in the gauge branch. Any discrete-horizon or black-hole spectroscopy template remains a Phase-III continuation and is not part of the recovered relativity-plus-Standard-Model core.
 
-The paper separates exact structural theorems, conditional scaling-limit branches, calibration-sector outputs, and phenomenological continuations.\footnote{Broader interpretive questions are deferred here so the claim-tier boundary remains explicit.} Several longer arguments are recorded below as proof sketches.
+The paper separates exact structural theorems, conditional scaling-limit branches, calibration-sector outputs, and phenomenological continuations.\footnote{Broader interpretive questions are deferred here so the claim-tier boundary remains explicit.} Several longer arguments are written in compressed proof form so the claim-tier boundary stays readable.
 
 The framework is intended as a candidate fundamental theory in the precise sense relevant for physics: general relativity and the Standard Model appear as effective sectors derived from a smaller axiom set plus an explicit refinement/scaling-limit package. The paper does not use simulation language, observer continuation stories, or other non-falsifiable additions.
 
@@ -1396,7 +1396,7 @@ By Theorem~\ref{thm:bw}, on the extracted prime geometric subnet the realized sc
 \end{proof}
 \subsection{The null modular bridge}
 
-The fixed-cutoff strip analysis begins from the transferred cut-center data and the inherited-strip Markov structure. At fixed regulator scale one obtains exact or controlled four-term strip additivity together with endpoint-Lipschitz control of the renormalized half-line family; on the same OPH geometric scaling branch used in Theorem~\ref{thm:bw}, the null half-line blow-up net then inherits geometric dilation and therefore half-sided modular inclusion. Standard Borchers--Wiesbrock theory~\cite{wiesbrock93} consequently applies to the resulting OPH half-sided modular pair, yielding positivity and unitary implementation of null translations. What remains downstream is narrower: the separate interval-preserving projective branch is still needed to transport the half-line result to bounded null intervals, and the later tensor upgrade still carries the standard null-invisible metric ambiguity. The half-line generator itself is identified below with the effective local null-stress charge.
+The fixed-cutoff strip analysis begins from the transferred cut-center data and the inherited-strip Markov structure. At fixed regulator scale one obtains exact or controlled four-term strip additivity together with endpoint-Lipschitz control of the renormalized half-line family; on the same scaling-limit geometric-cap branch used in Theorem~\ref{thm:bw}, the null half-line blow-up net then inherits geometric dilation and therefore half-sided modular inclusion. Standard Borchers--Wiesbrock theory~\cite{wiesbrock93} consequently applies to the resulting half-sided modular pair, yielding positivity and unitary implementation of null translations. What remains downstream is narrower: the separate interval-preserving projective branch is still needed to transport the half-line result to bounded null intervals, and the later tensor upgrade still carries the standard null-invisible metric ambiguity. The half-line generator itself is identified below with the effective local null-stress charge.
 \par
 The present subsection therefore establishes the following chain:
 \begin{enumerate}[leftmargin=2em]
@@ -1896,7 +1896,7 @@ a\le b
 \]
 
 \begin{corollary}[Derived half-sided modular inclusion on null half-lines]\label{cor:n2}
-On the OPH geometric scaling branch of Theorem~\ref{thm:bw}, the blow-up modular action near a smooth entangling cut acts on the null coordinate by
+On the scaling-limit geometric-cap branch of Theorem~\ref{thm:bw}, the blow-up modular action near a smooth entangling cut acts on the null coordinate by
 \[
 v\mapsto e^{-2\pi t}v.
 \]
@@ -2166,7 +2166,7 @@ The c.12-local bridge ends with explicit theorem-level objects: the positive sel
 \end{remark}
 \subsection{Generalized entropy and the Einstein equation}
 
-From this point through Corollary~\ref{cor:einstein} we specialize to the physical $d=4$ scaling branch. The claim boundary is explicit. The only standard geometric input used below, beyond the OPH outputs D3 and D4, is the fixed-volume area-variation identity for a small geodesic ball. The small-ball modular kernel used below is \emph{not} imported from a separate EFT law: it is the local expression of the OPH geometric cap generator $B_C$ from Theorem~\ref{thm:bw}, evaluated using the half-line null-stress identification of Theorem~\ref{thm:stress} together with the separate interval-preserving projective branch that transports it to bounded null intervals.
+From this point through Corollary~\ref{cor:einstein} we specialize to the physical $d=4$ scaling branch. The claim boundary is explicit. The only standard geometric input used below, beyond D3 and D4, is the fixed-volume area-variation identity for a small geodesic ball. The small-ball modular kernel used below is \emph{not} imported from a separate EFT law: it is the local expression of the geometric cap generator $B_C$ from Theorem~\ref{thm:bw}, evaluated using the half-line null-stress identification of Theorem~\ref{thm:stress} together with the separate interval-preserving projective branch that transports it to bounded null intervals.
 
 For a reference state $\omega$ and a small cap $C$,
 \[
@@ -2265,7 +2265,7 @@ The additional hypothesis $\delta\langle E^{(\eta)}_{C,\ell}\rangle=o(\ell^4)$ t
 2\pi\cdot\frac{4\pi\ell^4}{15}\,\delta\langle T_{00}\rangle
 +O(\ell^5\partial T)+o(\ell^4),
 \]
-which is exactly the stated coefficient. No separate EFT small-ball first law has been used: the kernel comes from the OPH geometric generator together with the D4 null-stress bridge.
+which is exactly the stated coefficient. No separate EFT small-ball first law has been used: the kernel comes from the geometric cap generator together with the D4 null-stress bridge.
 \end{proof}
 
 \begin{theorem}[Conditional Jacobson-type rest-frame relation from entanglement equilibrium]\label{thm:einstein}

--- a/paper/tex_fragments/OBSERVERS_SYNTHESIS_SECTIONS.tex
+++ b/paper/tex_fragments/OBSERVERS_SYNTHESIS_SECTIONS.tex
@@ -321,8 +321,9 @@ the family of terminal expectation functionals on the declared physical observab
 modulo implementation hiding and inert ancillary refinement, not a unique microscopic
 representative.
 \item The Lorentz/null-modular/Einstein chain remains a controlled refinement/scaling-limit
-branch. In the canonical premise ledger, the external burdens are the geometric modular
-branch, the scaling-limit scope clause, and the fixed-cap stationarity step.
+branch. In the canonical premise ledger, the external burdens are the \textbf{T2} scaling-limit
+scope clause, the theorem-local realized geometric cap-pair extraction plus ordered cut-pair
+rigidity on the extracted prime geometric subnet, and the fixed-cap stationarity step.
 \item Compact gauge reconstruction and the realized Standard Model quotient remain tied to the
 transportability, symmetric-braiding, and fiber-functor premises stated in the canonical
 technical-premise list.

--- a/paper/tex_fragments/PAPER.tex
+++ b/paper/tex_fragments/PAPER.tex
@@ -120,10 +120,10 @@ for \(d > v_{\mathrm{LR}}|t|\), where \(\xi = O(\ell_{\mathrm{UV}})\).
 
 This is the branch-internal control statement that turns the quasi-local structure of the
 local-Gibbs branch into explicit support control for time-evolved operators. It is not an extra
-premise beyond the third OPH axiom.
+premise beyond the third axiom.
 
 \begin{quote}
-\textbf{Approximate modular covariance on the geometric branch.} Under the fixed-cutoff realized presentation, Lemma 2.6 (local Gibbs), the derived quasi-local propagation bound above, and the collar double-scaling plus mixing hypotheses of Section 2.3, the modular flow \(\sigma_t^{\omega,C}\) maps \(\mathcal{A}(R)\) into a slightly thickened region algebra:
+\textbf{Approximate modular covariance on the fixed-cutoff realized branch.} Under the fixed-cutoff realized presentation, Lemma 2.6 (local Gibbs), the derived quasi-local propagation bound above, and the collar double-scaling plus mixing hypotheses of Section 2.3, the modular flow \(\sigma_t^{\omega,C}\) maps \(\mathcal{A}(R)\) into a slightly thickened region algebra:
 
 \[
 \sigma_t^{\omega,C}(\mathcal{A}(R)) \subseteq \mathcal{A}(R^{+v_{\mathrm{mod}}|t|})
@@ -940,7 +940,7 @@ otherwise the automorphism identity is the full statement and the action is oute
 \]
 for some \(\kappa_C>0\). Because \(s\) is normalized by the null blow-up \(v\mapsto e^{-s}v\), the modular KMS condition fixes \(\kappa_C=2\pi\). Thus
 \[
-\sigma_t^{\omega_\infty^C}
+\sigma_t^{\omega_\infty^{\mathrm{geo},C}}
 =
 \alpha_{\lambda_C(2\pi t)}.
 \]
@@ -974,15 +974,15 @@ By Theorem~\ref{42-theorem-mathrmbw_s2-from-markov-locality-symmetry-regularity}
 
 Section 4.2 fixes the cap modular statement first at the automorphism level. On the extracted prime geometric subnet, the scaling-limit cap modular flow is geometric with the standard \(2\pi\) normalization,
 \[
-\sigma_t^{\omega_\infty^C}
+\sigma_t^{\omega_\infty^{\mathrm{geo},C}}
 =
 \alpha_{\lambda_C(2\pi t)}.
 \]
-If the realized scaling-limit cap algebra happens to remain type I, one may choose a density matrix \(\rho_C^\omega\) and modular Hamiltonian
+If the realized scaling-limit cap algebra happens to remain type I, one may choose a density matrix \(\rho_C^{\omega_\infty^{\mathrm{geo},C}}\) and modular Hamiltonian
 \[
-K_C:=-\log\rho_C^\omega,
+K_C:=-\log\rho_C^{\omega_\infty^{\mathrm{geo},C}},
 \]
-and then for a perturbation \(\rho(\varepsilon)\) with \(\rho(0)=\omega\) the first-law identity reads
+and then for a perturbation \(\rho(\varepsilon)\) with \(\rho(0)=\omega_\infty^{\mathrm{geo},C}\) the first-law identity reads
 \[
 \delta S_C=\delta\langle K_C\rangle
 =
@@ -992,7 +992,7 @@ In the generic continuum/non-type-I case, Section 4.2 does not supply an inner o
 
 \subsubsection{Null-surface modular bridge}\label{52-null-surface-modular-bridge}
 
-This subsection extends the fixed-cutoff weak-tail-generator boundary to the derived positive null-translation stage and the exact half-line generator/charge identification. At fixed cutoff one can transfer cut-center data to regulated null strips, obtain exact or controlled strip additivity on one inherited strip model, and derive a weak tail generator for the renormalized half-line family. On the OPH geometric scaling branch of Theorem 4.2, the null half-line blow-up net then inherits geometric dilation and therefore half-sided modular inclusion, so Borchers--Wiesbrock supplies an explicit positive null-translation generator on its Stone domain. The remaining downstream boundary is narrower: bounded-interval formulas still require the separate interval-preserving projective branch, and the later tensor upgrade still carries the null-invisible metric ambiguity. Accordingly the c.12-local bridge consists of:
+This subsection extends the fixed-cutoff weak-tail-generator boundary to the derived positive null-translation stage and the exact half-line generator/charge identification. At fixed cutoff one can transfer cut-center data to regulated null strips, obtain exact or controlled strip additivity on one inherited strip model, and derive a weak tail generator for the renormalized half-line family. On the scaling-limit geometric-cap branch of Theorem 4.2, the null half-line blow-up net then inherits geometric dilation and therefore half-sided modular inclusion, so Borchers--Wiesbrock supplies an explicit positive null-translation generator on its Stone domain. The remaining downstream boundary is narrower: bounded-interval formulas still require the separate interval-preserving projective branch, and the later tensor upgrade still carries the null-invisible metric ambiguity. Accordingly the c.12-local bridge consists of:
 \begin{itemize}
 \tightlist
 \item
@@ -1240,7 +1240,7 @@ a\le b
 \mathcal M_b(\Omega)\subseteq \mathcal M_a(\Omega).
 \]
 
-\textbf{Corollary 5.2e (Derived half-sided modular inclusion on null half-lines).} On the OPH geometric scaling branch of Theorem 4.2, the blow-up modular action near a smooth entangling cut acts on the null coordinate by
+\textbf{Corollary 5.2e (Derived half-sided modular inclusion on null half-lines).} On the scaling-limit geometric-cap branch of Theorem 4.2, the blow-up modular action near a smooth entangling cut acts on the null coordinate by
 \[
 v\mapsto e^{-2\pi t}v.
 \]
@@ -1358,7 +1358,7 @@ as a quadratic-form identity on the common domain. The only imported continuum i
 \item
   the fixed-cutoff null-strip bridge is exact for exact Markov strip states on that inherited decomposition, and otherwise is replaced by a controlled limit with the carried defect operator \(\mathfrak D_J\);
 \item
-  the local finite-constraint MaxEnt branch gives endpoint-Lipschitz control strong enough to define a weak tail generator for renormalized half-lines, and the OPH geometric scaling branch then derives half-sided modular inclusion on the half-line blow-up net;
+  the local finite-constraint MaxEnt branch gives endpoint-Lipschitz control strong enough to define a weak tail generator for renormalized half-lines, and the scaling-limit geometric-cap branch of Theorem 4.2 then derives half-sided modular inclusion on the half-line blow-up net;
 \item
   Borchers--Wiesbrock therefore supplies a genuine positive null-translation generator \(P_\Omega\) inside the bridge itself, together with its Stone domain and the half-line modular-Hamiltonian relation \(K_a=K_0-2\pi aP_\Omega\);
 \item
@@ -1505,7 +1505,7 @@ On the t=0 slice its lapse is
 \[
 \xi_{D_\ell}\!\cdot n=\frac{\ell^2-r^2}{2\ell}.
 \]
-The bounded-interval kernel comes from combining the D3 geometric cap generator with the separate interval-preserving projective branch used downstream of the D4 half-line stress bridge, so the D3 geometric branch and the D4 stress bridge together yield
+The bounded-interval kernel comes from combining the D3 geometric cap generator with the separate interval-preserving projective branch used downstream of the D4 half-line stress bridge, so the D3 cap-modular theorem and the D4 stress bridge together yield
 \[
 \delta S_{\mathrm{bulk}}(C)
 =
@@ -1571,13 +1571,13 @@ Along any connected scaling branch of reference states, \(Y_{ab}\) is therefore 
 \[
 G_{ab}+\Lambda g_{ab}=8\pi G\,\langle T_{ab}\rangle.
 \]
-Thus the tensor upgrade does not require a separate EFT handoff once OPH supplies the geometric branch, the null bridge, and the overlap-complete timelike family.
+Thus the tensor upgrade does not require a separate EFT handoff once the D3 geometric-cap theorem, the D4 null bridge, and the overlap-complete timelike family are in place.
 
 \subsubsection{Non-tunable numerical constants}\label{58-non-tunable-numerical-constants}
 
 The gravity chain yields specific numerical constants as rigid outputs of the axiom chain.
 
-\textbf{The \(2\pi\) KMS normalization.} From Theorem 4.2, once the OPH refinement branch is geometric, cap modular flow is fixed by the KMS condition to the standard \(2\pi\) normalization. This is the same rigidity that fixes Unruh/Hawking temperature normalization. The period is determined by the stated scaling-limit package together with the geometric-branch hypothesis.
+\textbf{The \(2\pi\) KMS normalization.} From Theorem 4.2, once the scaling-limit geometric cap pair has been emitted and ordered cut-pair rigidity holds on it, cap modular flow is fixed by the KMS condition to the standard \(2\pi\) normalization. This is the same rigidity that fixes Unruh/Hawking temperature normalization. The period is determined by the \textbf{T2} scaling-limit package together with those theorem-local hypotheses.
 
 \textbf{The geometric coefficient \(\Omega_{d-2}/(d^2 - 1)\).} This coefficient appears in both (a) the CFT-ball modular Hamiltonian weight integral and (b) the geometric area-variation identity. It is an exact integral identity:
 
@@ -2466,7 +2466,7 @@ A natural question arises: how does this framework relate to the ``unsolved prob
 
 \textbf{What the usual dS holography problem is.} When people say ``dS holography is unsolved,'' they typically mean that we do not have anything as sharp as AdS/CFT, where the bulk has a timelike asymptotic boundary supporting a well-defined dual CFT with a precise dictionary. For de Sitter, there is no asymptotic timelike boundary in the static patch where one can simply place the dual theory. The classic dS/CFT proposal at future infinity has familiar difficulties, including non-unitarity worries and complex conformal weights.
 
-\textbf{What this model does differently.} The framework begins with an observer's static patch and its horizon screen \(S^2\), building a net of subregion algebras on that screen. At finite cutoff those algebras are type-I regulators. The Lorentz branch, when invoked, is a scaling-limit statement about the refinement-limit observer net, and that limit may leave the regulator class. On the extracted-prime-geometric branch of Theorem~\ref{42-theorem-mathrmbw_s2-from-markov-locality-symmetry-regularity}, the realized scaling-limit cap modular action is geometric and, in the non-type-I case of interest, generally outer. That identification is \emph{not} derived from MaxEnt alone; it is exactly the explicit \textbf{T2} plus extraction-and-rigidity boundary.
+\textbf{Static-patch/horizon-screen setup.} The framework begins with an observer's static patch and its horizon screen \(S^2\), building a net of subregion algebras on that screen. At finite cutoff those algebras are type-I regulators. The Lorentz statement, when invoked, is a scaling-limit statement about the refinement-limit observer net, and that limit may leave the regulator class. On the theorem-local branch of Theorem~\ref{42-theorem-mathrmbw_s2-from-markov-locality-symmetry-regularity} where the extracted prime geometric cap pair has been emitted, the realized scaling-limit cap modular action is geometric and, in the non-type-I case of interest, generally outer. That identification is \emph{not} derived from MaxEnt alone; it is exactly the explicit \textbf{T2} plus extraction-and-rigidity boundary.
 
 This is therefore a fundamental fork away from AdS/CFT-style holography:
 


### PR DESCRIPTION
This PR closes the remaining paper-surface gap behind
`papers.compact.c.08-replace-the-bw-cap-modular-proof-sketch-with-a-full-theorem`. #14 

The live compact paper already carries the right theorem-tier structure: geometric modular flow on
caps is stated as a conditional scaling-limit theorem on the extracted prime geometric subnet, the
\(2\pi\) normalization is fixed explicitly, and the remaining UV burden is sharpened to the
realized transported cap-local system plus the transported fixed-local-collar Markov/faithfulness
datum beneath the derived carried-collar schedule. The remaining issues were companion-surface and
notation mismatches that still weakened or blurred that theorem boundary.

This change tightens those surfaces in four places:
- the compact paper introduction no longer describes the current BW lane as merely a proof-sketch
  surface; it now states that longer arguments are written in compressed proof form;
- the master synthesis fragment now keeps the BW theorem chain on the same explicit carrier
  \(\omega_\infty^{\mathrm{geo},C}\) all the way through the theorem proof and the cap-first-law
  handoff, instead of drifting to the looser \(\omega_\infty^C\) shorthand at the key formulas;
- the top-level observers synthesis paper now states the Lorentz/null-modular/Einstein lane as a
  conditional scaling-limit branch with the same explicit \textbf{T2} plus extraction-and-rigidity
  boundary used by the compact paper, instead of summarizing it as a vague continuum branch with
  unnamed technical premises;
- the observer synthesis summary now names the actual external burdens on the Lorentz/null-modular
  side: the \textbf{T2} scaling-limit scope clause, the theorem-local realized geometric cap-pair
  extraction plus ordered cut-pair rigidity on the extracted prime geometric subnet, and the
  fixed-cap stationarity step.

Net effect: the compact paper, the master synthesis fragment, and the observer synthesis surface
now describe the BW/cap-modular theorem at the same claim tier, with the same carrier, and with
the same explicit UV scaffold and remaining blockers.
