### PR TITLE
fix: sync null-stress boundary wording (issue #19)

### DIFF
--- a/extra/jacobson_gravity_note.tex
+++ b/extra/jacobson_gravity_note.tex
@@ -33,7 +33,7 @@ Observer-Patch Holography (OPH) contains a gravity branch written for readers al
 \to G_{ab}+\Lambda g_{ab}=8\pi G\,\langle T_{ab}\rangle.
 \end{aligned}
 \]
-The chain is conditional. In particular, fixed-cap generalized-entropy stationarity, the density upgrade to a local null stress, and the relativistic null-stress identification remain explicit premises rather than derived outputs.
+The chain is conditional. In particular, fixed-cap generalized-entropy stationarity, the density upgrade to a local null stress, and the bounded-interval projective step used in the small-ball bridge remain explicit premises rather than derived outputs.
 
 The same observer-overlap axiom package is also used elsewhere in the SM/GR derivation paper to support a conditional Lorentz branch, a schedule-independent overlap-consistency normal form, and a separate compact gauge-reconstruction branch targeting Standard Model structure.
 \end{quote}
@@ -114,7 +114,7 @@ In the OPH chain, the positive null-translation generator is obtained from the c
 
 \section*{3. From the Half-Line Generator to Null Stress}
 
-At this stage the chain has not yet reached the Einstein equation. OPH then makes a downstream density-upgrade and EFT-identification step. In the SM/GR derivation paper this step is kept explicit:
+At this stage the chain has not yet reached the Einstein equation. In the SM/GR derivation paper, the half-line generator/charge identification is already fixed on the stated half-line family. What remains explicit downstream for the Jacobson step is the density upgrade together with the bounded-interval projective transport used in the small-ball bridge:
 \[
 \widetilde K[(a,\infty),\Omega]
 =
@@ -122,7 +122,7 @@ At this stage the chain has not yet reached the Einstein equation. OPH then make
 +
 E^{(\eta)}_{(a,\infty),\Omega}.
 \]
-Here \(E^{(\eta)}\) is a carried remainder controlled in matrix elements. The intended physical reading is that the null modular generator is identified with continuum null stress in the relativistic EFT branch.
+Here \(E^{(\eta)}\) is a carried remainder controlled in matrix elements. The half-line generator/charge identification is not a separate relativistic EFT premise here; it is already fixed on the stated half-line family. What remains downstream is transport to bounded null intervals for the small-ball/Jacobson step, and the later tensor upgrade is still defined only modulo the null-invisible metric term.
 
 Knowledge of \(T_{kk}\) in all null directions then determines the full stress tensor modulo a metric term: if a symmetric tensor \(X_{ab}\) obeys
 \[

--- a/paper/tex_fragments/PAPER.tex
+++ b/paper/tex_fragments/PAPER.tex
@@ -1830,7 +1830,7 @@ For null deformations parameterized by \(\lambda\), consider nested null regions
 \]
 
 \begin{quote}
-\textbf{Proposition 5.10a (Conditional internal QNEC).} Under the fixed-cutoff null bridge of \S{}5.2 together with the downstream density-upgrade and resulting null-stress-identification premises, the second null variation of von Neumann entropy satisfies
+\textbf{Proposition 5.10a (Conditional internal QNEC).} Under the fixed-cutoff null bridge of \S{}5.2 together with the downstream density-upgrade and bounded-interval projective premises, the second null variation of von Neumann entropy satisfies
 
 \[
 \frac{d^2 S_{\mathrm{bulk}}}{d\lambda^2} \le 2\pi \langle T_{kk}(\lambda) \rangle,


### PR DESCRIPTION
- rewrite Proposition 5.10a so the downstream burden is the density upgrade plus bounded-interval projective transport, not a separate null-stress-identification premise
- sync the Jacobson note summary and Section 3 wording with the accepted half-line generator/charge boundary
- keep bounded-interval transport and the later tensor upgrade as the explicit downstream burdens