### PR TITLE
fix: sync remaining dark-sector book wording (issue #48)

### DIFF
--- a/book/chapter-13-desitter.md
+++ b/book/chapter-13-desitter.md
@@ -275,9 +275,9 @@ where $g_b$ is the Newtonian acceleration from baryons. For a galaxy, this would
 
 $$V^4 = G \cdot M_b \cdot a_0^{(\text{OPH})}$$
 
-This has the observed Tully-Fisher form, with the normalization benchmark determined by screen capacity in the ansatz.
+This has the observed Tully-Fisher form in the ansatz, with a benchmark normalization set by screen capacity.
 
-**This continuation does not need new particles at the level of the ansatz.** The extra pull would come from an effective gravity-side contribution at large scales, not from a new matter species.
+**No new particles are required at the level of the ansatz.** The "dark matter" would be an effective correction to gravity at large scales, not a new species of particle.
 
 ### The Status
 
@@ -295,7 +295,7 @@ What remains missing:
 - Cosmological abundance and structure-formation analysis
 - Environment-dependence and stability checks
 
-So the present claim is modest but interesting: the same finite screen capacity that gives us the cosmological constant also supplies an infrared acceleration scale in the right ballpark for galaxy phenomenology.
+So the current claim is narrower: the same finite screen capacity that gives us the cosmological constant also supplies an IR benchmark scale for a possible dark-sector continuation. The continuation itself is still open.
 
 ### What A Future Closure Would Need To Face
 

--- a/book/chapter-15-relativity.md
+++ b/book/chapter-15-relativity.md
@@ -539,7 +539,7 @@ The framework connects this anomaly to the cosmological constant. The only avail
 
 $$a_0 = \frac{15}{8\pi^2} c^2 \sqrt{\frac{\Lambda}{3}} \approx 1.0 \times 10^{-10} \text{ m/s}^2$$
 
-This lands remarkably close to the empirical MOND acceleration scale, the threshold below which galaxy rotation curves deviate from Newtonian predictions. The numerical coincidence is suggestive, but the full galaxy-dynamics story, including rotation curves, lensing, and cluster behavior, remains open work.
+This lands near the empirical MOND acceleration scale. That numerical proximity motivates the continuation, but it does not yet derive a galaxy law.
 
 ## 15.14 Reverse Engineering Summary
 

--- a/book/prologue.md
+++ b/book/prologue.md
@@ -126,7 +126,7 @@ work out the consequences, the results are extraordinary:
 
 - **Gravity** emerges from how observers share entanglement across their screens
 - **The particle zoo** emerges from the symmetry structure forced by the framework
-- **The dark sector** gets a structured starting point, though the response laws and phenomenology remain open
+- **A dark-sector continuation** is explored through modular anomalies, but MOND/RAR-scale phenomenology remains future work rather than a recovered-core result
 - **Why anything exists at all** enters the story through a self-referential closure picture
 
 Once you make this shift, strange features of reality start making sense.


### PR DESCRIPTION
- Sync the remaining book surfaces with the passed issue48 continuation-only wording after the earlier dark-sector demotion in PR #129
- Keep the prologue and Chapters 13/15 at ansatz/future-work level for MOND, BTFR, and dark-sector language
- Match the approved task artifact wording without reopening the already-demoted paper-side files