### PR TITLE
fix: Tighten book chapters 01-05 wording and claim boundaries

### DIFF
--- a/book/chapter-01-consistency.md
+++ b/book/chapter-01-consistency.md
@@ -146,11 +146,11 @@ OPH reframes this problem.
 
 The puzzle assumes a God's-eye view where the wave function is "really" in superposition, followed by something magical called "collapse." There is no God's-eye view. There are only observer patches.
 
-From within a patch, you always see definite outcomes. That's what it means to be an observer: you have records, and records are definite. The "superposition" isn't a mysterious state waiting to collapse. It's a description of how different observers' potential records relate to each other before they compare notes.
+From within a patch, measurement is registered through definite records on the operational readout surface. The "superposition" is not a mysterious state waiting for a magic event. It is a description of how different observers' potential records relate to each other before they compare notes.
 
-When Alice measures an electron's spin, she gets a definite result. Always. There's no moment where she experiences superposition. The wave function describes the consistency relations between Alice's possible outcomes and Bob's possible outcomes. When they meet and compare, their records must agree. That agreement is what "collapse" describes from the outside.
+When Alice measures an electron's spin, her instrument writes one definite record on that readout surface. The wave function describes the consistency relations between Alice's possible records and Bob's possible records. When they meet and compare, those records must agree on the shared event surface. That agreement is the operational content behind textbook collapse language.
 
-The measurement problem asks: "When does objective reality become definite?" Our answer is that OPH reorganizes that question around observer patches and record consistency. Reality was never "indefinite" from any observer's perspective. It was always definite within each patch. The wave function describes how patches must relate, not some ghostly pre-measurement state.
+The measurement problem asks: "When does objective reality become definite?" Our answer is that OPH reorganizes that question around observer patches and record consistency. What becomes definite in the first instance are the records carried by each patch. The wave function describes how patches must relate, not some ghostly pre-measurement stage.
 
 Bohr was half right. He insisted that quantum mechanics describes relationships between observers and systems, not systems in isolation. OPH makes this precise: quantum mechanics is the mathematics of patch consistency.
 
@@ -267,7 +267,7 @@ observer lives on a finite patch.
 
 What picture explains all these hints?
 
-**A strong OPH reading is that what we call objective reality is reconstructed from a network of subjective perspectives that must agree where they overlap.**
+**What we call objective reality is reconstructed from a network of subjective perspectives that must agree where they overlap.**
 
 This sounds radical, but think about what "reality" actually means operationally. It means agreement. If I see a red car parked on the street, and you look at the same spot and see a blue elephant, we have a problem. If a third person sees a red car, and a fourth person sees a red car, we conclude the red car is "real."
 
@@ -289,7 +289,7 @@ We propose this principle goes deeper than biology. It applies to physics itself
 
 In OPH, the laws of physics, Lorentz symmetry, gauge structure, and conservation laws emerge from the consistency program. They are not imposed from outside.
 
-**A strong OPH reading views the laws of physics as survivors of a selection process.**
+**The laws of physics can be read as survivors of a selection process.**
 
 Think of the early universe as a chaos of competing possibilities: different geometries, different dynamics, different rules. Most configurations were inconsistent. They could not support stable patterns. They could not enable multiple observers to share a coherent reality.
 
@@ -387,7 +387,7 @@ In the chapters ahead, we'll apply this method systematically:
 
 **Chapter 17-19**: The selection hint-why these laws and not others? Are laws evolutionary survivors? And what does this mean for existence itself?
 
-The 3D world you see around you-the chairs, the stars, the empty space-is not the primary storage device of reality. The real data is stored on boundaries. We call this the holographic principle. It says that everything happening in a volume of space can be described by data on the surface that encloses it.
+The 3D world you see around you-the chairs, the stars, the empty space-is not the primary storage device of reality. The real data is organized on boundaries. We call this the holographic principle. In gravitational settings, it says that the independent bookkeeping for a region may be carried by data on the surface that encloses it.
 
 This isn't philosophy. It's physics, and the first hard clue came from black holes.
 

--- a/book/chapter-02-lineage.md
+++ b/book/chapter-02-lineage.md
@@ -9,7 +9,7 @@ accelerators or interferometers. They had something close in spirit: pure
 logical reasoning applied to careful observation. They asked what *must* be
 true if experience is to make any sense at all.
 
-And they found problems. Paradoxes. Contradictions. They discovered that the intuitive picture-objective reality independent of observers-leads to logical difficulties.
+And they found problems. Paradoxes. Contradictions. They discovered that the intuitive picture of an objective reality independent of observers leads to logical difficulties.
 
 These philosophical puzzles are the original hints. They're the first cracks in the naive picture. When modern physics confirmed that reality is stranger than it appears, it was validating insights that thinkers had glimpsed millennia ago.
 
@@ -207,7 +207,7 @@ We don't perceive space directly. Our minds construct spatial experience from mo
 
 The holographic principle and emergent geometry resonate with this picture.
 
-The fundamental data lives on the 2D holographic screen. This data has no spatial interpretation-it's just quantum information on a sphere. Space is *reconstructed* from this data through the pattern of entanglement.
+The fundamental data lives on the 2D holographic screen. This is not yet the familiar 3D bulk geometry; it is quantum information organized on a sphere. Space is *reconstructed* from this data through the pattern of entanglement.
 
 The Ryu-Takayanagi formula makes the geometry-entanglement link precise in
 holographic settings: the amount of entanglement across a boundary is computed

--- a/book/chapter-03-screen.md
+++ b/book/chapter-03-screen.md
@@ -299,9 +299,9 @@ physical.
 
 **Overlap consistency** is built into this constructive picture. Where two patches intersect, they access the same gauge-invariant observables. Both observers are reading the same underlying data, just from different angles. The gauge redundancy at boundaries is what makes gluing non-trivial and gives rise to the "edge modes" that carry geometric information.
 
-**The dynamics** comes from MaxEnt: among all states consistent with the constraints, nature selects the maximum entropy state. This is like a Gibbs state $\rho \propto e^{-H}$ where $H$ is a sum of local terms. The system thermalizes at the UV scale, and the macroscopic physics emerges from this equilibrium.
+**The dynamics** comes from MaxEnt: among all states consistent with the constraints, nature selects the maximum entropy state. At fixed cutoff this is modeled by a Gibbs-like state $\rho \propto e^{-H}$, where $H$ is a sum of local terms. The macroscopic physics then emerges from that constrained equilibrium picture.
 
-**The 4D bulk isn't on the sphere.** It emerges from the entanglement structure between patches. When you look around and see three-dimensional space, you're experiencing a compressed encoding of how your patch is entangled with others. Distance in the bulk is entanglement on the boundary.
+**The 4D bulk isn't on the sphere.** It emerges from the entanglement structure between patches. When you look around and see three-dimensional space, you're experiencing a compressed encoding of how your patch is entangled with others. In the constructions emphasized later, bulk distance is read from boundary entanglement structure.
 
 *The screen is the computation. Observer patches are the threads. Reality is what they agree on.*
 

--- a/book/chapter-04-entropy.md
+++ b/book/chapter-04-entropy.md
@@ -99,9 +99,9 @@ Boltzmann's answer: the arrow of time is not in the laws. It is in the initial c
 
 The universe started in a very low-entropy state. Given that starting point, entropy almost certainly increases. If the universe had started in equilibrium, it would stay there-no arrow of time, no memory, no observers.
 
-## 4.3 The Past principle
+## 4.3 The Past Hypothesis
 
-This idea-that the arrow of time traces back to a special beginning-is called the **Past principle**.
+This idea-that the arrow of time traces back to a special beginning-is called the **Past Hypothesis**.
 
 ### What Low Entropy Means for the Early Universe
 
@@ -132,14 +132,14 @@ laws.
 
 **The hint**: The microscopic laws are time-symmetric. Irreversibility is statistical, not fundamental. The arrow traces to the low-entropy initial condition.
 
-**The reframing**: OPH gives the Past principle a consistency role. Standard physics usually treats the low-entropy beginning as a brute fact, an unexplained initial condition. This picture suggests why low-entropy beginnings are structurally important.
+**The reframing**: OPH gives the Past Hypothesis a consistency role. Standard physics usually treats the low-entropy beginning as a brute fact, an unexplained initial condition. This picture suggests why low-entropy beginnings are structurally important.
 
 Consider: for observers to exist at all, they must be able to form consistent records. Records require entropy gradients-you can only write information by pushing entropy somewhere else. A universe in thermal equilibrium has no observers, no records, no consistency-checking, no reality in the sense we've been developing.
 
 The MaxEnt principle tells us to assign the maximum-entropy state *given our constraints*. But what are the constraints? If one of them is "observers exist to apply MaxEnt," then equilibrium states are ruled out by construction. The very act of asking "what state should I assign?" presupposes a questioner embedded in an entropy gradient.
 
 This does not derive the specific low entropy of the Big Bang from pure logic.
-It does show why the Past principle is structurally important in this picture.
+It does show why the Past Hypothesis is structurally important in this picture.
 A universe with durable observers checking for consistency requires a
 significant departure from equilibrium. The low-entropy past is therefore a
 structural precondition for the consistency-building present.
@@ -404,7 +404,7 @@ geometry. The work of making observations agree consumes free energy and
 generates entropy. Durable observers therefore require entropy gradients, and
 entropy gradients point back toward a low-entropy beginning.
 
-On this reading, the Past principle is not a decorative extra. It is part of
+On this reading, the Past Hypothesis is not a decorative extra. It is part of
 the deep structure required for records, comparison, and public reality.
 
 ## 4.11 Summary: The Entropy Budget

--- a/book/chapter-05-algebra.md
+++ b/book/chapter-05-algebra.md
@@ -23,10 +23,9 @@ $$[X, P] = XP - PX = i\hbar$$
 This is the **commutator**, and it's the heart of quantum mechanics.
 
 The symbols are the whole lesson. $X$ is the position operator. $P$ is the
-momentum operator. Writing $XP$ means "ask the momentum question after the
-position question" in the algebraic order used by operators, while $PX$ means
-the reverse order. The bracket $[X,P]$ measures the failure of those two orders
-to agree. The number $i$ is the imaginary unit and $\hbar$ is Planck's
+momentum operator. Writing $XP$ and $PX$ means composing the two operations in
+opposite orders. The bracket $[X,P]$ measures the failure of those two
+compositions to agree. The number $i$ is the imaginary unit and $\hbar$ is Planck's
 constant divided by $2\pi$. Nature is not saying that our instruments are
 clumsy. It is saying that these two questions do not belong to one classical
 spreadsheet of pre-existing answers.
@@ -84,7 +83,7 @@ The working idea is simple: non-commutativity is part of what makes overlap cons
 
 Consider the overlap condition. When two observers compare notes, they must agree on their shared observables. In a commutative world-where all measurements are compatible-the problem is much closer to the classical marginal setting. Pre-existing values can often be assigned more straightforwardly, especially on simple overlap structures, but compatibility is not automatic on arbitrary overlap graphs.
 
-The Quantum Marginal Problem shows where the classical intuition breaks. Pairwise-consistent marginals can fail to glue into a global state. The consistency constraints are non-trivial precisely because some observables do not commute.
+The Quantum Marginal Problem shows that the difficulty survives in a sharper form. Pairwise-compatible reduced states can still fail to come from one global state. Non-commutativity intensifies the quantum consistency problem, but it is not the only obstruction to gluing.
 
 **Non-commutativity makes the quantum consistency problem especially hard.** If measurements all commuted, the overlap conditions would be much closer to the classical case. Physics could have rich laws and dynamics, while missing the specifically quantum constraint structure highlighted here.
 
@@ -147,7 +146,7 @@ Thomas Bayes and Pierre-Simon Laplace developed the rules for updating probabili
 
 $$P(A|B) = \frac{P(B|A)P(A)}{P(B)}$$
 
-This "Bayesian update" is how rational agents modify beliefs in light of evidence. If two observers start with the same priors and observe the same evidence, this rule guarantees they reach the same posteriors.
+This "Bayesian update" is how rational agents modify beliefs in light of evidence. If two observers start with the same priors and observe the same evidence, this rule guarantees the same posteriors.
 
 The vertical bar means "given." $P(A|B)$ is the probability of $A$ after
 learning $B$. $P(A)$ is the prior probability of $A$, $P(B|A)$ says how likely
@@ -155,7 +154,7 @@ the evidence $B$ would be if $A$ were true, and $P(B)$ normalizes the result.
 Bayes' rule is a small equation with a large moral for this book: shared
 evidence can make separate observers converge.
 
-This is a form of consistency. Bayesian reasoning ensures that observers who share information will converge.
+This is one form of consistency. Bayesian reasoning shows how shared evidence can drive convergence when the starting assumptions are sufficiently aligned.
 
 ### From Sets to Hilbert Space
 
@@ -349,9 +348,11 @@ This connects to the **thermal time principle** of Connes and Rovelli: modular f
 
 ## 5.11 Commutation and Causality
 
-The locality axiom says disjoint patches have commuting algebras:
+The locality axiom says observables from disjoint patches commute: if
+$A \in \mathcal{A}(P)$ and $B \in \mathcal{A}(Q)$ with $P \cap Q = \emptyset$,
+then
 
-$$[A(P), A(Q)] = 0 \text{ when } P \cap Q = \emptyset$$
+$$[A, B] = 0$$
 
 ### But What About Entanglement?
 
@@ -361,11 +362,11 @@ The key distinction: **correlations** are not **influence**.
 
 Alice and Bob share an entangled pair. Alice measures and gets "up." She can then infer that Bob will measure "up." But she hasn't influenced Bob's particle-she has learned about it.
 
-The commutation relation [A(P), A(Q)] = 0 says Alice's measurement operator doesn't change Bob's statistics. Before Alice measures, Bob has 50/50 odds. After Alice measures, Bob still has 50/50 odds. Alice's knowledge changed, but not Bob's physics.
+The commutation relation above says Alice's measurement operator doesn't change Bob's statistics. Before Alice measures, Bob has 50/50 odds. After Alice measures, Bob still has 50/50 odds. Alice's knowledge changed, but not Bob's physics.
 
 Bell's theorem shows these correlations cannot be explained by local hidden variables. The correlations are genuinely quantum. But they still respect causality: no signal can be sent using entanglement alone.
 
-The algebraic condition [A(P), A(Q)] = 0 is the mathematical statement that consistency and causality can coexist, even with entanglement.
+That algebraic locality condition is the mathematical statement that consistency and causality can coexist, even with entanglement.
 
 ## 5.12 The Reverse Engineering Summary
 


### PR DESCRIPTION
This pass fixes a small set of genuine public-review vulnerabilities in the opening five chapters.

Chapter 1 narrows the measurement discussion so definiteness is attached to operational records and shared event surfaces, rather than reading like an unrestricted theorem about all observer experience, and it tightens the closing holography sentence so it no longer states a fully general boundary-encoding result too broadly.

Chapter 2 fixes a malformed sentence in the philosophy setup and clarifies that the screen data is not yet the reconstructed 3D bulk geometry.

Chapter 3 replaces one over-strong UV-thermalization sentence with the fixed-cutoff MaxEnt / Gibbs-like wording used by the paper surface and tightens the bulk-distance sentence so it reads as a reconstruction rule rather than an identity.

Chapter 4 restores the standard `Past Hypothesis` terminology.

Chapter 5 corrects two real technical slips: the marginal-gluing discussion no longer treats noncommutativity as the only obstruction, and the locality formula now states commutation for observables `A in A(P)` and `B in A(Q)` instead of writing whole algebras as if they were single operators. The Bayesian-convergence sentence is also narrowed to the assumptions that actually justify it.