### PR TITLE
fix: Tighten book chapters 06-10 against current OPH claim boundaries

### DIFF
--- a/book/chapter-06-overlap.md
+++ b/book/chapter-06-overlap.md
@@ -172,7 +172,8 @@ The hardness of the Quantum Marginal Problem tells us the filter is doing real w
 
 Overlap conditions favor allowing correlations that exceed classical bounds.
 Bell-violating correlations can then be read as part of the quantum structure
-that helps keep patches consistent without a large hidden-variable overhead.
+available to an observer-consistency framework, without appealing to a large
+hidden-variable overhead.
 
 In a universe built on observer agreement, the nonlocal correlations that so troubled Einstein are not inexplicable. They become part of the consistency structure, with no unexplained add-on.
 
@@ -263,7 +264,9 @@ handle.
 
 In classical physics, local data often determine global data on simple overlap structures, and compatibility checking is much easier than in the quantum case.
 
-In quantum physics, local data constrain but don't determine global data. Checking consistency is computationally hard-there's no efficient algorithm to decide if quantum marginals are compatible.
+In quantum physics, local data constrain but don't determine global data. In
+the worst case, checking consistency is computationally hard-there is no known
+efficient general algorithm to decide whether quantum marginals are compatible.
 
 This shows that quantum mechanics hides global structure in a fundamentally complex way. You can't easily deduce the whole from the parts.
 
@@ -408,7 +411,7 @@ The answer involves a concept called **quantum Darwinism**, developed by Wojciec
 
 The mechanism is environmental copying. A quantum system interacts with air molecules, photons, and everything around it. Some information about the system gets copied into the environment. Quantum mechanics forbids perfect copying of arbitrary unknown states, so the useful information is redundantly encoded in stable records.
 
-Consider Schroedinger's cat. If the cat is alive, air molecules bounce off it in a certain way. Light reflects off it in a certain way. Heat radiates from it in a certain way. Each of these environmental fragments carries partial information about the cat's state.
+Consider Schrödinger's cat. If the cat is alive, air molecules bounce off it in a certain way. Light reflects off it in a certain way. Heat radiates from it in a certain way. Each of these environmental fragments carries partial information about the cat's state.
 
 When you look at the cat, you're not accessing the cat directly-you're reading information from these environmental fragments. Many observers can read many different fragments and agree.
 

--- a/book/chapter-07-recovery.md
+++ b/book/chapter-07-recovery.md
@@ -78,9 +78,11 @@ The information isn't destroyed. It's scrambled. Hidden in correlations among bi
 
 ### The Universe's Error Correction
 
-**The universe is built with error-correcting structure that preserves information even when it appears lost.**
+**The universe appears to use error-correcting structure that preserves information even when it appears lost.**
 
-In quantum mechanics, this requirement is non-negotiable. Quantum evolution is **unitary**-reversible by definition. If information could genuinely be destroyed, unitarity would break. If unitarity breaks, probabilities don't sum to 1. Physics collapses into nonsense.
+In quantum mechanics, this requirement is non-negotiable. Closed-system quantum
+evolution is **unitary**. If information were genuinely destroyed in that
+setting, the standard quantum-mechanical evolution law would fail.
 
 So the universe must preserve information, even when it looks scrambled beyond recognition. There must be a mechanism-a "Save Game" feature-that allows, in principle, the smoke to remember what the scroll said.
 
@@ -121,7 +123,9 @@ The universe has finite resources. Recovery must be efficient, local, bounded. Y
 
 This constraint shapes reality. The area law says a boundary can only carry so many bits. If information capacity is bounded by area, then recovery must respect geometry. Distant regions can't share unlimited redundancy.
 
-**Spacetime itself behaves like a Shannon code.** Gravity acts like an error corrector, keeping the global account consistent even when local observations are noisy.
+**Spacetime can be read through a Shannon-code analogy.** Gravity then acts
+like an error corrector, keeping the global account consistent even when local
+observations are noisy.
 
 ## 7.5 The Mathematics of Redundancy
 
@@ -242,7 +246,10 @@ $\rho_{BC}$ is the reference correlation pattern telling the map how $B$ and
 $C$ fit together. The square roots and inverse square roots are matrix
 operations that rebalance the known state before rebuilding the missing side.
 
-Don't worry about the formula's details. This is a physical operation, something you could implement with a quantum computer. Given only B's state sigma, the Petz map outputs a state on BC that correctly reproduces all correlations with A.
+Don't worry about the formula's details. This is a physical operation, in
+principle something you could implement on a quantum device. Given only B's
+state sigma, the Petz map outputs a comparison state on BC that reproduces the
+reference correlations in the exact Markov case.
 
 Think of it like calibrating a distorted photograph. The original image (BC) got scrambled into a noisy version (B alone). The Petz map knows what the original "should" look like (from the reference state rho_BC) and applies the inverse distortion.
 
@@ -353,13 +360,13 @@ The recovery rule has dramatic consequences. If the interior of a region can be
 recovered from its boundary, bulk physics is encoded in boundary physics. If
 $I(A:C|B)$ is small, then $A$ and $C$ behave independently once $B$ is known,
 which is exactly the operational face of locality. Ground states of local
-Hamiltonians tend toward area-law entanglement because recovery keeps the
-correlations under control. Classical facts become the records that survive
-because they are redundantly encoded.
+Hamiltonians often show area-law entanglement, and recoverability helps explain
+why correlations can remain organized in a boundary-sensitive way. Classical
+facts become the records that survive because they are redundantly encoded.
 
-## 7.10 The Black Hole Information Paradox Resolved
+## 7.10 The Black Hole Information Paradox Reframed
 
-The recovery rule resolves one of physics' most famous puzzles.
+The recovery perspective sharpens one of physics' most famous puzzles.
 
 ### Hawking's Calculation
 
@@ -462,7 +469,8 @@ information does not need to sit in one place to survive.
 
 ## 7.13 The Indestructible Past
 
-The recovery rule has a startling implication: in this recoverability picture, nothing is ever truly lost.
+The recovery rule has a startling implication: in this recoverability picture,
+nothing is simply deleted from the full quantum description.
 
 If the universe is unitary and holographic encoding is robust, information is not simply destroyed; it is redistributed into increasingly nonlocal correlations of the full quantum state.
 
@@ -470,7 +478,8 @@ The Library of Alexandria? The scrolls burned, and the information scrambled int
 
 Paleontology and astronomy use weak versions of this. Fossils preserve information about creatures from millions of years ago. Astronomy records light that has traveled for billions of years before reaching our telescopes. The cosmic microwave background is one vivid example of very old information preserved in radiation.
 
-The recovery rule says this is not accident or luck. It's structural: the past is encoded in the present in increasingly scrambled form.
+The recovery rule says this is not accident or luck. In a unitary encoding
+picture, the past is carried forward in increasingly scrambled form.
 
 ### The Structural Constraint
 
@@ -493,7 +502,9 @@ why black holes do not behave like cosmic shredders. And it is why spacetime
 starts to look like a code, a structure whose geometry and stability are tied
 to the same redundancy that protects information.
 
-Shannon started with a practical problem-sending messages over noisy phone lines. His solution, redundancy, turns out to be built into spacetime itself. The universe is the ultimate error-correcting code.
+Shannon started with a practical problem-sending messages over noisy phone
+lines. His solution, redundancy, reappears as one of the strongest organizing
+analogies for spacetime and holographic encoding.
 
 ---
 

--- a/book/chapter-08-holography.md
+++ b/book/chapter-08-holography.md
@@ -110,7 +110,10 @@ observer's patch includes a region of the boundary. When patches overlap, the
 boundary values must agree. The bulk emerges as the most consistent account
 that fits all the boundary data.
 
-This explains why information scales with area, not volume. The boundary is the fundamental storage; the bulk is derivative. There's no hidden interior capacity beyond what the surface encodes-because the interior *is* the surface, reorganized into a convenient three-dimensional description.
+This explains why information scales with area, not volume. The boundary is the
+fundamental storage; the bulk is derivative. In the holographic settings that
+motivate the chapter, there is no independent interior bookkeeping beyond what
+the surface encodes.
 
 ## 8.4 The Soup Can Universe
 
@@ -122,7 +125,11 @@ It's not our universe-our universe has positive curvature, with an accelerating 
 
 Imagine the label on the can as a living quantum field theory with particles, forces, and fluctuations. It has no gravity of its own. It just lives on the surface.
 
-The bold claim is exact: **everything happening inside the can is exactly the same as what happens on the label**. A falling particle in the bulk corresponds to ripples on the boundary. A black hole forming inside corresponds to hot plasma on the surface. This isn't an approximation. It's a perfect translation.
+The bold claim is exact in that duality: **everything happening inside the can
+is exactly the same as what happens on the label**. A falling particle in the
+bulk corresponds to ripples on the boundary. A black hole forming inside
+corresponds to hot plasma on the surface. This isn't an approximation. It's a
+perfect translation within AdS/CFT.
 
 This is the **AdS/CFT correspondence**, the most important theoretical discovery in physics of the past thirty years.
 
@@ -334,7 +341,8 @@ Black holes saturate the quantum **chaos bound**-they're the fastest scramblers 
 
 ## 8.12 How Gravity Emerges from Entanglement
 
-The deepest insight from holography is that gravity isn't fundamental. It emerges from entanglement structure on the boundary.
+One of holography's deepest insights is that gravity may be emergent from
+entanglement structure on the boundary.
 
 ### Entanglement Builds Geometry
 
@@ -389,10 +397,10 @@ then Jacobson's thermodynamic argument applies. Under those conditions, Einstein
 equations emerge as the natural effective way for observer horizons to remain
 thermodynamically consistent.
 
-Four-dimensional spacetime geometry works so well because it is the
-thermodynamic equilibrium of horizon entropy. The geometry we observe is the
-most probable configuration, the one that maximizes entropy subject to matter
-constraints.
+On this thermodynamic reading, four-dimensional spacetime geometry works so well
+because it behaves like an equilibrium description of horizon entropy. The
+geometry we observe is then read as the effective configuration favored by that
+entropy bookkeeping under matter constraints.
 
 ## 8.13 What We Borrow from AdS/CFT (and What We Don't)
 
@@ -417,7 +425,7 @@ finite horizon.
 
 ### The De Sitter Advantage
 
-De Sitter space is actually **better suited** to this approach than AdS.
+De Sitter space is, in one important respect, **well suited** to this approach.
 
 In AdS/CFT, there's one global boundary that all observers share. A global CFT lives on it. The bulk and boundary are two complete, equivalent descriptions.
 
@@ -429,7 +437,9 @@ needed to make this work.
 
 For that reason, OPH is not a dS/CFT proposal. A hypothetical dS/CFT would posit a CFT at future infinity dual to de Sitter bulk physics. The claim here is weaker and more concrete:
 
-**Observer-patch consistency on cosmological horizons, combined with entanglement equilibrium, yields semiclassical gravity in the bulk.**
+**Observer-patch consistency on cosmological horizons, combined with the
+entanglement-equilibrium / Jacobson-style branch, can yield semiclassical
+gravity in the bulk.**
 
 The bulk and boundary do not need to be complete dual descriptions. The bulk emerges from the boundary through consistency and compression. It is not an independent theory that happens to match.
 

--- a/book/chapter-09-entanglement.md
+++ b/book/chapter-09-entanglement.md
@@ -211,7 +211,8 @@ The **Multi-scale Entanglement Renormalization Ansatz** (MERA) handles critical 
 
 In 2012, Brian Swingle noticed something striking: the geometry of a MERA network is **hyperbolic**-just like AdS space. The depth in the network plays the role of the radial direction in AdS.
 
-MERA isn't just a numerical trick. It's a discrete version of AdS/CFT-the first concrete circuit that turns entanglement into geometry.
+MERA isn't just a numerical trick. It is one influential discrete model showing
+how entanglement can organize geometry in an AdS-like way.
 
 ### The HaPPY Code
 
@@ -242,7 +243,9 @@ system made from $B$ and $C$." The inequality says that entanglement cannot be
 freely duplicated. If $A$ uses up its entanglement budget with $B$, less is
 available for $C$.
 
-That's what locality means. Things can only be near a limited number of other things. Geometry emerges from the constraints of entanglement monogamy.
+That is one reason locality can emerge. Things can only be near a limited
+number of other things. Geometry can then inherit sparse structure from the
+constraints of entanglement monogamy.
 
 ## 9.9 Entanglement Wedges and Reconstruction
 
@@ -294,13 +297,15 @@ respect unitarity through encoded interior information.
 That is the direction the evidence points. Ryu-Takayanagi works in the
 settings where it should. Area-law scaling is widespread in the regimes that
 matter here. Entanglement wedge reconstruction works in explicit examples.
-Black-hole information is read through encoded radiation, not deletion.
+Black-hole information is read through encoded radiation, not simple deletion,
+in the semiclassical holographic models where the island/Page-curve picture is
+under control.
 
 ### Entanglement as a Discovery Chain
 
 Entanglement has one of the strangest histories in physics because it began
 as a complaint. Einstein, Podolsky, and Rosen used it in 1935 to argue that
-quantum mechanics could not be complete. Schrodinger answered by naming the
+quantum mechanics could not be complete. Schrödinger answered by naming the
 phenomenon and emphasizing that entanglement was not a small detail. It was
 the distinctive feature of quantum theory. For decades the issue looked
 philosophical. Then John Bell found the inequality that moved the argument

--- a/book/chapter-10-error-correction.md
+++ b/book/chapter-10-error-correction.md
@@ -74,7 +74,8 @@ memories fade, quantum fluctuations intrude. If two observers want to agree on
 a shared world, they need redundancy, overlap, and a correction protocol. That
 is exactly what error-correcting codes provide.
 
-**Reality is error-corrected.** The consistency we observe requires robust encoding of shared information.
+**Reality can be read as error-corrected.** The consistency we observe requires
+robust encoding of shared information.
 
 ### Holographic Error Correction
 
@@ -84,7 +85,9 @@ In 2015, Almheiri, Dong, and Harlow (ADH) showed that the AdS/CFT dictionary has
 
 The geometric structure is controlled by **entanglement wedges**. For a boundary region A, the entanglement wedge is the bulk region that can be reconstructed from A. A bulk point can be reconstructed from any boundary region whose entanglement wedge contains it.
 
-This redundancy makes the bulk stable. Operators deep in the bulk require large boundary regions to reconstruct-they have high code distance. The radial direction in AdS corresponds to protection level. Depth equals robustness.
+This redundancy makes the bulk stable. Operators deep in the bulk require large
+boundary regions to reconstruct-they have high code distance. In the toy-model
+picture, radial depth tracks protection level.
 
 ### The HaPPY Code
 
@@ -245,7 +248,10 @@ protected subspace in the same bland way, differing only by an overall number.
 The physical carrier may be damaged, but the logical information stays hidden
 from the noise. That hiddenness is what makes recovery possible.
 
-In quantum gravity, we only have approximate codes. The Knill-Laflamme condition holds up to 1/N corrections. This is enough to make classical spacetime look stable.
+In quantum gravity, we only have approximate codes. The Knill-Laflamme
+condition is correspondingly approximate, with corrections often organized in
+powers of \(1/N\). That is enough to make classical spacetime look stable in
+the controlled large-\(N\) settings where the code picture applies.
 
 ## 10.9 The Threshold Theorem
 


### PR DESCRIPTION
This pass fixes the main chapter-06-to-10 places where the book was stronger than the current paper surface.

Chapter 6 now states the quantum-marginal hardness claim in the standard worst-case form, slightly narrows the Bell-consistency interpretation so it reads as an OPH-compatible structural reading rather than a completed derivation, and fixes `Schrödinger`.

Chapter 7 tightens the recovery language substantially. The no-loss discussion no longer reads like OPH has already proved a full black-hole-evaporation theorem, the Petz paragraph now distinguishes exact-Markov comparison-state recovery from a blanket “correctly reproduces all correlations” claim, the area-law sentence no longer overstates what recovery alone explains, and the closing rhetoric is kept strong without claiming more than the present holographic/island support tier.

Chapter 8 keeps the holography chapter ambitious but removes a few technically attackable shortcuts: AdS/CFT exactness is now explicitly scoped to that duality, the “gravity isn’t fundamental” line is softened to an emergent reading, the de Sitter comparison no longer claims it is simply “better suited,” and the OPH gravity sentence now tracks the Jacobson / entanglement-equilibrium branch language used in the paper.

Chapter 9 narrows MERA and monogamy claims so they read as strong structural clues rather than universal identifications, and it limits the radiation-encoding sentence to the semiclassical holographic settings where that picture is actually under control. It also fixes `Schrödinger`.

Chapter 10 now phrases the error-correction thesis as an OPH reading rather than a literal theorem, scopes the radial-depth/code-distance sentence to the toy-model setting, and makes the approximate Knill-Laflamme sentence explicitly about controlled large-`N` holographic code regimes.