### PR TITLE
fix: import the fixed-cutoff observer continuation package (issue #58)

### DIFF
--- a/paper/observers_are_all_you_need.tex
+++ b/paper/observers_are_all_you_need.tex
@@ -167,7 +167,7 @@ The answer is sharply tiered. Fixed-cutoff collar structure, higher-gauge defect
 the consensus/fixed-point formulation together with observable-level quotient confluence on the
 declared physical algebras, the
 record-algebra / Born-L\"uders package with its quantitative stability surface, and the
-checkpoint/restoration package are theorem-bearing on their stated finite
+checkpoint/restoration package, including checkpoint data, restoration maps, future-law stability under restoration error, and an operational observer-identity criterion imported from Ref.~\cite{ophmicrophysics}, are theorem-bearing on their stated finite
 surfaces. The Lorentz/null-modular/Einstein chain remains a conditional scaling-limit branch,
 and compact gauge reconstruction remains a conditional categorical branch. The particle lane is the most tiered part of
 the suite: the structural carrier skeleton and realized Standard Model branch are fixed, the

--- a/paper/tex_fragments/OBSERVERS_APPENDICES.tex
+++ b/paper/tex_fragments/OBSERVERS_APPENDICES.tex
@@ -232,7 +232,9 @@ Why anything exists / strange-loop closure & Interpretive epilogue only & Append
 This appendix uses the fixed-cutoff checkpoint/restoration/error/identity theorem package proved
 in Ref.~\cite{ophmicrophysics} and summarizes its algebraic interface in observer language. It
 does not define a strange-loop closure map on an invariant observer-supporting sector or establish
-uniqueness and stability for such a map.
+uniqueness and stability for such a map. Nor does it upgrade the fixed-cutoff theorem stack to
+continuation across redesigned environments: the proved package is same-interface restoration on
+observer-accessible event algebras with explicit error control.
 
 \subsection{Observer as Algebraic Pattern}
 
@@ -299,13 +301,15 @@ requires additional modeling assumptions beyond the bound itself.
 The fixed-cutoff microphysics claim is stronger than the bare recoverability estimate written
 above. In Ref.~\cite{ophmicrophysics}, exact checkpoint restoration preserves the full future
 law of observer-accessible events, while an \(\varepsilon\)-accurate restoration changes that
-future law by at most \(\varepsilon\) in total variation. The stronger strange-loop closure story
+future law by at most \(\varepsilon\) in total variation. The stronger strange-loop / substrate-transfer closure story
 remains open.
 
 \subsection{Physical Meaning}
 
 At fixed cutoff, Ref.~\cite{ophmicrophysics} proves a checkpoint/restoration theorem and backup
-corollary for observer-accessible event algebras. This appendix states the observer-facing meaning
+corollary for observer-accessible event algebras. The proved package stops at same-interface
+backup/restoration with explicit future-law error control; stronger continuation and
+substrate-selection claims remain outside it. This appendix states the observer-facing meaning
 of that theorem and its algebraic prerequisites. Open items are the stronger substrate-selection,
 strange-loop closure, uniqueness, and stability package.
 


### PR DESCRIPTION
## Summary
- expand the observer synthesis wrapper so it names the imported fixed-cutoff continuation package explicitly
- state in the appendix that the proved package stops at same-interface checkpoint/restoration with explicit future-law error control
- keep redesigned-environment, substrate-transfer, and strange-loop continuation claims outside the proved fixed-cutoff package

## Context
- issue #58 asks for the observer continuation / backup theorem package to be carried honestly on the current observer-facing surfaces
- the fixed-cutoff theorem stack already exists in `ophmicrophysics`; this patch synchronizes the observer wrapper and appendix surfaces with that theorem-bearing scope

## Changed Files
- `paper/observers_are_all_you_need.tex`
- `paper/tex_fragments/OBSERVERS_APPENDICES.tex`

## Verification
- compared the changed line set against `task/patched/issue58/patch.diff`
- verified the working tree changes are confined to the two documented issue 58 files

## Notes
- no manuscript build was run for this wording-only synchronization patch
