### PR TITLE
feat: constants: close the local familiar-unit readout package on the exact-release surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,13 @@ Charged leptons sit on a split claim tier. The repo carries an exact same-family
 
 ## Local Unification Surface
 
-OPH places a local unification surface around the calibrated local UV input. The same `P`-driven scale carries the electroweak boson and Higgs lane together with the gravity-side entropy lane, while the Lorentz branch supplies the invariant causal speed and the local readout package supplies the SI display. On the stated local extension surface, the lifted product presentation of the realized quotient branch gives `ellbar_shared = ellbar_SU(2) + ellbar_SU(3)`; the same D10 pixel law on that surface fixes `ellbar_shared = P/4`, and the local SI readout is `G_SI = c^3 a_cell / (hbar P)` relative to the declared microscopic datum `a_cell`.
-On the public constants surface, `hbar` and `k_B` belong to that downstream familiar-unit readout. OPH does not emit them as standalone constants.
+The local unification surface is organized around the calibrated local UV input. The same `P`-driven scale carries the electroweak boson and Higgs lane together with the gravity-side entropy lane, while the Lorentz branch supplies the invariant causal speed and the local familiar-unit package supplies meters, seconds, GeV, and Kelvin. On the stated local extension surface, the lifted product presentation of the realized quotient branch gives `ellbar_shared = ellbar_SU(2) + ellbar_SU(3)`; the same D10 pixel law on that surface fixes `ellbar_shared = P/4`, and the gravity-side emitted row is `G_SI = c^3 a_cell / (hbar P)` relative to the declared microscopic datum `a_cell`.
+The familiar-unit package on that surface is explicit: `L_loc = sqrt(a_cell) * Lhat(P)`,
+`t_loc = sqrt(a_cell) * That(P) / c`, `E_loc = hbar c * Ehat(P) / sqrt(a_cell)`, and
+`Theta_loc = hbar c * Thetahat(P) / (k_B sqrt(a_cell))`, with dimensionless branch outputs
+`Lhat`, `That`, `Ehat`, `Thetahat`. So `a_cell` supplies the one local ruler, `c` is the
+structural Lorentz output, and `hbar` and `k_B` are downstream familiar-unit display conventions
+for GeV and Kelvin rather than standalone OPH-emitted constants.
 
 <p align="center">
   <a href="assets/OPH_Unification_Diagram.svg" target="_blank" rel="noopener noreferrer">

--- a/book/chapter-18-synthesis.md
+++ b/book/chapter-18-synthesis.md
@@ -248,7 +248,14 @@ The quantitative implementation is characterized by exactly **two external conti
 
 The axiom structure contains no dimensionful constants. It is pure mathematics describing how information organizes on holographic screens. These two parameters are the only "settings" that distinguish our universe from other possible universes running the same axiom structure.
 
-**Pixel area** determines the resolution of the computation, roughly 1.63 Planck areas per pixel. From this single calibration scale, Newton's gravitational constant and the Planck length follow. The gauge coupling strengths are also organized through this scale.
+**Pixel area** determines the resolution of the computation, roughly 1.63 Planck areas per pixel. From this single calibration scale, Newton's gravitational constant and the local mass scale follow. The gauge coupling strengths are also organized through this scale.
+
+The local familiar-unit package is then simple. Once \(P\) is fixed, the single local ruler is
+\(\sqrt{a_{\text{cell}}}\). Lengths are \(\sqrt{a_{\text{cell}}}\) times dimensionless branch
+values. Times are that same ruler divided by the structural causal speed \(c\). Energies and
+masses in GeV are the inverse ruler multiplied by \(\hbar c\). Temperatures in Kelvin are the
+same energy scale divided by \(k_B\). So \(c\) is a structural output, while \(\hbar\) and
+\(k_B\) are part of the familiar-unit display convention rather than extra emitted constants.
 
 **Screen capacity** determines the size of the computation. From the observed cosmological constant, we infer that the screen holds roughly $10^{122}$ bits, an enormous but finite number. This sets the de Sitter horizon radius at about $10^{26}$ meters. The cosmological constant itself is an input. It tells us how big the screen is, not why it has that size.
 

--- a/paper/deriving_the_particle_zoo_from_observer_consistency.tex
+++ b/paper/deriving_the_particle_zoo_from_observer_consistency.tex
@@ -404,9 +404,10 @@ P/4,
 \qquad
 G=\frac{a_{\mathrm{cell}}}{4\,\ellbar(t)}.
 \]
-The local unification surface has three explicit boundary objects: exact public \(W/Z\) requires
-one target-free D10 chart-identity theorem, exact public Higgs requires one forward
-Higgs-promotion theorem, and the gravity-side release retains the strict classical-regime clause.
+The local unification surface now separates one explicit familiar-unit readout package from three
+remaining theorem-side boundary objects: exact public \(W/Z\) requires one target-free D10
+chart-identity theorem, exact public Higgs requires one forward Higgs-promotion theorem, and the
+gravity-side release retains the strict classical-regime clause.
 On the gravity side, the stated local extension surface uses the lifted product presentation of the
 realized quotient branch and identifies
 \[
@@ -422,6 +423,21 @@ and the local SI readout is
 G_{\mathrm{SI}}=\frac{c^3 a_{\mathrm{cell}}}{\hbar P}
 \]
 relative to the declared microscopic datum \(a_{\mathrm{cell}}\). On that declared extension
+surface the same familiar-unit package reads
+\[
+L_{\mathrm{loc}}=\sqrt{a_{\mathrm{cell}}}\,\widehat L(P),
+\qquad
+t_{\mathrm{loc}}=\frac{\sqrt{a_{\mathrm{cell}}}}{c}\,\widehat T(P),
+\]
+\[
+E_{\mathrm{loc}}=\frac{\hbar c}{\sqrt{a_{\mathrm{cell}}}}\,\widehat E(P),
+\qquad
+\Theta_{\mathrm{loc}}=\frac{\hbar c}{k_B\sqrt{a_{\mathrm{cell}}}}\,\widehat\Theta(P),
+\]
+with dimensionless \(\widehat L,\widehat T,\widehat E,\widehat\Theta\). Thus, at fixed \(P\), the
+local ruler is \(\sqrt{a_{\mathrm{cell}}}\); seconds are that ruler divided by the structural
+Lorentz output \(c\); and GeV and Kelvin are downstream familiar-unit displays of the inverse
+local ruler through \(\hbar\) and \(k_B\). On that declared extension
 surface the local release bundle is
 \[
 c=299792458\,\mathrm{m/s},

--- a/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
+++ b/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
@@ -1293,7 +1293,7 @@ On the product heat-kernel branch, expectation values add, so
 If the same branch satisfies the D10 pixel law, the right-hand side equals \(P/4\). \qedhere
 \end{proof}
 
-\begin{proposition}[Local SI readout of the gravity row]\label{prop:gsi}
+\begin{proposition}[Local familiar-unit readout package on the gravity row]\label{prop:gsi}
 On the declared local extension surface, let \(a_{\mathrm{cell}}\) be the microscopic cell-area datum and define
 \[
 G_{\mathrm{nat}}:=\frac{a_{\mathrm{cell}}}{4\ellbar_{\mathrm{shared}}}.
@@ -1308,6 +1308,22 @@ G_{\mathrm{SI}}
 =
 \frac{c^3 a_{\mathrm{cell}}}{\hbar P}.
 \]
+More generally, if \(\widehat L(P)\), \(\widehat T(P)\), \(\widehat E(P)\), and
+\(\widehat\Theta(P)\) denote dimensionless branch outputs on that same local branch, then
+\[
+L_{\mathrm{loc}}=\sqrt{a_{\mathrm{cell}}}\,\widehat L(P),
+\qquad
+t_{\mathrm{loc}}=\frac{\sqrt{a_{\mathrm{cell}}}}{c}\,\widehat T(P),
+\]
+\[
+E_{\mathrm{loc}}=\frac{\hbar c}{\sqrt{a_{\mathrm{cell}}}}\,\widehat E(P),
+\qquad
+\Theta_{\mathrm{loc}}=\frac{\hbar c}{k_B\sqrt{a_{\mathrm{cell}}}}\,\widehat\Theta(P).
+\]
+Thus, at fixed \(P\), local lengths scale with \(a_{\mathrm{cell}}^{1/2}\) alone, local times
+use that same \(a_{\mathrm{cell}}^{1/2}\) scale divided by the structural Lorentz output \(c\),
+and local mass/energy and temperature rows use the inverse \(a_{\mathrm{cell}}^{1/2}\) scale
+dressed only by the familiar-unit display conventions \(\hbar\) and \(k_B\).
 \end{proposition}
 
 \begin{proof}
@@ -1328,8 +1344,13 @@ then gives
 G_{\mathrm{SI}}
 =
 \frac{c^3 a_{\mathrm{cell}}}{\hbar P}.
-\qedhere
 \]
+The remaining formulas are dimensional bookkeeping on the same declared local branch. Because \(P\)
+is dimensionless and \(a_{\mathrm{cell}}\) is the only local microscopic area datum, every local
+length readout is \(\sqrt{a_{\mathrm{cell}}}\) times a dimensionless branch quantity. The structural
+Lorentz output \(c\) converts that same local ruler to seconds, while the familiar-unit display
+constants \(\hbar\) and \(k_B\) convert the inverse local ruler to energy/mass rows and to Kelvin
+rows. \qedhere
 \end{proof}
 
 Proposition~\ref{prop:splice} is the algebraic version of interior invariance under compatible exterior substitutions. Proposition~\ref{prop:modulartransport} is the precise bridge from small collar conditional mutual information to the exact modular identities later used by the spatial and null branches: at finite stage one carries a remainder, and exact identities appear only when that remainder is zero or tends to zero in the controlled collar limit. Proposition~\ref{prop:gensplit} isolates the exact entropy split, while Definition~\ref{def:newton} supplies the continuum identification that turns the edge center into a gravitational coupling.
@@ -3360,9 +3381,11 @@ P/4,
 \qquad
 G=\frac{a_{\mathrm{cell}}}{4\,\ellbar(t)}.
 \]
-The exact local release burden consists of two explicit objects: one strict classical-regime
-clause above the BW/Lorentz honesty package and one target-free D10 chart-identity theorem for exact
-\(W/Z\). On the gravity side,
+The remaining exact local release burden consists of two theorem-sized objects: one strict
+classical-regime clause above the BW/Lorentz honesty package and one target-free D10
+chart-identity theorem for exact \(W/Z\). The familiar-unit readout is not a third theorem-sized
+burden. It is the explicit display package attached to the theorem-side data
+\(a_{\mathrm{cell}}\), \(c\), and \(\ellbar_{\mathrm{shared}}\). On the gravity side,
 Proposition~\ref{prop:sharededgeentropy} gives
 \[
 \ellbar_{\mathrm{shared}}
@@ -3378,6 +3401,19 @@ and Proposition~\ref{prop:gsi} gives the local SI readout
 G_{\mathrm{SI}}=\frac{c^3 a_{\mathrm{cell}}}{\hbar P}
 \]
 relative to the declared microscopic datum \(a_{\mathrm{cell}}\).
+The same proposition fixes the full familiar-unit package:
+\[
+L_{\mathrm{loc}}=\sqrt{a_{\mathrm{cell}}}\,\widehat L(P),\qquad
+t_{\mathrm{loc}}=\frac{\sqrt{a_{\mathrm{cell}}}}{c}\,\widehat T(P),
+\]
+\[
+E_{\mathrm{loc}}=\frac{\hbar c}{\sqrt{a_{\mathrm{cell}}}}\,\widehat E(P),\qquad
+\Theta_{\mathrm{loc}}=\frac{\hbar c}{k_B\sqrt{a_{\mathrm{cell}}}}\,\widehat\Theta(P),
+\]
+with dimensionless \(\widehat L,\widehat T,\widehat E,\widehat\Theta\). Meters and seconds are
+therefore read from the single local ruler \(\sqrt{a_{\mathrm{cell}}}\) together with the
+structural Lorentz output \(c\), while GeV and Kelvin are downstream familiar-unit displays of the
+inverse local ruler through \(\hbar\) and \(k_B\).
 On that declared extension surface the local release values are
 \[
 c=299792458\,\mathrm{m/s},
@@ -3400,7 +3436,7 @@ The paper does not claim complete closure of all low-energy observables.\footnot
 
 Observer-Patch Holography starts from overlap consistency of observer patches and yields, within one framework, several effective structures usually treated separately in modern fundamental physics. This SM/GR derivation paper supports a unique schedule-independent normal form for overlap repair and hence a unique physical UV branch only modulo boundary redundancy, implementation hiding, and inert ancillary stabilization, a conditional Lorentz branch on the extracted prime geometric cap pair, a conditional Jacobson-type Einstein branch under fixed-cap stationarity and the null modular bridge together with the bounded-interval projective branch, the Standard Model gauge quotient with exact hypercharges on the realized matter package under the MAR admissibility package in the bosonic internal-gauge branch, the realized counting chain \(N_g=3\) then \(N_c=3\) on that branch, a separate integrated gauge-calibration sector, and a separate input-dependent cosmological-capacity corollary. Phenomenological continuations are discussed separately from the recovered core.
 
-The framework therefore presents general relativity and the Standard Model as effective descriptions arising once the stated scaling-limit, geometric-subnet, and categorical premises are realized. The local quantitative claim surface is equally explicit: on a four-object extension surface, the same declared pixel input \(P\) controls the electroweak/Higgs mass trunk and the classical-regime gravity coupling, while the invariant causal speed \(c\) is the structural Lorentz output with explicit SI readout. Open items are sharper quantitative control, full derivation of the refinement-limit bosonic ordinary/central gauge package of Assumption~\ref{ass:gaugeprem}, a fuller fermionic gauge branch, explicit microscopic realizations that emit the prime geometric cap pair and support ordered cut-pair rigidity, and proof of those four local exact-release objects on the live corpus.
+The framework therefore presents general relativity and the Standard Model as effective descriptions arising once the stated scaling-limit, geometric-subnet, and categorical premises are realized. The local quantitative claim surface is equally explicit: the same declared pixel input \(P\) controls the electroweak/Higgs mass trunk and the classical-regime gravity coupling, the invariant causal speed \(c\) is the structural Lorentz output, and the familiar-unit package reads meters, seconds, GeV, and Kelvin from the single local ruler \(\sqrt{a_{\mathrm{cell}}}\) with \(\hbar\) and \(k_B\) used only as display conventions. Open items are sharper quantitative control, full derivation of the refinement-limit bosonic ordinary/central gauge package of Assumption~\ref{ass:gaugeprem}, a fuller fermionic gauge branch, explicit microscopic realizations that emit the prime geometric cap pair and support ordered cut-pair rigidity, and proof of the remaining theorem-side local exact-release objects on the live corpus.
 
 \appendix
 \input{tex_fragments/COMPACT_TECHNICAL_SUPPLEMENT_PORT.tex}

--- a/paper/tex_fragments/OBSERVERS_SYNTHESIS_SECTIONS.tex
+++ b/paper/tex_fragments/OBSERVERS_SYNTHESIS_SECTIONS.tex
@@ -364,8 +364,20 @@ Quantity & Best value on the paper surface & Common OPH chain & Caveat \\
 
 The exact-release package on that surface is local and finite: the strict classical-regime clause
 and the target-free electroweak chart identity for \(W/Z\).
-The gravity-side shared-edge identity and the local SI readout are fixed relative to the declared
-microscopic datum \(a_{\mathrm{cell}}\).
+The familiar-unit display split on that same surface is
+\[
+L_{\mathrm{loc}}=\sqrt{a_{\mathrm{cell}}}\,\widehat L(P),\qquad
+t_{\mathrm{loc}}=\frac{\sqrt{a_{\mathrm{cell}}}}{c}\,\widehat T(P),
+\]
+\[
+E_{\mathrm{loc}}=\frac{\hbar c}{\sqrt{a_{\mathrm{cell}}}}\,\widehat E(P),\qquad
+\Theta_{\mathrm{loc}}=\frac{\hbar c}{k_B\sqrt{a_{\mathrm{cell}}}}\,\widehat\Theta(P),
+\]
+with dimensionless \(\widehat L,\widehat T,\widehat E,\widehat\Theta\). The gravity-side
+shared-edge identity and the local SI readout are therefore fixed relative to the declared
+microscopic datum \(a_{\mathrm{cell}}\), while meters, seconds, GeV, and Kelvin remain downstream
+display conventions built from the structural \(c\) row and the familiar constants \(\hbar\),
+\(k_B\).
 
 \paragraph{Companion papers.}
 Detailed derivations appear in Refs.~\cite{ophcompact,ophconsensus,ophmicrophysics,ophparticles}.
@@ -386,8 +398,8 @@ fixed-cap-stationarity / local-Lorentz tensor-upgrade step, the transportable-se
 lift, the microphysics closure passes, and the matter-family and hadron closure lanes.
 Refs.~\cite{ophcompact,ophconsensus,ophmicrophysics,ophparticles} are the depth surfaces for
 sector-by-sector proofs, calibration details, and continuation-level material. The local
-cross-lane numerical surface is explicit enough to summarize concisely: one
-declared input \(P\) organizes the bosonic mass trunk and the gravity-side shared edge-entropy
-identity beneath the local \(G\) readout,
-while \(c\) remains the structural invariant speed of the Lorentz branch with an explicit local
-SI readout layer.
+cross-lane numerical surface is explicit enough to summarize concisely: one declared input \(P\)
+organizes the bosonic mass trunk and the gravity-side shared edge-entropy identity beneath the
+emitted local \(G\) row, while the same familiar-unit package reads meters and seconds from the
+single ruler \(\sqrt{a_{\mathrm{cell}}}\) together with the structural invariant speed \(c\), and
+reads GeV and Kelvin from the inverse local ruler through \(\hbar\) and \(k_B\).


### PR DESCRIPTION
This change closes the remaining paper-surface gap behind
`constants.surface.02-close-the-local-unit-bridge-for-familiar-in-universe-units`. #159 

The repo already stated the status of `c`, `G`, `\hbar`, and `k_B` individually, but the local
exact-release surface still lacked one explicit theorem/convention split for the familiar-unit
package as a whole.

The update makes that split explicit on every live constants-facing surface:
- the compact paper upgrades `prop:gsi` from a gravity-row SI formula into the full local
  familiar-unit package, with one explicit theorem/convention split:
  lengths scale as `sqrt(a_cell)`, times as `sqrt(a_cell)/c`, energies and masses as
  `\hbar c / sqrt(a_cell)`, and temperatures as `\hbar c / (k_B sqrt(a_cell))`;
- the local unification / exact-release discussion in the compact paper now states that the
  familiar-unit package is finished display data attached to theorem-side branch values, not a
  separate open theorem-sized boundary object;
- the particle paper now uses the same package on its local release surface instead of only giving
  the gravity-row SI formula and the negative caveat that `\hbar`/`k_B` are not standalone
  emitted constants;
- the observer synthesis constants summary now carries the same readout dictionary for meters,
  seconds, GeV, and Kelvin;
- the README and the book synthesis chapter now present the same reader-facing split between the
  local ruler `sqrt(a_cell)`, the structural Lorentz output `c`, and the familiar-unit display
  conventions `\hbar` and `k_B`.

Net effect: the compact paper, particle paper, README, book, and constants-facing synthesis
surface now state one synchronized familiar-unit readout package for the local exact-release
surface, with `a_cell`, `c`, `\hbar`, `k_B`, and the dimensionful local scales separated cleanly
into theorem outputs, emitted branch values, and display conventions.
