### PR TITLE
fix: tighten Majorana promotion provenance checks

### DIFF
--- a/code/particles/RESULTS_STATUS.md
+++ b/code/particles/RESULTS_STATUS.md
@@ -1,6 +1,6 @@
 # Particle Results Status
 
-Generated: `2026-04-14T11:23:03Z`
+Generated: `2026-04-14T11:38:10Z`
 
 Inputs: `P=1.63094` | `log_dim_H=1e+122` | `loops=4` | `with_hadrons=False` | `hadron_profile=suppressed`
 

--- a/code/particles/RESULTS_STATUS.md
+++ b/code/particles/RESULTS_STATUS.md
@@ -1,6 +1,6 @@
 # Particle Results Status
 
-Generated: `2026-04-14T10:36:26Z`
+Generated: `2026-04-14T11:23:03Z`
 
 Inputs: `P=1.63094` | `log_dim_H=1e+122` | `loops=4` | `with_hadrons=False` | `hadron_profile=suppressed`
 
@@ -75,8 +75,8 @@ Measured/reference values are pinned from the official Particle Data Group 2025 
 
 | Observable | Status | OPH value | Note |
 | --- | --- | --- | --- |
-| alpha21^(Maj) | theorem_grade | 153.618518 deg | Theorem-grade physical Majorana phase on the repaired shared-basis weighted-cycle surface. The readout uses the canonical Takagi congruence of the emitted symmetric cycle matrix together with the electron-row gauge `U_e1 in R_{>0}`, so it is insensitive to computational column rephasings of the intermediate unitary. |
-| alpha31^(Maj) | theorem_grade | 257.003241 deg | Same theorem surface as `alpha21^(Maj)`: emitted by the canonical Takagi congruence readout on the repaired shared-basis weighted-cycle matrix. |
+| alpha21^(Maj) | theorem_grade | 153.618518 deg | Theorem-grade physical Majorana phase on the repaired shared-basis weighted-cycle surface. The readout uses the canonical Takagi congruence of the emitted symmetric cycle matrix together with the readout-only electron-row gauge `U_e1 in R_{>0}`, so it is insensitive to computational column rephasings of the intermediate unitary. |
+| alpha31^(Maj) | theorem_grade | 257.003241 deg | Same theorem surface as `alpha21^(Maj)`: emitted by the same canonical Takagi readout after the readout-only electron-row gauge on the repaired shared-basis weighted-cycle matrix. |
 
 ## Quarks
 

--- a/code/particles/neutrino/derive_neutrino_physical_majorana_phase_theorem.py
+++ b/code/particles/neutrino/derive_neutrino_physical_majorana_phase_theorem.py
@@ -253,6 +253,26 @@ def _shared_basis_transport_checks(
     }
 
 
+def _shared_basis_branch_identity_checks(
+    weighted_cycle_matrix: np.ndarray,
+    canonical_pmns: np.ndarray,
+    charged_basis_matrix: np.ndarray,
+    shared_basis_matrix: np.ndarray,
+    u_nu_shared: np.ndarray,
+    pmns: np.ndarray,
+    u_e_left: np.ndarray,
+) -> dict[str, float]:
+    expected_shared_basis_matrix = u_e_left.conj() @ weighted_cycle_matrix @ u_e_left.conj().T
+    expected_u_nu_shared = u_e_left @ canonical_pmns
+    expected_pmns = np.conjugate(u_e_left).T @ expected_u_nu_shared
+    return {
+        "charged_basis_matrix_max_abs_delta": float(np.max(np.abs(charged_basis_matrix - weighted_cycle_matrix))),
+        "shared_basis_matrix_max_abs_delta": float(np.max(np.abs(shared_basis_matrix - expected_shared_basis_matrix))),
+        "u_nu_shared_max_abs_delta": float(np.max(np.abs(u_nu_shared - expected_u_nu_shared))),
+        "pmns_matrix_max_abs_delta": float(np.max(np.abs(pmns - expected_pmns))),
+    }
+
+
 def build_payload(
     weighted_cycle: dict[str, Any],
     shared_charged_left: dict[str, Any],
@@ -267,6 +287,8 @@ def build_payload(
         raise ValueError("shared charged-lepton left basis must be closed before Majorana phases can be emitted")
     if not basis_contract.get("orientation_preserved", False):
         raise ValueError("shared charged-lepton basis must preserve orientation")
+    if weighted_cycle.get("physical_window_status") != "pmns_and_hierarchy_repaired":
+        raise ValueError("weighted-cycle repair must close the physical PMNS window first")
     if weighted_cycle.get("pmns_row_order_for_pdg") != ["e", "mu", "tau"]:
         raise ValueError("weighted-cycle branch must already be in PDG row order")
 
@@ -311,6 +333,7 @@ def build_payload(
     }
     readout_checks = dict(majorana_readout["checks"])
     row_gauged_pmns = majorana_readout["row_gauged_pmns"]
+    shared_basis_identity_checks: dict[str, float] | None = None
 
     if shared_basis_representation is not None:
         if shared_basis_representation.get("artifact") != "oph_neutrino_weighted_cycle_shared_basis_representation":
@@ -320,9 +343,34 @@ def build_payload(
         if not bool(shared_basis_representation.get("physical_branch_closed", False)):
             raise ValueError("shared-basis weighted-cycle representation must explicitly close the physical branch")
         u_e_left = _complex_matrix(shared_charged_left["U_e_left"], "real", "imag")
-        pmns = _complex_matrix(shared_basis_representation, "pmns_matrix_real", "pmns_matrix_imag")
+        charged_basis_matrix = _complex_matrix(shared_basis_representation, "charged_basis_matrix_real", "charged_basis_matrix_imag")
+        representation_pmns = _complex_matrix(shared_basis_representation, "pmns_matrix_real", "pmns_matrix_imag")
         shared_basis_matrix = _complex_matrix(shared_basis_representation, "shared_basis_matrix_real", "shared_basis_matrix_imag")
         u_nu_shared = _complex_matrix(shared_basis_representation, "u_nu_shared_real", "u_nu_shared_imag")
+        shared_basis_identity_checks = _shared_basis_branch_identity_checks(
+            matrix,
+            canonical["pmns"],
+            charged_basis_matrix,
+            shared_basis_matrix,
+            u_nu_shared,
+            representation_pmns,
+            u_e_left,
+        )
+        if float(shared_basis_identity_checks["charged_basis_matrix_max_abs_delta"]) > 1.0e-8:
+            raise ValueError("shared-basis weighted-cycle representation must come from the same repaired weighted-cycle matrix")
+        if float(shared_basis_identity_checks["shared_basis_matrix_max_abs_delta"]) > 1.0e-8:
+            raise ValueError(
+                "shared-basis weighted-cycle representation must equal the explicit U_e_left congruence transport of the repaired weighted-cycle matrix"
+            )
+        if float(shared_basis_identity_checks["u_nu_shared_max_abs_delta"]) > 1.0e-8:
+            raise ValueError(
+                "shared-basis weighted-cycle representation must use the transported Takagi unitary of the same repaired weighted-cycle matrix"
+            )
+        if float(shared_basis_identity_checks["pmns_matrix_max_abs_delta"]) > 1.0e-8:
+            raise ValueError(
+                "shared-basis weighted-cycle representation must recover the same canonical PMNS branch as the repaired weighted-cycle matrix"
+            )
+        pmns = representation_pmns
         transport_checks = _shared_basis_transport_checks(shared_basis_matrix, u_nu_shared, pmns, u_e_left)
         if float(transport_checks["shared_basis_symmetry_max_abs"]) > 1.0e-8:
             raise ValueError("shared-basis weighted-cycle representation must remain complex symmetric")
@@ -340,7 +388,6 @@ def build_payload(
         observable_match = _observable_match(observables, weighted_cycle_observables)
         if max(observable_match.values()) > 1.0e-8:
             raise ValueError("shared-basis weighted-cycle representation must recover the weighted-cycle oscillation observables")
-        takagi_congruence_payload = dict(shared_basis_representation.get("weighted_cycle_takagi_congruence") or takagi_congruence_payload)
         public_promotion_status = "closed_on_weighted_cycle_shared_basis_representation"
         public_promotion_blocker = None
         shared_basis_use_status = "public_emission_closed_on_weighted_cycle_shared_basis_representation"
@@ -349,6 +396,7 @@ def build_payload(
             "status": shared_basis_representation.get("status"),
             "physical_branch_closed": bool(shared_basis_representation.get("physical_branch_closed", False)),
             "statement": shared_basis_representation.get("statement"),
+            "branch_identity_checks": shared_basis_identity_checks,
             "transport_checks": transport_checks,
         }
         if shared_basis_representation_path is not None:
@@ -377,7 +425,7 @@ def build_payload(
         "theorem_surface": theorem_surface,
         "statement": statement,
         "readout_convention": {
-            "stored_pmns_matrix": "pmns_matrix_* stores the canonical Takagi unitary recovered from the emitted symmetric matrix before any charged-lepton row rephasing for display.",
+            "stored_pmns_matrix": "pmns_matrix_* stores the canonical Takagi unitary on the repaired weighted-cycle branch before any charged-lepton row rephasing for Majorana readout. On the promoted path, the same matrix is revalidated against the explicit shared-basis transport data.",
             "takagi_condition": "U_PMNS^T M_nu U_PMNS = diag(m_i) with diag(m_i) in R_{>0}",
             "majorana_readout_row_gauge": "row_gauged_pmns_matrix_* = diag(exp(-i arg(U_e1)), 1, 1) * pmns_matrix_* so (row_gauged U)_{e1} in R_{>0}",
             "majorana_readout_formula": {
@@ -411,6 +459,7 @@ def build_payload(
         "pmns_observables": observables,
         "readout_checks": readout_checks,
         "weighted_cycle_observables_match": observable_match,
+        "shared_basis_identity_checks": shared_basis_identity_checks,
         "shared_basis_representation": shared_basis_representation_summary,
         "candidate_parameters": majorana_pair,
         "emitted_parameters": emitted_parameters,
@@ -418,7 +467,7 @@ def build_payload(
             "A strict readout from PMNS columns alone would remain computational-gauge dependent, because arbitrary intermediate column phases leave the oscillation observables unchanged while moving alpha21 and alpha31.",
             "The readout fixes that ambiguity by first taking the canonical Takagi congruence of the emitted symmetric weighted-cycle matrix and then applying the readout-only electron-row gauge `U_e1 in R_{>0}`.",
             (
-                "The resulting pair is promoted publicly because the repaired weighted-cycle branch is now represented explicitly on the closed shared basis and the physical PMNS path is recovered there exactly. This promotion does not identify that branch with the separate intrinsic/shared-basis PMNS diagnostic surface."
+                "The resulting pair is promoted publicly because the repaired weighted-cycle branch is now represented explicitly on the closed shared basis, rechecked directly against the same repaired weighted-cycle matrix, and the physical PMNS path is recovered there exactly. This promotion does not identify that branch with the separate intrinsic/shared-basis PMNS diagnostic surface."
                 if shared_basis_representation is not None
                 else "The resulting pair is stable under computational column rephasings of the intermediate unitary, but it is not promoted here as a public physical emission because the repaired weighted-cycle branch has not yet been represented explicitly on the closed shared basis."
             ),

--- a/code/particles/neutrino/derive_neutrino_physical_majorana_phase_theorem.py
+++ b/code/particles/neutrino/derive_neutrino_physical_majorana_phase_theorem.py
@@ -141,25 +141,46 @@ def _standard_pmns_parameters(unitary: np.ndarray) -> dict[str, float]:
     }
 
 
-def _majorana_pair_from_pmns(unitary: np.ndarray, delta_rad: float) -> dict[str, float]:
+def _row_gauge_pmns(unitary: np.ndarray) -> tuple[np.ndarray, float]:
     electron_row_phase = float(np.angle(unitary[0, 0]))
     row_gauged = np.diag([np.exp(-1j * electron_row_phase), 1.0, 1.0]) @ unitary
+    u_e1 = row_gauged[0, 0]
+    if abs(float(np.imag(u_e1))) > 1.0e-12:
+        raise ValueError("electron-row Majorana readout gauge must make U_e1 real")
+    if float(np.real(u_e1)) <= 0.0:
+        raise ValueError("electron-row Majorana readout gauge must make U_e1 positive")
+    return row_gauged, electron_row_phase
+
+
+def _majorana_readout_details(unitary: np.ndarray, delta_rad: float) -> dict[str, Any]:
+    row_gauged, electron_row_phase = _row_gauge_pmns(unitary)
     alpha21_signed = _wrap_signed_phase(2.0 * float(np.angle(row_gauged[0, 1])))
     alpha31_signed = _wrap_signed_phase(2.0 * (float(np.angle(row_gauged[0, 2])) + delta_rad))
     alpha21_mod = float(alpha21_signed % (2.0 * math.pi))
     alpha31_mod = float(alpha31_signed % (2.0 * math.pi))
     return {
-        "electron_row_gauge_phase_rad": electron_row_phase,
-        "electron_row_gauge_phase_deg": math.degrees(electron_row_phase),
-        "alpha21_rad": alpha21_signed,
-        "alpha21_deg": math.degrees(alpha21_signed),
-        "alpha21_rad_0_to_2pi": alpha21_mod,
-        "alpha21_deg_0_to_360": math.degrees(alpha21_mod),
-        "alpha31_rad": alpha31_signed,
-        "alpha31_deg": math.degrees(alpha31_signed),
-        "alpha31_rad_0_to_2pi": alpha31_mod,
-        "alpha31_deg_0_to_360": math.degrees(alpha31_mod),
+        "row_gauged_pmns": row_gauged,
+        "checks": {
+            "row_gauged_u_e1_real": float(np.real(row_gauged[0, 0])),
+            "row_gauged_u_e1_imag_abs": abs(float(np.imag(row_gauged[0, 0]))),
+        },
+        "parameters": {
+            "electron_row_gauge_phase_rad": electron_row_phase,
+            "electron_row_gauge_phase_deg": math.degrees(electron_row_phase),
+            "alpha21_rad": alpha21_signed,
+            "alpha21_deg": math.degrees(alpha21_signed),
+            "alpha21_rad_0_to_2pi": alpha21_mod,
+            "alpha21_deg_0_to_360": math.degrees(alpha21_mod),
+            "alpha31_rad": alpha31_signed,
+            "alpha31_deg": math.degrees(alpha31_signed),
+            "alpha31_rad_0_to_2pi": alpha31_mod,
+            "alpha31_deg_0_to_360": math.degrees(alpha31_mod),
+        },
     }
+
+
+def _majorana_pair_from_pmns(unitary: np.ndarray, delta_rad: float) -> dict[str, float]:
+    return dict(_majorana_readout_details(unitary, delta_rad)["parameters"])
 
 
 def _canonical_pmns_from_weighted_cycle_matrix(matrix: np.ndarray) -> dict[str, Any]:
@@ -211,6 +232,27 @@ def _observable_match(observables: dict[str, float], weighted_cycle_observables:
     }
 
 
+def _shared_basis_transport_checks(
+    shared_basis_matrix: np.ndarray,
+    u_nu_shared: np.ndarray,
+    pmns: np.ndarray,
+    u_e_left: np.ndarray,
+) -> dict[str, Any]:
+    recovered_pmns = np.conjugate(u_e_left).T @ u_nu_shared
+    shared_diagonalized = u_nu_shared.T @ shared_basis_matrix @ u_nu_shared
+    shared_offdiag = shared_diagonalized - np.diag(np.diag(shared_diagonalized))
+    shared_diag_real = np.real(np.diag(shared_diagonalized))
+    if np.any(shared_diag_real <= 0.0):
+        raise ValueError("shared-basis weighted-cycle representation must keep a positive Takagi diagonal")
+    return {
+        "shared_basis_symmetry_max_abs": float(np.max(np.abs(shared_basis_matrix - shared_basis_matrix.T))),
+        "shared_basis_diagonalized_offdiag_max_abs": float(np.max(np.abs(shared_offdiag))),
+        "shared_basis_diagonalized_imag_max_abs": float(np.max(np.abs(np.imag(np.diag(shared_diagonalized))))),
+        "shared_basis_diagonalized_real_masses": [float(x) for x in shared_diag_real.tolist()],
+        "pmns_recovery_max_abs": float(np.max(np.abs(recovered_pmns - pmns))),
+    }
+
+
 def build_payload(
     weighted_cycle: dict[str, Any],
     shared_charged_left: dict[str, Any],
@@ -232,7 +274,8 @@ def build_payload(
     canonical = _canonical_pmns_from_weighted_cycle_matrix(matrix)
     pmns = canonical["pmns"]
     observables = _standard_pmns_parameters(pmns)
-    majorana_pair = _majorana_pair_from_pmns(pmns, observables["delta_rad"])
+    majorana_readout = _majorana_readout_details(pmns, observables["delta_rad"])
+    majorana_pair = dict(majorana_readout["parameters"])
     weighted_cycle_observables = dict(weighted_cycle["pmns_observables"])
     observable_match = _observable_match(observables, weighted_cycle_observables)
     if max(observable_match.values()) > 1.0e-8:
@@ -266,25 +309,34 @@ def build_payload(
         "diagonalized_imag_max_abs": canonical["diagonalized_imag_max_abs"],
         "diagonalized_offdiag_max_abs": canonical["diagonalized_offdiag_max_abs"],
     }
+    readout_checks = dict(majorana_readout["checks"])
+    row_gauged_pmns = majorana_readout["row_gauged_pmns"]
 
     if shared_basis_representation is not None:
         if shared_basis_representation.get("artifact") != "oph_neutrino_weighted_cycle_shared_basis_representation":
             raise ValueError("unexpected shared-basis weighted-cycle artifact id")
+        if shared_basis_representation.get("status") != "theorem_grade_emitted":
+            raise ValueError("shared-basis weighted-cycle representation must already be theorem-grade emitted")
         if not bool(shared_basis_representation.get("physical_branch_closed", False)):
             raise ValueError("shared-basis weighted-cycle representation must explicitly close the physical branch")
-        transport_checks = dict(shared_basis_representation.get("transport_checks") or {})
-        if transport_checks:
-            if float(transport_checks.get("shared_basis_symmetry_max_abs", 0.0)) > 1.0e-8:
-                raise ValueError("shared-basis weighted-cycle representation must remain complex symmetric")
-            if float(transport_checks.get("shared_basis_diagonalized_offdiag_max_abs", 0.0)) > 1.0e-8:
-                raise ValueError("shared-basis weighted-cycle representation must diagonalize exactly")
-            if float(transport_checks.get("shared_basis_diagonalized_imag_max_abs", 0.0)) > 1.0e-8:
-                raise ValueError("shared-basis weighted-cycle representation must keep a real positive Takagi diagonal")
-            if float(transport_checks.get("pmns_recovery_max_abs", 0.0)) > 1.0e-8:
-                raise ValueError("shared-basis weighted-cycle representation must recover the physical PMNS exactly")
+        u_e_left = _complex_matrix(shared_charged_left["U_e_left"], "real", "imag")
         pmns = _complex_matrix(shared_basis_representation, "pmns_matrix_real", "pmns_matrix_imag")
+        shared_basis_matrix = _complex_matrix(shared_basis_representation, "shared_basis_matrix_real", "shared_basis_matrix_imag")
+        u_nu_shared = _complex_matrix(shared_basis_representation, "u_nu_shared_real", "u_nu_shared_imag")
+        transport_checks = _shared_basis_transport_checks(shared_basis_matrix, u_nu_shared, pmns, u_e_left)
+        if float(transport_checks["shared_basis_symmetry_max_abs"]) > 1.0e-8:
+            raise ValueError("shared-basis weighted-cycle representation must remain complex symmetric")
+        if float(transport_checks["shared_basis_diagonalized_offdiag_max_abs"]) > 1.0e-8:
+            raise ValueError("shared-basis weighted-cycle representation must diagonalize exactly")
+        if float(transport_checks["shared_basis_diagonalized_imag_max_abs"]) > 1.0e-8:
+            raise ValueError("shared-basis weighted-cycle representation must keep a real positive Takagi diagonal")
+        if float(transport_checks["pmns_recovery_max_abs"]) > 1.0e-8:
+            raise ValueError("shared-basis weighted-cycle representation must recover the physical PMNS exactly")
         observables = _standard_pmns_parameters(pmns)
-        majorana_pair = _majorana_pair_from_pmns(pmns, observables["delta_rad"])
+        majorana_readout = _majorana_readout_details(pmns, observables["delta_rad"])
+        majorana_pair = dict(majorana_readout["parameters"])
+        readout_checks = dict(majorana_readout["checks"])
+        row_gauged_pmns = majorana_readout["row_gauged_pmns"]
         observable_match = _observable_match(observables, weighted_cycle_observables)
         if max(observable_match.values()) > 1.0e-8:
             raise ValueError("shared-basis weighted-cycle representation must recover the weighted-cycle oscillation observables")
@@ -325,9 +377,13 @@ def build_payload(
         "theorem_surface": theorem_surface,
         "statement": statement,
         "readout_convention": {
+            "stored_pmns_matrix": "pmns_matrix_* stores the canonical Takagi unitary recovered from the emitted symmetric matrix before any charged-lepton row rephasing for display.",
             "takagi_condition": "U_PMNS^T M_nu U_PMNS = diag(m_i) with diag(m_i) in R_{>0}",
-            "row_gauge": "U_e1 in R_{>0}",
-            "phase_parameterization": "U_PMNS = V(theta12, theta23, theta13, delta_PMNS) * diag(1, exp(i alpha21 / 2), exp(i alpha31 / 2))",
+            "majorana_readout_row_gauge": "row_gauged_pmns_matrix_* = diag(exp(-i arg(U_e1)), 1, 1) * pmns_matrix_* so (row_gauged U)_{e1} in R_{>0}",
+            "majorana_readout_formula": {
+                "alpha21": "2 arg((row_gauged U)_{e2})",
+                "alpha31": "2 (arg((row_gauged U)_{e3}) + delta_PMNS)",
+            },
         },
         "public_promotion_status": public_promotion_status,
         "public_promotion_blocker": public_promotion_blocker,
@@ -350,14 +406,17 @@ def build_payload(
         "takagi_congruence": takagi_congruence_payload,
         "pmns_matrix_real": np.real(pmns).tolist(),
         "pmns_matrix_imag": np.imag(pmns).tolist(),
+        "row_gauged_pmns_matrix_real": np.real(row_gauged_pmns).tolist(),
+        "row_gauged_pmns_matrix_imag": np.imag(row_gauged_pmns).tolist(),
         "pmns_observables": observables,
+        "readout_checks": readout_checks,
         "weighted_cycle_observables_match": observable_match,
         "shared_basis_representation": shared_basis_representation_summary,
         "candidate_parameters": majorana_pair,
         "emitted_parameters": emitted_parameters,
         "notes": [
             "A strict readout from PMNS columns alone would remain computational-gauge dependent, because arbitrary intermediate column phases leave the oscillation observables unchanged while moving alpha21 and alpha31.",
-            "The readout fixes that ambiguity by reading the phases only after the canonical Takagi congruence of the emitted symmetric weighted-cycle matrix.",
+            "The readout fixes that ambiguity by first taking the canonical Takagi congruence of the emitted symmetric weighted-cycle matrix and then applying the readout-only electron-row gauge `U_e1 in R_{>0}`.",
             (
                 "The resulting pair is promoted publicly because the repaired weighted-cycle branch is now represented explicitly on the closed shared basis and the physical PMNS path is recovered there exactly. This promotion does not identify that branch with the separate intrinsic/shared-basis PMNS diagnostic surface."
                 if shared_basis_representation is not None

--- a/code/particles/neutrino/test_physical_majorana_phase_theorem.py
+++ b/code/particles/neutrino/test_physical_majorana_phase_theorem.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import copy
 import importlib.util
 import json
 import pathlib
@@ -58,6 +59,7 @@ def test_weighted_cycle_majorana_phase_candidate_is_stable_but_not_publicly_prom
     assert "represented explicitly on the closed shared same-label basis" in payload["public_promotion_blocker"]
     assert "phase_parameterization" not in payload["readout_convention"]
     assert "majorana_readout_row_gauge" in payload["readout_convention"]
+    assert payload["shared_basis_identity_checks"] is None
     assert payload["readout_checks"]["row_gauged_u_e1_imag_abs"] < 1.0e-12
     assert payload["readout_checks"]["row_gauged_u_e1_real"] > 0.0
     assert payload["takagi_congruence"]["diagonalized_offdiag_max_abs"] < 1.0e-12
@@ -94,9 +96,11 @@ def test_weighted_cycle_majorana_phase_theorem_promotes_when_shared_basis_repres
     assert payload["source_artifacts"]["weighted_cycle_branch"] == "code/particles/runs/neutrino/neutrino_weighted_cycle_repair.json"
     assert payload["source_artifacts"]["shared_charged_left_basis"] == "code/particles/runs/neutrino/shared_charged_lepton_left_basis.json"
     assert payload["source_artifacts"]["shared_basis_representation"] == "code/particles/runs/neutrino/neutrino_weighted_cycle_shared_basis_representation.json"
-    assert payload["pmns_matrix_real"][0][0] > 0.0
-    assert payload["pmns_matrix_real"][0][1] > 0.0
-    assert payload["pmns_matrix_real"][0][2] > 0.0
+    assert payload["shared_basis_identity_checks"] is not None
+    assert payload["shared_basis_identity_checks"]["charged_basis_matrix_max_abs_delta"] < 1.0e-12
+    assert payload["shared_basis_identity_checks"]["shared_basis_matrix_max_abs_delta"] < 1.0e-12
+    assert payload["shared_basis_identity_checks"]["u_nu_shared_max_abs_delta"] < 1.0e-12
+    assert payload["shared_basis_identity_checks"]["pmns_matrix_max_abs_delta"] < 1.0e-12
     assert payload["emitted_parameters"] is not None
     assert "phase_parameterization" not in payload["readout_convention"]
     assert "majorana_readout_row_gauge" in payload["readout_convention"]
@@ -123,11 +127,40 @@ def test_shared_basis_majorana_promotion_revalidates_transport_even_without_decl
     representation_payload["transport_checks"] = {}
     representation_payload["shared_basis_matrix_real"][0][1] += 1.0e-4
 
-    with pytest.raises(ValueError, match="must remain complex symmetric"):
+    with pytest.raises(ValueError, match="explicit U_e_left congruence transport"):
         module.build_payload(
             json.loads(WEIGHTED_CYCLE.read_text(encoding="utf-8")),
             json.loads(SHARED_CHARGED_LEFT.read_text(encoding="utf-8")),
             representation_payload,
+            weighted_cycle_path=WEIGHTED_CYCLE,
+            shared_charged_left_path=SHARED_CHARGED_LEFT,
+            shared_basis_representation_path=ROOT / "particles" / "runs" / "neutrino" / "neutrino_weighted_cycle_shared_basis_representation.json",
+        )
+
+
+def test_shared_basis_majorana_promotion_requires_same_weighted_cycle_branch() -> None:
+    module = _load_module()
+    representation_module = _load_representation_module()
+    weighted_cycle = json.loads(WEIGHTED_CYCLE.read_text(encoding="utf-8"))
+    shifted_weighted_cycle = copy.deepcopy(weighted_cycle)
+    shifted_weighted_cycle["repaired_cycle_matrix_real"][0][0] += 1.0e-4
+    shifted_matrix = np.array(shifted_weighted_cycle["repaired_cycle_matrix_real"], dtype=float) + 1j * np.array(
+        shifted_weighted_cycle["repaired_cycle_matrix_imag"], dtype=float
+    )
+    shifted_pmns = module._canonical_pmns_from_weighted_cycle_matrix(shifted_matrix)["pmns"]
+    shifted_weighted_cycle["pmns_observables"] = module._standard_pmns_parameters(shifted_pmns)
+    shifted_representation_payload = representation_module.build_payload(
+        shifted_weighted_cycle,
+        json.loads(SHARED_CHARGED_LEFT.read_text(encoding="utf-8")),
+        weighted_cycle_path=WEIGHTED_CYCLE,
+        shared_charged_left_path=SHARED_CHARGED_LEFT,
+    )
+
+    with pytest.raises(ValueError, match="same repaired weighted-cycle matrix"):
+        module.build_payload(
+            weighted_cycle,
+            json.loads(SHARED_CHARGED_LEFT.read_text(encoding="utf-8")),
+            shifted_representation_payload,
             weighted_cycle_path=WEIGHTED_CYCLE,
             shared_charged_left_path=SHARED_CHARGED_LEFT,
             shared_basis_representation_path=ROOT / "particles" / "runs" / "neutrino" / "neutrino_weighted_cycle_shared_basis_representation.json",

--- a/code/particles/neutrino/test_physical_majorana_phase_theorem.py
+++ b/code/particles/neutrino/test_physical_majorana_phase_theorem.py
@@ -8,6 +8,7 @@ import json
 import pathlib
 
 import numpy as np
+import pytest
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
@@ -55,6 +56,10 @@ def test_weighted_cycle_majorana_phase_candidate_is_stable_but_not_publicly_prom
     assert payload["public_surface_candidate_allowed"] is False
     assert payload["public_promotion_status"] == "blocked_missing_shared_basis_representation"
     assert "represented explicitly on the closed shared same-label basis" in payload["public_promotion_blocker"]
+    assert "phase_parameterization" not in payload["readout_convention"]
+    assert "majorana_readout_row_gauge" in payload["readout_convention"]
+    assert payload["readout_checks"]["row_gauged_u_e1_imag_abs"] < 1.0e-12
+    assert payload["readout_checks"]["row_gauged_u_e1_real"] > 0.0
     assert payload["takagi_congruence"]["diagonalized_offdiag_max_abs"] < 1.0e-12
     assert payload["takagi_congruence"]["diagonalized_imag_max_abs"] < 1.0e-12
     assert abs(payload["weighted_cycle_observables_match"]["delta_deg_abs_delta"]) < 1.0e-10
@@ -93,8 +98,40 @@ def test_weighted_cycle_majorana_phase_theorem_promotes_when_shared_basis_repres
     assert payload["pmns_matrix_real"][0][1] > 0.0
     assert payload["pmns_matrix_real"][0][2] > 0.0
     assert payload["emitted_parameters"] is not None
+    assert "phase_parameterization" not in payload["readout_convention"]
+    assert "majorana_readout_row_gauge" in payload["readout_convention"]
+    row_gauged = np.array(payload["row_gauged_pmns_matrix_real"], dtype=float) + 1j * np.array(
+        payload["row_gauged_pmns_matrix_imag"], dtype=float
+    )
+    assert payload["readout_checks"]["row_gauged_u_e1_imag_abs"] < 1.0e-12
+    assert payload["readout_checks"]["row_gauged_u_e1_real"] > 0.0
+    assert abs(np.imag(row_gauged[0, 0])) < 1.0e-12
+    assert np.real(row_gauged[0, 0]) > 0.0
     assert abs(payload["emitted_parameters"]["alpha21_deg_0_to_360"] - 153.6185177794357) < 1.0e-9
     assert abs(payload["emitted_parameters"]["alpha31_deg_0_to_360"] - 257.0032408220805) < 1.0e-9
+
+
+def test_shared_basis_majorana_promotion_revalidates_transport_even_without_declared_checks() -> None:
+    module = _load_module()
+    representation_module = _load_representation_module()
+    representation_payload = representation_module.build_payload(
+        json.loads(WEIGHTED_CYCLE.read_text(encoding="utf-8")),
+        json.loads(SHARED_CHARGED_LEFT.read_text(encoding="utf-8")),
+        weighted_cycle_path=WEIGHTED_CYCLE,
+        shared_charged_left_path=SHARED_CHARGED_LEFT,
+    )
+    representation_payload["transport_checks"] = {}
+    representation_payload["shared_basis_matrix_real"][0][1] += 1.0e-4
+
+    with pytest.raises(ValueError, match="must remain complex symmetric"):
+        module.build_payload(
+            json.loads(WEIGHTED_CYCLE.read_text(encoding="utf-8")),
+            json.loads(SHARED_CHARGED_LEFT.read_text(encoding="utf-8")),
+            representation_payload,
+            weighted_cycle_path=WEIGHTED_CYCLE,
+            shared_charged_left_path=SHARED_CHARGED_LEFT,
+            shared_basis_representation_path=ROOT / "particles" / "runs" / "neutrino" / "neutrino_weighted_cycle_shared_basis_representation.json",
+        )
 
 
 def test_naive_pmns_only_majorana_readout_is_column_phase_dependent() -> None:

--- a/code/particles/results_status.json
+++ b/code/particles/results_status.json
@@ -99,7 +99,7 @@
       "unit": "eV^2"
     }
   ],
-  "generated_utc": "2026-04-14T11:23:03Z",
+  "generated_utc": "2026-04-14T11:38:10Z",
   "inputs": {
     "P": 1.63094,
     "hadron_profile": "suppressed",

--- a/code/particles/results_status.json
+++ b/code/particles/results_status.json
@@ -99,7 +99,7 @@
       "unit": "eV^2"
     }
   ],
-  "generated_utc": "2026-04-14T10:36:26Z",
+  "generated_utc": "2026-04-14T11:23:03Z",
   "inputs": {
     "P": 1.63094,
     "hadron_profile": "suppressed",
@@ -109,7 +109,7 @@
   },
   "majorana_rows": [
     {
-      "note": "Theorem-grade physical Majorana phase on the repaired shared-basis weighted-cycle surface. The readout uses the canonical Takagi congruence of the emitted symmetric cycle matrix together with the electron-row gauge `U_e1 in R_{>0}`, so it is insensitive to computational column rephasings of the intermediate unitary.",
+      "note": "Theorem-grade physical Majorana phase on the repaired shared-basis weighted-cycle surface. The readout uses the canonical Takagi congruence of the emitted symmetric cycle matrix together with the readout-only electron-row gauge `U_e1 in R_{>0}`, so it is insensitive to computational column rephasings of the intermediate unitary.",
       "observable": "alpha21^(Maj)",
       "observable_id": "alpha21_majorana",
       "prediction_display": "153.618518 deg",
@@ -118,7 +118,7 @@
       "unit": "deg"
     },
     {
-      "note": "Same theorem surface as `alpha21^(Maj)`: emitted by the canonical Takagi congruence readout on the repaired shared-basis weighted-cycle matrix.",
+      "note": "Same theorem surface as `alpha21^(Maj)`: emitted by the same canonical Takagi readout after the readout-only electron-row gauge on the repaired shared-basis weighted-cycle matrix.",
       "observable": "alpha31^(Maj)",
       "observable_id": "alpha31_majorana",
       "prediction_display": "257.003241 deg",

--- a/code/particles/runs/neutrino/neutrino_physical_majorana_phase_theorem.json
+++ b/code/particles/runs/neutrino/neutrino_physical_majorana_phase_theorem.json
@@ -37,11 +37,11 @@
     "electron_row_gauge_phase_deg": 79.72751605060557,
     "electron_row_gauge_phase_rad": 1.3915076595196934
   },
-  "generated_utc": "2026-04-14T11:23:02Z",
+  "generated_utc": "2026-04-14T11:38:10Z",
   "notes": [
     "A strict readout from PMNS columns alone would remain computational-gauge dependent, because arbitrary intermediate column phases leave the oscillation observables unchanged while moving alpha21 and alpha31.",
     "The readout fixes that ambiguity by first taking the canonical Takagi congruence of the emitted symmetric weighted-cycle matrix and then applying the readout-only electron-row gauge `U_e1 in R_{>0}`.",
-    "The resulting pair is promoted publicly because the repaired weighted-cycle branch is now represented explicitly on the closed shared basis and the physical PMNS path is recovered there exactly. This promotion does not identify that branch with the separate intrinsic/shared-basis PMNS diagnostic surface."
+    "The resulting pair is promoted publicly because the repaired weighted-cycle branch is now represented explicitly on the closed shared basis, rechecked directly against the same repaired weighted-cycle matrix, and the physical PMNS path is recovered there exactly. This promotion does not identify that branch with the separate intrinsic/shared-basis PMNS diagnostic surface."
   ],
   "pmns_matrix_imag": [
     [
@@ -102,7 +102,7 @@
       "alpha31": "2 (arg((row_gauged U)_{e3}) + delta_PMNS)"
     },
     "majorana_readout_row_gauge": "row_gauged_pmns_matrix_* = diag(exp(-i arg(U_e1)), 1, 1) * pmns_matrix_* so (row_gauged U)_{e1} in R_{>0}",
-    "stored_pmns_matrix": "pmns_matrix_* stores the canonical Takagi unitary recovered from the emitted symmetric matrix before any charged-lepton row rephasing for display.",
+    "stored_pmns_matrix": "pmns_matrix_* stores the canonical Takagi unitary on the repaired weighted-cycle branch before any charged-lepton row rephasing for Majorana readout. On the promoted path, the same matrix is revalidated against the explicit shared-basis transport data.",
     "takagi_condition": "U_PMNS^T M_nu U_PMNS = diag(m_i) with diag(m_i) in R_{>0}"
   },
   "row_gauged_pmns_matrix_imag": [
@@ -139,8 +139,20 @@
       0.10373135846276055
     ]
   ],
+  "shared_basis_identity_checks": {
+    "charged_basis_matrix_max_abs_delta": 0.0,
+    "pmns_matrix_max_abs_delta": 1.4392811567525336e-15,
+    "shared_basis_matrix_max_abs_delta": 2.4532694666933987e-18,
+    "u_nu_shared_max_abs_delta": 1.894101977298092e-15
+  },
   "shared_basis_representation": {
     "artifact": "oph_neutrino_weighted_cycle_shared_basis_representation",
+    "branch_identity_checks": {
+      "charged_basis_matrix_max_abs_delta": 0.0,
+      "pmns_matrix_max_abs_delta": 1.4392811567525336e-15,
+      "shared_basis_matrix_max_abs_delta": 2.4532694666933987e-18,
+      "u_nu_shared_max_abs_delta": 1.894101977298092e-15
+    },
     "physical_branch_closed": true,
     "source_path": "code/particles/runs/neutrino/neutrino_weighted_cycle_shared_basis_representation.json",
     "statement": "The repaired weighted-cycle Majorana matrix is transported exactly into the closed shared same-label basis, and the physical PMNS surface is recovered there as U_e_left^dagger * U_nu_shared. This closes the weighted-cycle theorem lane on the shared basis without identifying it with the separate intrinsic/shared-basis PMNS diagnostic surface.",
@@ -167,26 +179,26 @@
   "status": "theorem_grade_emitted",
   "takagi_congruence": {
     "congruence_half_angles_deg": [
-      -79.72751605060562,
-      23.46322505967657,
-      -82.64852414714792
+      -79.72751605060567,
+      23.463225059676475,
+      -82.64852414714794
     ],
     "congruence_half_angles_rad": [
-      -1.391507659519694,
-      0.40951053042779917,
-      -1.4424888682817696
+      -1.391507659519695,
+      0.4095105304277975,
+      -1.4424888682817698
     ],
-    "diagonalized_imag_max_abs": 8.673617379884035e-18,
-    "diagonalized_offdiag_max_abs": 4.437129678412874e-17,
+    "diagonalized_imag_max_abs": 6.071532165918825e-18,
+    "diagonalized_offdiag_max_abs": 1.780205822318556e-17,
     "diagonalized_real_masses": [
       0.01012630148527337,
       0.011302414501969324,
-      0.030791424088410596
+      0.030791424088410606
     ],
-    "phase_relation_offdiag_max_abs": 4.1111994833554825e-15,
+    "phase_relation_offdiag_max_abs": 1.5553031891404223e-15,
     "singular_values": [
-      0.010126301485273374,
-      0.011302414501969326,
+      0.010126301485273378,
+      0.01130241450196933,
       0.03079142408841062
     ]
   },

--- a/code/particles/runs/neutrino/neutrino_physical_majorana_phase_theorem.json
+++ b/code/particles/runs/neutrino/neutrino_physical_majorana_phase_theorem.json
@@ -37,10 +37,10 @@
     "electron_row_gauge_phase_deg": 79.72751605060557,
     "electron_row_gauge_phase_rad": 1.3915076595196934
   },
-  "generated_utc": "2026-04-14T10:36:26Z",
+  "generated_utc": "2026-04-14T11:23:02Z",
   "notes": [
     "A strict readout from PMNS columns alone would remain computational-gauge dependent, because arbitrary intermediate column phases leave the oscillation observables unchanged while moving alpha21 and alpha31.",
-    "The readout fixes that ambiguity by reading the phases only after the canonical Takagi congruence of the emitted symmetric weighted-cycle matrix.",
+    "The readout fixes that ambiguity by first taking the canonical Takagi congruence of the emitted symmetric weighted-cycle matrix and then applying the readout-only electron-row gauge `U_e1 in R_{>0}`.",
     "The resulting pair is promoted publicly because the repaired weighted-cycle branch is now represented explicitly on the closed shared basis and the physical PMNS path is recovered there exactly. This promotion does not identify that branch with the separate intrinsic/shared-basis PMNS diagnostic surface."
   ],
   "pmns_matrix_imag": [
@@ -78,7 +78,7 @@
     ]
   ],
   "pmns_observables": {
-    "J": -0.027531156135653618,
+    "J": -0.027531156135653614,
     "delta_deg": 305.58061231449767,
     "delta_rad": 5.333387815148314,
     "theta12_deg": 34.22590463180999,
@@ -92,11 +92,53 @@
   "public_promotion_blocker": null,
   "public_promotion_status": "closed_on_weighted_cycle_shared_basis_representation",
   "public_surface_candidate_allowed": true,
+  "readout_checks": {
+    "row_gauged_u_e1_imag_abs": 2.7755575615628914e-17,
+    "row_gauged_u_e1_real": 0.8173425625636905
+  },
   "readout_convention": {
-    "phase_parameterization": "U_PMNS = V(theta12, theta23, theta13, delta_PMNS) * diag(1, exp(i alpha21 / 2), exp(i alpha31 / 2))",
-    "row_gauge": "U_e1 in R_{>0}",
+    "majorana_readout_formula": {
+      "alpha21": "2 arg((row_gauged U)_{e2})",
+      "alpha31": "2 (arg((row_gauged U)_{e3}) + delta_PMNS)"
+    },
+    "majorana_readout_row_gauge": "row_gauged_pmns_matrix_* = diag(exp(-i arg(U_e1)), 1, 1) * pmns_matrix_* so (row_gauged U)_{e1} in R_{>0}",
+    "stored_pmns_matrix": "pmns_matrix_* stores the canonical Takagi unitary recovered from the emitted symmetric matrix before any charged-lepton row rephasing for display.",
     "takagi_condition": "U_PMNS^T M_nu U_PMNS = diag(m_i) with diag(m_i) in R_{>0}"
   },
+  "row_gauged_pmns_matrix_imag": [
+    [
+      -2.7755575615628914e-17,
+      -0.5413360354678765,
+      0.007696123391525533
+    ],
+    [
+      -0.31350036679223126,
+      0.3592600183629337,
+      0.7538755297968618
+    ],
+    [
+      -0.12886571615680517,
+      0.45971242842462084,
+      -0.630595766022623
+    ]
+  ],
+  "row_gauged_pmns_matrix_real": [
+    [
+      0.8173425625636905,
+      -0.12687693300356018,
+      0.15082919373282172
+    ],
+    [
+      0.2886616009610346,
+      0.3471946575181609,
+      -0.021255463343815444
+    ],
+    [
+      0.3657003729461609,
+      0.479489450065568,
+      0.10373135846276055
+    ]
+  ],
   "shared_basis_representation": {
     "artifact": "oph_neutrino_weighted_cycle_shared_basis_representation",
     "physical_branch_closed": true,
@@ -104,8 +146,8 @@
     "statement": "The repaired weighted-cycle Majorana matrix is transported exactly into the closed shared same-label basis, and the physical PMNS surface is recovered there as U_e_left^dagger * U_nu_shared. This closes the weighted-cycle theorem lane on the shared basis without identifying it with the separate intrinsic/shared-basis PMNS diagnostic surface.",
     "status": "theorem_grade_emitted",
     "transport_checks": {
-      "pmns_recovery_max_abs": 4.494775313252277e-16,
-      "shared_basis_diagonalized_imag_max_abs": 9.974659986866641e-18,
+      "pmns_recovery_max_abs": 1.3877787807814457e-17,
+      "shared_basis_diagonalized_imag_max_abs": 1.0842021724855044e-17,
       "shared_basis_diagonalized_offdiag_max_abs": 4.5561138054344816e-17,
       "shared_basis_diagonalized_real_masses": [
         0.010126301485273364,
@@ -151,7 +193,7 @@
   "theorem_object": "physical_majorana_phase_pair",
   "theorem_surface": "weighted_cycle_shared_basis_transport",
   "weighted_cycle_observables_match": {
-    "J_abs_delta": 1.0061396160665481e-16,
+    "J_abs_delta": 1.0408340855860843e-16,
     "delta_deg_abs_delta": 2.8421709430404007e-13,
     "theta12_deg_abs_delta": 3.552713678800501e-14,
     "theta13_deg_abs_delta": 2.4868995751603507e-14,

--- a/code/particles/runs/status/status_table_forward_current.json
+++ b/code/particles/runs/status/status_table_forward_current.json
@@ -100,7 +100,7 @@
       "unit": "eV^2"
     }
   ],
-  "generated_utc": "2026-04-14T11:23:03Z",
+  "generated_utc": "2026-04-14T11:38:10Z",
   "inputs": {
     "P": 1.63094,
     "hadron_profile": "suppressed",

--- a/code/particles/runs/status/status_table_forward_current.json
+++ b/code/particles/runs/status/status_table_forward_current.json
@@ -100,7 +100,7 @@
       "unit": "eV^2"
     }
   ],
-  "generated_utc": "2026-04-14T10:36:26Z",
+  "generated_utc": "2026-04-14T11:23:03Z",
   "inputs": {
     "P": 1.63094,
     "hadron_profile": "suppressed",
@@ -110,7 +110,7 @@
   },
   "majorana_rows": [
     {
-      "note": "Theorem-grade physical Majorana phase on the repaired shared-basis weighted-cycle surface. The readout uses the canonical Takagi congruence of the emitted symmetric cycle matrix together with the electron-row gauge `U_e1 in R_{>0}`, so it is insensitive to computational column rephasings of the intermediate unitary.",
+      "note": "Theorem-grade physical Majorana phase on the repaired shared-basis weighted-cycle surface. The readout uses the canonical Takagi congruence of the emitted symmetric cycle matrix together with the readout-only electron-row gauge `U_e1 in R_{>0}`, so it is insensitive to computational column rephasings of the intermediate unitary.",
       "observable": "alpha21^(Maj)",
       "observable_id": "alpha21_majorana",
       "prediction_display": "153.618518 deg",
@@ -119,7 +119,7 @@
       "unit": "deg"
     },
     {
-      "note": "Same theorem surface as `alpha21^(Maj)`: emitted by the canonical Takagi congruence readout on the repaired shared-basis weighted-cycle matrix.",
+      "note": "Same theorem surface as `alpha21^(Maj)`: emitted by the same canonical Takagi readout after the readout-only electron-row gauge on the repaired shared-basis weighted-cycle matrix.",
       "observable": "alpha31^(Maj)",
       "observable_id": "alpha31_majorana",
       "prediction_display": "257.003241 deg",

--- a/code/particles/scripts/build_results_status_table.py
+++ b/code/particles/scripts/build_results_status_table.py
@@ -953,7 +953,7 @@ def build_neutrino_oscillation_comparison_rows(surface_state: Dict[str, Any]) ->
 
 
 def _majorana_emitted_degrees(theorem: Dict[str, Any]) -> tuple[float, float] | None:
-    emitted = dict(theorem.get("emitted_parameters") or theorem.get("candidate_parameters") or {})
+    emitted = dict(theorem.get("emitted_parameters") or {})
     try:
         alpha21 = float(emitted["alpha21_deg_0_to_360"])
         alpha31 = float(emitted["alpha31_deg_0_to_360"])

--- a/code/particles/scripts/build_results_status_table.py
+++ b/code/particles/scripts/build_results_status_table.py
@@ -952,6 +952,16 @@ def build_neutrino_oscillation_comparison_rows(surface_state: Dict[str, Any]) ->
     return rows
 
 
+def _majorana_emitted_degrees(theorem: Dict[str, Any]) -> tuple[float, float] | None:
+    emitted = dict(theorem.get("emitted_parameters") or theorem.get("candidate_parameters") or {})
+    try:
+        alpha21 = float(emitted["alpha21_deg_0_to_360"])
+        alpha31 = float(emitted["alpha31_deg_0_to_360"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    return alpha21, alpha31
+
+
 def build_majorana_phase_surface_rows(surface_state: Dict[str, Any]) -> List[Dict[str, Any]]:
     active = dict(surface_state["active_local_public_candidates"])
     if not active.get("neutrino_repaired_branch"):
@@ -967,34 +977,42 @@ def build_majorana_phase_surface_rows(surface_state: Dict[str, Any]) -> List[Dic
         and theorem.get("status") == "theorem_grade_emitted"
         and theorem.get("public_surface_candidate_allowed", False)
     ):
-        emitted = dict(theorem.get("emitted_parameters") or theorem.get("candidate_parameters") or {})
-        alpha21_note = (
-            "Theorem-grade physical Majorana phase on the repaired shared-basis weighted-cycle surface. "
-            "The readout uses the canonical Takagi congruence of the emitted symmetric cycle matrix together with the readout-only electron-row gauge `U_e1 in R_{>0}`, so it is insensitive to computational column rephasings of the intermediate unitary."
-        )
-        alpha31_note = (
-            "Same theorem surface as `alpha21^(Maj)`: emitted by the same canonical Takagi readout after the readout-only electron-row gauge on the repaired shared-basis weighted-cycle matrix."
-        )
-        return [
-            {
-                "observable_id": "alpha21_majorana",
-                "observable": "alpha21^(Maj)",
-                "status": "theorem_grade",
-                "prediction_value": float(emitted["alpha21_deg_0_to_360"]),
-                "prediction_display": format_observable_value(float(emitted["alpha21_deg_0_to_360"]), "deg"),
-                "unit": "deg",
-                "note": alpha21_note,
-            },
-            {
-                "observable_id": "alpha31_majorana",
-                "observable": "alpha31^(Maj)",
-                "status": "theorem_grade",
-                "prediction_value": float(emitted["alpha31_deg_0_to_360"]),
-                "prediction_display": format_observable_value(float(emitted["alpha31_deg_0_to_360"]), "deg"),
-                "unit": "deg",
-                "note": alpha31_note,
-            },
-        ]
+        emitted = _majorana_emitted_degrees(theorem)
+        if emitted is None:
+            theorem = dict(theorem)
+            theorem["public_promotion_blocker"] = (
+                "The promoted Majorana theorem artifact is incomplete on disk: expected numeric emitted parameters "
+                "`alpha21_deg_0_to_360` and `alpha31_deg_0_to_360`."
+            )
+        else:
+            alpha21_deg, alpha31_deg = emitted
+            alpha21_note = (
+                "Theorem-grade physical Majorana phase on the repaired shared-basis weighted-cycle surface. "
+                "The readout uses the canonical Takagi congruence of the emitted symmetric cycle matrix together with the readout-only electron-row gauge `U_e1 in R_{>0}`, so it is insensitive to computational column rephasings of the intermediate unitary."
+            )
+            alpha31_note = (
+                "Same theorem surface as `alpha21^(Maj)`: emitted by the same canonical Takagi readout after the readout-only electron-row gauge on the repaired shared-basis weighted-cycle matrix."
+            )
+            return [
+                {
+                    "observable_id": "alpha21_majorana",
+                    "observable": "alpha21^(Maj)",
+                    "status": "theorem_grade",
+                    "prediction_value": alpha21_deg,
+                    "prediction_display": format_observable_value(alpha21_deg, "deg"),
+                    "unit": "deg",
+                    "note": alpha21_note,
+                },
+                {
+                    "observable_id": "alpha31_majorana",
+                    "observable": "alpha31^(Maj)",
+                    "status": "theorem_grade",
+                    "prediction_value": alpha31_deg,
+                    "prediction_display": format_observable_value(alpha31_deg, "deg"),
+                    "unit": "deg",
+                    "note": alpha31_note,
+                },
+            ]
 
     if theorem is None:
         alpha21_note = (

--- a/code/particles/scripts/build_results_status_table.py
+++ b/code/particles/scripts/build_results_status_table.py
@@ -970,10 +970,10 @@ def build_majorana_phase_surface_rows(surface_state: Dict[str, Any]) -> List[Dic
         emitted = dict(theorem.get("emitted_parameters") or theorem.get("candidate_parameters") or {})
         alpha21_note = (
             "Theorem-grade physical Majorana phase on the repaired shared-basis weighted-cycle surface. "
-            "The readout uses the canonical Takagi congruence of the emitted symmetric cycle matrix together with the electron-row gauge `U_e1 in R_{>0}`, so it is insensitive to computational column rephasings of the intermediate unitary."
+            "The readout uses the canonical Takagi congruence of the emitted symmetric cycle matrix together with the readout-only electron-row gauge `U_e1 in R_{>0}`, so it is insensitive to computational column rephasings of the intermediate unitary."
         )
         alpha31_note = (
-            "Same theorem surface as `alpha21^(Maj)`: emitted by the canonical Takagi congruence readout on the repaired shared-basis weighted-cycle matrix."
+            "Same theorem surface as `alpha21^(Maj)`: emitted by the same canonical Takagi readout after the readout-only electron-row gauge on the repaired shared-basis weighted-cycle matrix."
         )
         return [
             {

--- a/code/particles/test_results_status_majorana_surface.py
+++ b/code/particles/test_results_status_majorana_surface.py
@@ -103,6 +103,10 @@ def test_majorana_phase_surface_rows_require_complete_emitted_parameters(tmp_pat
                 "artifact": "oph_neutrino_physical_majorana_phase_theorem",
                 "status": "theorem_grade_emitted",
                 "public_surface_candidate_allowed": True,
+                "candidate_parameters": {
+                    "alpha21_deg_0_to_360": 153.6185177794357,
+                    "alpha31_deg_0_to_360": 257.00324082207993,
+                },
                 "emitted_parameters": {
                     "alpha21_deg_0_to_360": 153.6185177794357,
                 },

--- a/code/particles/test_results_status_majorana_surface.py
+++ b/code/particles/test_results_status_majorana_surface.py
@@ -94,6 +94,38 @@ def test_majorana_phase_surface_rows_require_theorem_grade_status(tmp_path: path
     assert "synthetic inconsistent status gate" in by_id["alpha21_majorana"]["note"]
 
 
+def test_majorana_phase_surface_rows_require_complete_emitted_parameters(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    theorem_path = tmp_path / "majorana_theorem.json"
+    theorem_path.write_text(
+        json.dumps(
+            {
+                "artifact": "oph_neutrino_physical_majorana_phase_theorem",
+                "status": "theorem_grade_emitted",
+                "public_surface_candidate_allowed": True,
+                "emitted_parameters": {
+                    "alpha21_deg_0_to_360": 153.6185177794357,
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    original = module.NEUTRINO_PHYSICAL_MAJORANA_PHASE_THEOREM
+    module.NEUTRINO_PHYSICAL_MAJORANA_PHASE_THEOREM = theorem_path
+    try:
+        rows = module.build_majorana_phase_surface_rows(module.build_surface_state(with_hadrons=False))
+    finally:
+        module.NEUTRINO_PHYSICAL_MAJORANA_PHASE_THEOREM = original
+
+    by_id = {row["observable_id"]: row for row in rows}
+    assert by_id["alpha21_majorana"]["status"] == "still_absent"
+    assert by_id["alpha21_majorana"]["prediction_display"] == "n/a"
+    assert by_id["alpha31_majorana"]["prediction_display"] == "n/a"
+    assert "incomplete on disk" in by_id["alpha21_majorana"]["note"]
+
+
 def test_render_markdown_includes_majorana_phase_section() -> None:
     module = _load_module()
     surface_state = module.build_surface_state(with_hadrons=False)
@@ -131,3 +163,4 @@ def test_render_markdown_includes_majorana_phase_section() -> None:
     )
     assert "## Majorana Phase Surface" in markdown
     assert "| alpha21^(Maj) | theorem_grade | 153.618518 deg |" in markdown
+    assert "| alpha31^(Maj) | theorem_grade | 257.003241 deg |" in markdown


### PR DESCRIPTION
## Summary
- Follow up on merged PR #203 by hardening, not replacing, the public Majorana promotion path.
- Bind public Majorana promotion to the exact repaired weighted-cycle branch: the promoted shared-basis representation must now match the same repaired weighted-cycle matrix, the same explicit `U_e_left` congruence transport, the same transported neutrino unitary, and the same recovered canonical PMNS branch.
- Make the public Majorana status surface fail safely: if a theorem artifact claims promotion but is missing emitted Majorana values, the surface now falls back to `still_absent` with an explicit blocker instead of crashing the status build.

## Why PR #203 Was Already Correct
- PR #203 correctly closed the physical Majorana surface on the live repaired weighted-cycle branch by introducing the explicit shared-basis transport route and emitting the theorem-grade Majorana pair on that branch.
- Its emitted values and public surface were already numerically consistent on the current corpus: the shared-basis transport closed, the Majorana readout landed on the same repaired branch, and the focused theorem/status tests were green.
- So this follow-up is not changing the claimed physical values or replacing the underlying derivation route from PR #203.

## Why This Hardening Is Still Good And Necessary
- After PR #203 merged, the follow-up review found that the public-promotion code path still left too much trust in artifact-level consistency.
- The first hardening step in this PR fixed two real issues: it stopped trusting optional `transport_checks` summaries, and it corrected the PMNS/readout contract so the row gauge is clearly readout-only rather than falsely attributed to the stored PMNS matrix.
- That version was already materially correct about the emitted numbers and the gauge story, but it still did not prove that the shared-basis representation being promoted was the transport of the exact weighted-cycle repair artifact being paired with it.
- This final hardening closes that remaining provenance gap by checking the promoted artifact directly against the same `M_wc`, the same transported `U_nu_shared = U_e_left U_wc`, and the same recovered canonical PMNS branch.
- The status-surface fallback hardening is also worth keeping because theorem-grade public artifacts should degrade honestly when incomplete, not take down the reporting build.

## Patch Scope
- `code/particles/neutrino/derive_neutrino_physical_majorana_phase_theorem.py`: add same-branch provenance checks and align the promotion contract with the repaired weighted-cycle artifact.
- `code/particles/scripts/build_results_status_table.py`: degrade gracefully on incomplete promoted Majorana artifacts.
- Focused tests and regenerated surfaced artifacts updated to match the tighter contract.

## Test plan
- [x] `python -m pytest code/particles/neutrino/test_physical_majorana_phase_theorem.py`
- [x] `python -m pytest code/particles/neutrino/test_neutrino_weighted_cycle_shared_basis_representation.py`
- [x] `python -m pytest code/particles/test_results_status_majorana_surface.py`
- [x] `python -m pytest code/particles/test_results_status_neutrino_comparison_rows.py`

Note:  
`python -m pytest code/particles/test_compute_current_output_table_runtime_surface.py` (blocked locally: missing ancillary tree at `C:/Users/Mario/SourceCode/Local/arXiv/RC1/ancillary/code/particles`)