### PR TITLE
fix(lint): apply ruff lint autofixes (5 fixes)

### DIFF
--- a/code/ibm_quantum_cloud/programs/stage1_markov_fingerprint.py
+++ b/code/ibm_quantum_cloud/programs/stage1_markov_fingerprint.py
@@ -13,7 +13,7 @@ from qiskit.circuit.random import random_circuit
 from qiskit.quantum_info import DensityMatrix, Statevector
 from qiskit_aer import AerSimulator
 from qiskit_ibm_runtime import SamplerV2
-from scipy.linalg import eigh, sqrtm
+from scipy.linalg import eigh
 
 from ibm_runtime_common import ensure_dir, get_service, write_json
 

--- a/code/particles/calibration/implied_p_consistency_audit.py
+++ b/code/particles/calibration/implied_p_consistency_audit.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import math
 import sys
 from dataclasses import asdict
 from datetime import datetime, timezone

--- a/code/particles/neutrino/test_no_oscillation_import.py
+++ b/code/particles/neutrino/test_no_oscillation_import.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import pathlib
-import sys
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]

--- a/code/particles/neutrino/test_no_pmns_import.py
+++ b/code/particles/neutrino/test_no_pmns_import.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import pathlib
-import sys
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]

--- a/code/particles/scripts/refresh_reference_values_from_pdg.py
+++ b/code/particles/scripts/refresh_reference_values_from_pdg.py
@@ -13,7 +13,7 @@ import json
 import pathlib
 import urllib.request
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]


### PR DESCRIPTION
## Summary

Applies ruff lint autofixes to 5 Python files, removing unused imports.

## Changes

| File | Fix |
|------|-----|
| `code/ibm_quantum_cloud/programs/stage1_markov_fingerprint.py` | Drop unused `scipy.linalg.sqrtm` |
| `code/particles/calibration/implied_p_consistency_audit.py` | Drop unused `math` |
| `code/particles/neutrino/test_no_oscillation_import.py` | Drop unused import |
| `code/particles/neutrino/test_no_pmns_import.py` | Drop unused import |
| `code/particles/scripts/refresh_reference_values_from_pdg.py` | Drop unused import |

## Verification

- `git apply --check`: passed
- AST parse: all 5 modified files parse cleanly
- Ruff error count: 32 → 25 (7 fixes; audit estimated 5)

## Provenance

This patch was generated as part of a Wave 5C parallel polish campaign in the cohezion sibling repo. Diffstat: 5 files changed, 2 insertions(+), 5 deletions(-).

No behavior changes; pure import cleanup.