### PR TITLE
fix: audit closure ledger statuses (issue #59)

### DIFF
--- a/paper/tex_fragments/OBSERVERS_APPENDICES.tex
+++ b/paper/tex_fragments/OBSERVERS_APPENDICES.tex
@@ -193,28 +193,42 @@ for existence is interpretive only and is not part of the recovered theorem pack
 \subsection{Additional Problem Closures}
 
 Using the phase split of Section~\ref{16-summary-complete-axiom-set}, the broader closure claims
-read as follows.
+read as follows. The ledger also records appendix-tier closure stories so they cannot float
+outside the official status ledger. In this table, ``Proved corollary of earlier theorems'' means
+proved under the dependencies named in the row, including declared branch premises and cited
+companion-paper theorem surfaces.
 
-\begin{itemize}
-\item \textbf{Recovered or conditional core}: quantum-gravity consistency, the Lorentz/Einstein
-branch, the realized Standard Model quotient, charge quantization, three generations, three colors,
-and the absence of gauge-mediated proton decay.
-\item \textbf{Problem of time}: on the BW\(_{S^2}\) geometric branch, OPH reads
-observer-relative time from the cap modular automorphism parameter of the observer's accessible
-algebra/state pair. This is a declared reading of D3, not a separate operational-clock theorem or
-a global solution of the problem of time.
-\item \textbf{Fixed-cutoff microphysics}: measurement/Born-rule, Bell/CHSH, checkpoint, and
-restoration packages are fixed-cutoff theorem packages proved in
-Ref.~\cite{ophmicrophysics}.
-\item \textbf{Global closure}: the cosmological constant and de Sitter
-static-patch package use the external capacity input \(N_{\mathrm{scr}}\).
-\item \textbf{Continuation branches}: black-hole combs and evaporation closure, dark matter
-phenomenology, heuristic baryogenesis continuations, proton spin, downstream flavor data, hadron masses, and critical-string
-lifts require extra branch-specific structure.
-\item \textbf{Interpretive epilogue}: strange-loop or existence-closure readings use the
-state-and-law habitat below, but the recovered theorem package does not include a closure self-map
-or uniqueness/stability theorem for such a map.
-\end{itemize}
+\begin{center}
+\scriptsize
+\setlength{\tabcolsep}{3pt}
+\begin{tabular}{@{}>{\raggedright\arraybackslash}p{0.24\textwidth}>{\raggedright\arraybackslash}p{0.22\textwidth}>{\raggedright\arraybackslash}p{0.48\textwidth}@{}}
+\toprule
+Claim & Status & Boundary \\
+\midrule
+Quantum gravity consistency & Proved corollary of earlier theorems & Conditional Lorentz and Jacobson-type Einstein branches already follow once the stated scaling-limit, null-bridge, and fixed-cap premises are imported. \\
+UV completion / microscopic uniqueness & Explicit future program & Fixed-cutoff theorem packages exist, but a unique microscopic representative, the continuum BW lift on the extracted geometric subnet, and the refinement-limit transportable compact-gauge lift remain open. \\
+Measurement problem & Explicit future program & Ref.~\cite{ophmicrophysics} closes the fixed-cutoff central-record / Born-L\"uders interface, but a full philosophical or continuum-level measurement closure is not derived here. \\
+Cosmological principle and horizon homogeneity & Explicit future program & MaxEnt symmetry inheritance is suggestive only; an independent derivation of cosmological isotropy and homogeneity remains outside the recovered-core theorems. \\
+Observer-relative modular time & Proved corollary of earlier theorems & On the BW\(_{S^2}\) geometric branch, observer-relative time is read from the cap modular automorphism parameter of the observer's accessible algebra/state pair. This is the D3 reading only. \\
+Global / operational problem of time & Explicit future program & OPH does not prove a separate operational-clock theorem or a global solution of the problem of time. \\
+Black-hole information paradox & Explicit future program & Edge-center sectorization and recoverability motivate an internal resolution template, but the full black-hole-information branch remains outside Phase I. \\
+D6 cosmological-capacity closure under declared screen-capacity premise & Proved corollary of earlier theorems & Once the external input \(N_{\mathrm{scr}}\) and the D6 identification \(N_{\mathrm{scr}}=S_{\mathrm{dS}}\) are declared, the same Einstein branch fixes \(\Lambda=3\pi/(G N_{\mathrm{scr}})\) and the static-patch readout. \\
+Bare cosmological-constant problem from local null data & Explicit future program & The local null-data route determines the Einstein branch only modulo \(\Lambda g_{ab}\) and does not derive the screen-capacity identification from bare OPH axioms. \\
+Magnetic monopole expectation from simple GUT groups & Proved corollary of earlier theorems & The realized product-group branch \(\SU(3)\times\SU(2)\times\U(1)/\mathbb Z_6\) removes the standard simple-GUT symmetry-breaking monopole channel. \\
+Proton stability against gauge-mediated decay & Proved corollary of earlier theorems & The realized product-group branch removes the standard simple-GUT gauge-mediated proton-decay channel. \\
+Proton spin fraction & Explicit future program & Closing the proton-spin claim still requires nonperturbative QCD completion beyond Phase I. \\
+Dark matter phenomenology & Explicit future program & Modular-anomaly response laws remain conjectural beyond the recovered gravity chain. \\
+Baryon asymmetry scale & Explicit future program & Suppression-counting estimates are not a substitute for a derived out-of-equilibrium mechanism. \\
+Three generations & Proved corollary of earlier theorems & \(N_g=3\) is recovered on the realized MAR-admissible branch. \\
+Downstream flavor structure, Koide, and charged-lepton fits & Explicit future program & Later flavor constructions require extra ans\"atze and remain outside the recovered core. \\
+Edge-to-2D-YM / controlled large-\(N_{\mathrm{edge}}\) worldsheet branch & Proved corollary of earlier theorems & On the stated overlap-gauge, local-Gibbs/MaxEnt, compact-group, and large-\(N_{\mathrm{edge}}\) premises, the edge-sector heat-kernel bridge and controlled Gross--Taylor worldsheet effective description are theorem-level. \\
+Critical superstring / worldsheet CFT lift & Explicit future program & Critical-superstring claims, worldsheet CFT closure, anomaly cancellation, and full massless-spectrum matching require extra ingredients outside the recovered core. \\
+Why anything exists / strange-loop closure & Explicit future program & Appendix B provides only the habitat theorem and fixed-point setting. The OPH closure map, invariant observer-supporting sector, and uniqueness/stability proofs remain open. \\
+Fixed-cutoff checkpoint/restoration/backup & Proved corollary of earlier theorems & Ref.~\cite{ophmicrophysics} proves same-interface checkpoint/restoration and backup for observer-accessible event algebras with explicit future-law error control. \\
+Substrate-transfer / stronger observer continuation & Explicit future program & Stronger substrate-selection, redesigned-environment continuation, strange-loop closure, uniqueness, and stability claims remain open. \\
+\bottomrule
+\end{tabular}
+\end{center}
 
 \section{Observer Continuation and Backup}
 


### PR DESCRIPTION
- Replace the broad Additional Problem Closures status list with a binary closure ledger.
- Split mixed rows for problem of time, D6 cosmological closure, string/worldsheet claims, and observer backup.
- Add an explicit dependency convention for proved corollaries and keep future-program blockers visible.