### PR TITLE
Synchronize hypercharge lattice and Z6 quotient summaries

### DIFF
--- a/book/chapter-14-standard-model.md
+++ b/book/chapter-14-standard-model.md
@@ -446,7 +446,7 @@ With N_c = 3 and standard normalization:
 
 $$\boxed{Y_Q = \frac{1}{6}, \quad Y_L = -\frac{1}{2}, \quad Y_u = \frac{2}{3}, \quad Y_d = -\frac{1}{3}, \quad Y_e = -1, \quad Y_H = \frac{1}{2}}$$
 
-These are exact rationals, the Standard Model hypercharges, with the ratios fixed by anomaly freedom + Yukawa invariance and the absolute values fixed by standard normalization. There are no continuous parameters to adjust.
+These are exact rationals, the Standard Model hypercharges, with the ratios fixed by anomaly freedom + Yukawa invariance and the absolute values fixed by standard normalization. There are no continuous parameters to adjust. On the realized branch, this sixth-integer lattice is exactly the one compatible with the physical quotient \((SU(3) \times SU(2) \times U(1))/Z_6\), not just a Lie-algebra normalization convention.
 
 That is what makes the derivation satisfying. The equations are not decorative bookkeeping. They explain why the charges come out in the strange pattern we observe. Quarks carry third-integer charges because the weak interaction, the Higgs couplings, and anomaly cancellation all have to coexist in one self-consistent chiral theory.
 

--- a/paper/observers_are_all_you_need.tex
+++ b/paper/observers_are_all_you_need.tex
@@ -214,7 +214,7 @@ the locally Lorentzian \(d=4\) scaling regime, and the tensor-upgrade side condi
 \item \textbf{The Standard Model gauge skeleton appears as a constrained consistency output.}
 Technically, compact gauge reconstruction and the realized
 \(\SU(3)\times\SU(2)\times\U(1)/\mathbb Z_6\) branch follow under the stated transportability and
-categorical premises, with the realized counting chain \(N_g=3\) then \(N_c=3\).
+categorical premises, with the exact hypercharge lattice and the realized counting chain \(N_g=3\) then \(N_c=3\).
 \item \textbf{The particle lane has real outputs and a nonuniform closure profile.}
 Technically, the structural carriers are exact, the electroweak stage remains on a non-core
 Phase-II calibration branch with target-free public \(W/Z\) rows, a Ward-projected


### PR DESCRIPTION
## Summary
- add the exact hypercharge lattice to the wrapper-level Standard Model gauge summary
- tie the Chapter 14 sixth-integer hypercharge lattice explicitly to the realized physical `(SU(3) x SU(2) x U(1)) / Z6` quotient
- keep the change scoped to the approved Issue 28 summary-surface synchronization patch

## Changed Files
- `paper/observers_are_all_you_need.tex`
- `book/chapter-14-standard-model.md`

## Validation
- the landed diff matches the refreshed `task/patched/issue28/patch.diff`
- changed files are limited to the two target surfaces recorded in the Issue 28 artifact
