### PR TITLE
fix: Tighten book chapters 11-15 against current OPH paper scope

### DIFF
--- a/book/chapter-11-maxent.md
+++ b/book/chapter-11-maxent.md
@@ -23,7 +23,7 @@ General relativity and quantum theory broke that picture.
 
 Physics has a scandal.
 
-Almost all our fundamental laws are time-reversible. Newton's F = ma works the same forward and backward. Maxwell's equations are reversible. Schroedinger's equation is reversible. Einstein's General Relativity is reversible.
+Almost all our fundamental laws are time-reversible. Newton's F = ma works the same forward and backward. Maxwell's equations are reversible. Schrödinger's equation is reversible. Einstein's General Relativity is reversible.
 
 Film a planet orbiting a star and play it backward-it looks perfectly physical. But film an egg breaking and play it backward? Absurd.
 
@@ -33,7 +33,7 @@ This is the **Arrow of Time**. Where does it come from? It's not in the microsco
 
 In general relativity, there's no preferred time coordinate. Different observers slice spacetime differently; none is privileged.
 
-The Wheeler-DeWitt equation-the analog of Schroedinger's equation for the universe-is:
+The Wheeler-DeWitt equation-the analog of Schrödinger's equation for the universe-is:
 
 $$H\Psi = 0$$
 
@@ -137,19 +137,19 @@ In Chapter 4, we saw Boltzmann's insight: entropy $S = k \ln W$ measures the num
 
 But why did the universe start with low entropy in the first place?
 
-### The Past principle
+### The Past Hypothesis
 
-The deeper answer to the arrow of time is the **Past principle**: the universe began in a state of extraordinarily low entropy.
+The deeper answer to the arrow of time is the **Past Hypothesis**: the universe began in a state of extraordinarily low entropy.
 
 We are riding the expansion from a very special initial condition: the Big Bang. The early universe was hot and smooth, with matter spread almost uniformly. That uniformity is low gravitational entropy.
 
 Why was the Big Bang low entropy? Standard physics treats this as an unexplained initial condition. OPH gives the condition a role in record formation.
 
-**The Past principle as a consistency requirement**: For observers to exist at all, they must be able to form and compare records. Records require entropy gradients-you can only write information by pushing entropy elsewhere. A universe in thermal equilibrium contains no observers, no records, no consistency-checking.
+**The Past Hypothesis as a consistency requirement**: For observers to exist at all, they must be able to form and compare records. Records require entropy gradients-you can only write information by pushing entropy elsewhere. A universe in thermal equilibrium contains no observers, no records, no consistency-checking.
 
 The MaxEnt principle says: assign the maximum-entropy state consistent with your constraints. But one constraint is that someone must exist to apply MaxEnt. This rules out equilibrium. The very existence of observers selecting MaxEnt states presupposes a universe far from equilibrium.
 
-This doesn't derive the specific numerical entropy of the Big Bang. But it reframes the question: the Past principle isn't an arbitrary input to be explained by some deeper theory. It can be read as a consistency requirement. A universe containing observers who check for consistency appears to require a low-entropy beginning. The arrow of time points in the direction that allows records to be made.
+This doesn't derive the specific numerical entropy of the Big Bang. But it reframes the question: the Past Hypothesis isn't an arbitrary input to be explained by some deeper theory. It can be read as a consistency requirement. A universe containing observers who check for consistency appears to require a low-entropy beginning. The arrow of time points in the direction that allows records to be made.
 
 ## 11.5 Jaynes: Entropy as Ignorance
 
@@ -194,17 +194,17 @@ trace over $\bar P$ discards inaccessible degrees of freedom and leaves the
 state available to the observer. The logarithm then turns that restricted
 state into the modular generator for the patch.
 
-**Every observer has their own emergent clock.**
+**Each observer patch carries its own emergent modular clock.**
 
 ### Consistency of Clocks
 
-If two observers' patches overlap, their modular times must be compatible on the overlap. This is a strong constraint. Reality hangs together because the modular flows mesh.
+If two observers' patches overlap, their modular times have to agree on the shared operational content. On the smooth geometric branch, that compatibility is what later supports a shared causal structure.
 
 ### Cosmic Time
 
 Why do we all agree on a "cosmic time"?
 
-If the global state is highly entangled in a particular pattern, the modular flows of local patches are synchronized. Cosmic time emerges as the "center of mass" of all local modular times.
+If the global state synchronizes many local modular flows, a shared coarse-grained cosmic time can emerge as an effective collective clock. It is not a second fundamental time parameter.
 
 ### Roadmap: From Modular Time to Gravity
 
@@ -301,12 +301,12 @@ One structure is doing two jobs at once. Read algebraically, it is the modular e
 
 ### Boosts from Thermal Structure
 
-Start with thermal structure. Ask: what is the natural notion of time evolution? The answer is Lorentz boosts.
+Start with thermal structure. Ask: what is the natural notion of time evolution? In the wedge setting, the answer is Lorentz boosts.
 
 This reverses the usual logic in QFT. We don't postulate Lorentz symmetry and then discover thermal horizons; the BW theorem shows the boost structure is encoded in modular flow.
 
-That modular-boost link is the route by which Lorentz kinematics and a
-universal light speed are recovered on the screen.
+That modular-boost link is the route by which the smooth geometric branch
+recovers Lorentz kinematics and a universal causal speed on the screen.
 
 ### Connection to OPH
 
@@ -338,7 +338,7 @@ The modular flow provides the time direction. Entanglement provides correlations
 
 Einstein discovered special relativity in 1905 by thinking about light and motion. QFT gives the same structure another reading: Lorentz boosts are tied to horizon thermodynamics via the Bisognano-Wichmann theorem. In OPH the same pattern appears when the screen reaches its smooth geometric limit, so the Lorentz group shows up as the geometry of modular flow on caps.
 
-The laws of physics look the same to all inertial observers because thermal states on wedge-shaped regions naturally evolve via boosts. In the OPH program, the universal speed emerges when that modular-boost structure is carried over to the screen and then read back into bulk kinematics.
+The laws of physics look the same to all inertial observers because thermal states on wedge-shaped regions naturally evolve via boosts. In the OPH program, the universal speed emerges on the smooth geometric branch when that modular-boost structure is carried over to the screen and then read back into bulk kinematics.
 
 ## 11.10 What Time Predicts
 

--- a/book/chapter-12-symmetry.md
+++ b/book/chapter-12-symmetry.md
@@ -127,7 +127,7 @@ state by an overall phase changes the vector but not the physical state. That
 small freedom is what lets spinors carry the minus sign after a 360-degree
 rotation without changing observable probabilities.
 
-The matter content of the universe-quarks, leptons, all fermions-exists because quantum mechanics allows projective representations of the screen's symmetry group.
+Half-integer-spin matter sectors become possible because quantum mechanics allows projective representations of the screen's symmetry group.
 
 ## 12.6 Wigner's Classification
 
@@ -145,7 +145,7 @@ discrete ladder $0, 1/2, 1, 3/2, 2, \ldots$.
 
 That's it. Those are the only quantum numbers that follow from spacetime symmetry.
 
-**Particles are representations of symmetries.** The specific zoo of particles is dictated by the symmetry group of the boundary.
+**Particles are representations of symmetries.** Spacetime symmetry fixes the mass-and-spin labels, while the realized internal charges and matter content require additional structure.
 
 That is a profound change in what a particle is. A particle is not a tiny marble with a fixed identity tag. It is an allowed transformation pattern. Mass tells you how the excitation sits with time translations. Spin tells you how it sits with rotations.
 
@@ -153,7 +153,7 @@ The spare label set matters. Once the symmetry group is fixed, only a limited me
 
 ## 12.7 The Standard Model Gauge Groups
 
-The Standard Model is based on the gauge group:
+One usually writes the Standard Model gauge group as:
 
 $$G_{SM} = SU(3) \times SU(2) \times U(1)$$
 
@@ -231,7 +231,7 @@ A conserved current on the screen creates a gauge boson in the bulk.
 
 ### Our Route: Gauge Group from Gluing
 
-In this book we take a different route. The gauge group is not assumed in advance. Instead, we look at what happens when you glue observer patches together: fixed-cutoff edge charges fuse in specific ways, their transport data persists coherently across refinement, and the compatible multiplicity spaces descend with them. A reconstruction theorem then lets you work backward from that persistent sector package to the symmetry group behind it. A minimal admissible realization principle fixes the realized low-energy branch, and the answer turns out to be exactly $SU(3) \times SU(2) \times U(1)/\mathbb{Z}_6$, the Standard Model gauge group. On that same branch, the minimal coupled carrier fixes three colors, while CKM phase counting together with weak-sector ultraviolet consistency fixes three generations.
+In this book we take a different route. The gauge group is not assumed in advance. Instead, we look at what happens when you glue observer patches together: fixed-cutoff edge charges fuse in specific ways, their transport data persists coherently across refinement, and the compatible multiplicity spaces descend with them. A reconstruction theorem then lets you work backward from that persistent sector package to the symmetry group behind it. On the realized one-Higgs low-energy branch, the physical gauge group is exactly $SU(3) \times SU(2) \times U(1)/\mathbb{Z}_6$. On that same branch, the minimal coupled carrier fixes the realized color triplet, while CKM phase counting together with weak-sector ultraviolet consistency picks the minimal viable generation count.
 
 The notation looks forbidding, but the roles are practical. $SU(3)$ is the
 color accounting system for quarks. $SU(2)$ is the weak doublet accounting
@@ -291,7 +291,7 @@ You can break C, P, T, CP, CT, PT individually. But if you apply all three toget
 The consequences are famously sharp. Every particle has an antiparticle with
 exactly the same mass, and particle and antiparticle lifetimes are identical.
 
-On the screen, CPT corresponds to mapping every point to its antipode and reversing the modular flow.
+A full screen implementation of CPT is subtler than a literal antipodal map. At book level, the clean statement is that the effective Lorentzian field-theory limit inherits the usual combined charge, parity, and time-reversal symmetry.
 
 CPT is the immune system of reality-the consistency check that can never be bypassed.
 

--- a/book/chapter-13-desitter.md
+++ b/book/chapter-13-desitter.md
@@ -163,11 +163,11 @@ This fits naturally with OPH. Reality is a collection of consistent patches. You
 
 Where should we put the holographic screen in de Sitter?
 
-The natural answer: on the cosmological horizon.
+A natural candidate: on the cosmological horizon.
 
 For an observer at $r = 0$, the horizon is a sphere at $r = c/H$. This sphere has area $4\pi c^2/H^2$ and the entropy capacity above.
 
-The three-dimensional bulk inside the horizon is encoded holographically on the two-dimensional horizon.
+The three-dimensional bulk inside the horizon is treated holographically as data organized on the two-dimensional horizon.
 
 When an object falls toward the horizon, it gets redshifted and appears to freeze onto the surface, its information smeared across the screen.
 
@@ -200,13 +200,13 @@ equation that acts like a uniform large-scale tendency for space to accelerate.
 OPH reads it as global capacity data, not as one more local particle-physics
 coupling.
 
-So Lambda must be fixed by a **global** constraint: the total capacity of the screen. In natural units, the relationship is:
+So on the D6 closure branch Lambda is fixed by a **global** constraint: the total capacity of the screen. In natural units, once $N_{\mathrm{scr}}=\log(\dim \mathcal{H}_{\text{tot}})$ is supplied, the relationship is:
 
 $$\Lambda = \frac{3\pi}{G \cdot \log(\dim \mathcal{H}_{\text{tot}})}$$
 
 In the book's reading, the observed $\Lambda$ is the way the world announces
-its total screen capacity. It is the global size parameter carried by every
-consistent patch.
+its total screen capacity once that global input is identified. It is the
+global size parameter carried by every consistent patch.
 
 The symbol $\mathcal H_{\text{tot}}$ means the total Hilbert space available to
 the screen, and $\dim$ means its dimension, the number of independent quantum
@@ -277,9 +277,9 @@ OPH suggests a different route.
 
 ### The Modular Anomaly
 
-In Chapter 11, we saw that a first-variation Einstein relation, later upgraded to the semiclassical Einstein equation, emerges from an entanglement-equilibrium argument in the scaling regime. But that derivation assumed perfect Markov structure-perfect recoverability across patch overlaps.
+In Chapter 11, we saw that a first-variation Einstein relation emerges from an entanglement-equilibrium argument in the scaling regime, and that the same branch can be upgraded to the semiclassical Einstein equation. The continuation below asks what happens when one moves away from the ideal recoverability limit.
 
-In reality, the Markov condition is only approximate. There's always some residual correlation that can't be perfectly captured by the boundary alone. This imperfection appears as an extra term:
+In the phenomenological continuation considered here, the Markov condition is treated as only approximate. Some residual correlation is then not perfectly captured by the boundary alone. That imperfection is packaged as an extra term:
 
 $$K_C = 2\pi B_C + K_C^{(\text{anom})} + \text{const}$$
 
@@ -297,14 +297,14 @@ energy and has no direct observational role.
 
 $$G_{00} + \Lambda g_{00} = 8\pi G \left( \langle T_{00} \rangle + \langle T_{00}^{\text{anom}} \rangle \right)$$
 
-The coefficient is fixed by the derivation: $\frac{15}{8\pi^2} \approx 0.19$.
+The continuation highlighted here uses the coefficient $\frac{15}{8\pi^2} \approx 0.19$.
 
 ### Why This Is "Dark"
 
-The anomalous term $T_{00}^{\text{anom}}$ is dark by construction. It arises
-from information structure, not from Standard Model fields, it
-gravitates, and it does not couple electromagnetically. That gives it exactly
-the profile a dark component ought to have.
+In this continuation, the anomalous term $T_{00}^{\text{anom}}$ is dark at the
+level of its couplings. It arises from information structure rather than
+Standard Model fields, it gravitates, and it carries no direct electromagnetic
+coupling in the effective description.
 
 ### The Acceleration Scale
 
@@ -329,9 +329,9 @@ de Sitter capacity logic that fixed the horizon.
 
 ### What This Continuation Looks Like
 
-If the modular anomaly is read as part of the dark sector, the deep infrared
-picture takes a familiar form. In the regime where $g<a_0$, the effective
-gravitational acceleration can be written as
+If the modular anomaly is read as part of the dark sector, one MOND-like
+continuation takes a familiar deep-infrared form. In the regime where $g<a_0$,
+the effective gravitational acceleration is written as
 
 $$g_{\text{obs}} \approx \sqrt{a_0 \cdot g_b}$$
 
@@ -348,10 +348,11 @@ The same picture yields the baryonic Tully-Fisher relation:
 
 $$V^4 = G \cdot M_b \cdot a_0^{(\text{OPH})}$$
 
-This has the observed Tully-Fisher form, with its normalization set by screen
-capacity. The dark sector is then read as an infrared correction to gravity,
-not as a new species of particle. The cosmological constant and the
-galaxy-scale anomaly sit inside one de Sitter picture.
+This is the observed Tully-Fisher form that the continuation aims to
+reproduce, with its normalization set by screen capacity. In that
+phenomenological branch, the dark sector is read as an infrared correction to
+gravity rather than a new species of particle. The cosmological constant and
+the galaxy-scale anomaly then sit inside one de Sitter picture.
 
 ---
 

--- a/book/chapter-14-standard-model.md
+++ b/book/chapter-14-standard-model.md
@@ -68,34 +68,34 @@ where p is momentum. For everyday objects, this wavelength is absurdly tiny. A b
 
 In 1927, Davisson and Germer proved de Broglie right. They bounced electrons off a nickel crystal and saw interference patterns. Electrons really do behave like waves.
 
-### Schrodinger's Equation
+### Schrödinger's Equation
 
-Erwin Schrodinger took de Broglie's idea and ran with it. If electrons are waves, what's waving?
+Erwin Schrödinger took de Broglie's idea and ran with it. If electrons are waves, what's waving?
 
-Schrodinger proposed that electrons are described by a wave function psi(x,t). The equation governing this wave is:
+Schrödinger proposed that electrons are described by a wave function psi(x,t). The equation governing this wave is:
 
 $$i\hbar \frac{\partial \psi}{\partial t} = -\frac{\hbar^2}{2m}\nabla^2\psi + V\psi$$
 
-This is the Schrodinger equation, and it works spectacularly well. It predicts atomic spectra, chemical bonds, semiconductor behavior. It's the foundation of quantum chemistry and materials science.
+This is the Schrödinger equation, and it works spectacularly well. It predicts atomic spectra, chemical bonds, semiconductor behavior. It's the foundation of quantum chemistry and materials science.
 
-But what is psi? Schrodinger initially thought it described a smeared-out electron, spread across space like a cloud. Max Born had a different interpretation: psi squared gives the probability of finding the electron at each location.
+But what is psi? Schrödinger initially thought it described a smeared-out electron, spread across space like a cloud. Max Born had a different interpretation: psi squared gives the probability of finding the electron at each location.
 
 $$P(x) = |\psi(x)|^2$$
 
-The electron isn't smeared out. It's genuinely indeterminate. The wave function doesn't describe where the electron is. It describes the probabilities of where you might find it.
+Operationally, the wave function does not assign a classical trajectory. It gives the probabilities for different measurement outcomes.
 
 The early formulas introduce the basic quantum dictionary. In Planck's
 $E=nhf$, $E$ is energy, $n$ is a whole-number quantum count, $h$ is Planck's
 constant, and $f$ is frequency. In Bohr's $L=n\hbar$, $L$ is angular momentum
 and $\hbar=h/(2\pi)$. In de Broglie's $\lambda=h/p$, $\lambda$ is wavelength
-and $p$ is momentum. In Schrodinger's equation, $\psi$ is the wave function,
+and $p$ is momentum. In Schrödinger's equation, $\psi$ is the wave function,
 $m$ is mass, $V$ is potential energy, and $\nabla^2$ measures spatial
 curvature of the wave. Born's rule, $P(x)=|\psi(x)|^2$, turns the wave
 function into a probability density for detection at position $x$.
 
 That dictionary was assembled by many people under pressure from experiment.
 Planck's blackbody curve, Einstein's photons, Bohr's spectral lines, de
-Broglie's matter waves, Schrodinger's wave mechanics, Heisenberg's matrices,
+Broglie's matter waves, Schrödinger's wave mechanics, Heisenberg's matrices,
 Born's probability rule, Dirac's relativistic equation, and Feynman's diagrams
 are different steps in one long reconstruction. The Standard Model inherits
 that whole history.
@@ -122,7 +122,7 @@ Bohr and Heisenberg developed what became the "Copenhagen interpretation." The w
 
 This interpretation was never universally accepted. Einstein famously objected: "God does not play dice." But the mathematics works. Quantum mechanics makes predictions, and those predictions are confirmed to extraordinary precision.
 
-The lesson is clear. At the fundamental level, nature is not deterministic. Outcomes are genuinely random. The best we can do is calculate probabilities.
+The core lesson is operational rather than interpretive. Quantum theory gives probabilities for measurement outcomes with extraordinary accuracy. What those probabilities mean ontologically depends on the interpretation.
 
 ## 14.4 From Particles to Fields
 
@@ -132,7 +132,7 @@ You don't. You need quantum field theory.
 
 ### Dirac's Equation
 
-In 1928, Paul Dirac sought a relativistic version of Schrodinger's equation. He found something deeper.
+In 1928, Paul Dirac sought a relativistic version of Schrödinger's equation. He found something deeper.
 
 The Dirac equation describes spin-1/2 particles like electrons:
 
@@ -235,7 +235,7 @@ The electron is stable. The muon and tau decay quickly.
 
 The fermions come in a strange pattern: three copies. The up and down quarks, plus the electron and its neutrino, form the first generation. The charm and strange quarks, plus the muon and its neutrino, form the second. The top and bottom, plus the tau and its neutrino, form the third.
 
-Why three? No one knows. The charged members of the second and third generations are heavier copies of the first, while the neutrino sector has its own mixing pattern. Almost all ordinary matter uses only first-generation particles.
+Historically, the Standard Model by itself does not explain why there are three generations. OPH later argues that, on its realized one-Higgs branch, the minimal viable count is three. The charged members of the second and third generations are heavier copies of the first, while the neutrino sector has its own mixing pattern. Almost all ordinary matter uses only first-generation particles.
 
 ### Bosons: The Force Carriers
 
@@ -253,7 +253,7 @@ Forces are mediated by bosons: particles with integer spin.
 
 ### The Gauge Groups
 
-The Standard Model is organized by symmetry. The gauge group is:
+The Standard Model is organized by symmetry. One usually writes the gauge group as:
 
 $$G_{SM} = SU(3)_C \times SU(2)_L \times U(1)_Y$$
 
@@ -305,10 +305,9 @@ Lee and Yang had predicted this. Wu proved it. Parity violation earned Lee and Y
 
 ### Why Chirality Matters
 
-Chirality matters everywhere. It helps explain why neutrinos stay so light,
-why the weak interaction carries the C and P violation needed for CP
-violation, and why anomaly cancellation places such sharp restrictions on the
-allowed fermion content.
+Chirality matters everywhere. It is essential to weak parity violation and to
+anomaly-cancellation constraints, and it sharply restricts which fermion mass
+terms can appear without extra structure.
 
 ## 14.7 Anomaly Cancellation: Why the Charges Are What They Are
 
@@ -481,7 +480,7 @@ supplied by the transport premises, is unique and checkable.
 
 ### The Standard Model Factors
 
-Why does the reconstructed group have the form SU(3) x SU(2) x U(1)?
+Why does the reconstructed group have the form SU(3) x SU(2) x U(1) up to finite quotient?
 
 Once you ask for the smallest matter sector that can carry color, weak
 interactions, chirality, and ordinary charge, the answer is forced into a
@@ -515,7 +514,7 @@ Given one generation of chiral fermions with SU(3) x SU(2) x U(1) charges, and r
 
 ### The Derivation
 
-Start with Yukawa invariance. Writing the anomaly equations in terms of left-handed Weyl fields means the right-handed singlets enter through their conjugates:
+Start with Yukawa invariance. Using the familiar physical hypercharges for the right-handed singlets gives:
 
 $$Y_u = Y_Q + Y_H, \quad Y_d = Y_Q - Y_H, \quad Y_e = Y_L - Y_H$$
 

--- a/book/chapter-15-relativity.md
+++ b/book/chapter-15-relativity.md
@@ -364,10 +364,10 @@ Consider two observers with overlapping patches. Each has a modular flow, a
 local clock. When their descriptions are compared, the admissible
 transformations have to map patches to patches, preserve the overlap
 structure, and avoid turning any one patch into the privileged center of the
-world. The group that does exactly that is the conformal group of $S^2$, and
-$\text{Conf}(S^2)\cong \mathrm{SO}(3,1)$ is the Lorentz group.
+world. A natural symmetry group that does that is the conformal group of
+$S^2$, and $\text{Conf}(S^2)\cong \mathrm{SO}(3,1)$ is the Lorentz group.
 
-So Lorentz invariance is not imposed from outside. It is the *only* way different observer perspectives can be consistently related without privileging any one of them.
+So Lorentz invariance is not imposed from outside. It is the natural symmetry class relating observer perspectives without privileging any one of them.
 
 **The qubits do not need to move.** What we call "motion" in the emergent 4D spacetime is not qubits rearranging themselves. Motion is a pattern in how correlations change. A "moving particle" is a correlation pattern that shifts across the screen. A "Lorentz boost" is a transformation relating how two observers describe the same correlation pattern.
 
@@ -377,12 +377,16 @@ The substrate (the qubits) is not in spacetime. Spacetime emerges from how patch
 
 Why is there a maximum speed, and why is it the same for everyone?
 
-Information propagates on the screen. The modular flow determines the rate of
-propagation. The conformal structure of $S^2$ determines the causal structure.
+On the recovered geometric branch, the common causal structure on the screen
+determines the effective light cone.
 
-The speed of light c is the conversion factor between modular time and geometric distance. It's universal because the conformal structure of the sphere is unique.
+The speed of light $c$ is then the conversion factor between modular time and
+geometric distance in the emergent bulk description. It is universal because
+all observers read the same conformal light-cone structure.
 
-Different observers have different modular flows. But their flows are all conformal transformations of S^2. The Lorentz group is precisely the set of transformations that preserve the causal structure while changing the observer's notion of time.
+Different observers have different modular flows. On the geometric branch, the
+inter-observer relations are carried by conformal transformations of $S^2$.
+The Lorentz group is the corresponding symmetry of the shared causal structure.
 
 ## 15.9 Recovering General Relativity
 
@@ -393,9 +397,9 @@ Special relativity emerges from the conformal structure of the screen. What abou
 Patch consistency does two crucial jobs here. First, it forbids any preferred
 observer or preferred frame. Second, once each observer gets the same local
 rest-frame relation, patch consistency forces those local relations to fit
-together into a full tensor equation. MaxEnt supplies the equilibrium state,
-modular flow supplies the local clock, and generalized entropy supplies the
-thermodynamic relation that becomes Einstein's equation.
+together into a tensor law. MaxEnt supplies the equilibrium state, modular
+flow supplies the local clock, and the null-modular and bounded-interval
+bridges let generalized-entropy stationarity feed the Einstein branch.
 
 ### Jacobson's Insight (1995, 2016)
 
@@ -485,8 +489,8 @@ to be shadows of one frame-independent tensor relation:
 
 $$G_{ab} + \Lambda g_{ab} = 8\pi G \langle T_{ab} \rangle$$
 
-This is the semiclassical Einstein equation, obtained by combining the
-thermodynamic argument with patch consistency in the scaling regime.
+On the stated scaling branch, this is the semiclassical Einstein equation,
+obtained by combining the thermodynamic argument with patch consistency.
 
 The lower-case indices $a,b$ again label spacetime directions. The angle
 brackets around $T_{ab}$ mean expectation value: matter is still quantum, so
@@ -548,7 +552,10 @@ Emergent geometry is the most economical description of how modular clocks fit t
 
 Imagine collecting all the data about how every patch's modular flow relates to every other patch's flow. This is an enormous amount of information.
 
-But there's a compression. If you specify a metric g_{ab}, you can derive all the modular flows from it. The metric is the minimum description that captures the overlap structure.
+But there's a compression. In the effective geometric regime, specifying a
+metric $g_{ab}$ organizes the leading overlap relations between nearby modular
+flows. The metric is the compressed description that captures that common
+structure.
 
 General relativity is the natural effective dynamics associated with this compression. It's not arbitrary. It's the simplest theory that respects the recovered structure.
 
@@ -606,14 +613,14 @@ An alternative: modify gravity (MOND). At low accelerations, perhaps gravity beh
 
 ### A Third Route
 
-OPH gives a third route. Extra gravitational pull may come from imperfect
-information recovery.
+One phenomenological OPH continuation gives a third route. Extra
+gravitational pull may come from imperfect information recovery.
 
 The underlying logic is simple. In the ideal Markov limit, information on one
 side of a boundary is perfectly recoverable from the boundary itself, and the
-result is pure Einstein gravity. Move away from that ideal limit and some
-correlation sits out of reach. That leftover correlation can feed an extra
-term into the effective equations.
+recovered branch follows the Einstein relation. In the D12 continuation
+considered here, one moves away from that ideal limit and some correlation
+sits out of reach. That leftover correlation can feed an extra effective term.
 
 It gravitates because missing recoverability has physical weight in the
 bookkeeping. This supplies a structural ingredient for a dark sector without
@@ -621,16 +628,17 @@ introducing new particle species.
 
 ### Why It's Dark
 
-This sector is dark by construction. It comes from information structure, it
-gravitates, and it does not couple electromagnetically. The observational work
-then becomes concrete: rotation curves, lensing, clusters, and cosmology have
-to read the same information-recovery term.
+In that continuation, the sector is dark at the level of its couplings. It
+comes from information structure, it gravitates, and it does not couple
+electromagnetically. Any successful phenomenological completion then has to
+confront rotation curves, lensing, clusters, and cosmology with the same
+information-recovery term.
 
 ### The MOND Scale
 
-This anomaly is tied to the cosmological constant. The only
-available large-scale length in this construction is the de Sitter radius, and from it
-the construction singles out a characteristic acceleration:
+In that continuation, the cosmological constant supplies the natural infrared
+scale. The de Sitter radius then singles out a characteristic acceleration
+benchmark:
 
 $$a_0 = \frac{15}{8\pi^2} c^2 \sqrt{\frac{\Lambda}{3}} \approx 1.0 \times 10^{-10} \text{ m/s}^2$$
 
@@ -643,14 +651,16 @@ logic that shaped the horizon from the start.
 The old picture treated time as universal, gravity as a force, and geometry as
 a fixed stage. Relativity overturns each part. The speed of light forces time
 and distance into one four-dimensional structure. Free fall reveals gravity as
-geometry. OPH pushes the logic one step deeper. Lorentz symmetry becomes the
-geometry of how modular times mesh across patches, and gravity becomes the
-equilibrium condition that lets those patches share one spacetime.
+geometry. OPH pushes the logic one step deeper. On the controlled scaling
+branch, Lorentz symmetry becomes the geometry of how modular times mesh across
+patches, and gravity becomes the equilibrium condition that lets those patches
+share one spacetime.
 
 On this reading, the speed of light is not a random number sprinkled into the
 laws. It is the conversion factor between information flow on the screen and
-emergent geometry in the bulk. Einstein's equation is the public face of
-entanglement equilibrium written in the language of curvature.
+emergent geometry in the bulk. On the Einstein branch, Einstein's equation is
+the public face of entanglement equilibrium written in the language of
+curvature.
 
 Newton's absolute time and space were beautiful ideas that served humanity well for two centuries. But they were always approximations. The deeper truth is that time and space are not the stage on which physics happens. They emerge from the physics itself.
 


### PR DESCRIPTION
This pass fixes the main chapter-11-to-15 places where the book either overstated the current OPH paper surface or used technically sloppy wording.

Chapter 11 now uses the standard `Past Hypothesis` term, fixes `Schrödinger`, and narrows the modular-time discussion so overlap compatibility and cosmic time read as branch-conditioned effective structure rather than a blanket global theorem.

Chapter 12 keeps the symmetry narrative strong but removes two attackable shortcuts: projective representations now justify half-integer-spin matter sectors rather than the entire particle content, and the CPT paragraph no longer claims a literal antipodal-map implementation. The gauge-group paragraph is also tightened to the realized one-Higgs branch and the physical `/Z6` quotient.

Chapter 13 now states the de Sitter capacity relation as the D6 global-capacity closure with explicit screen-capacity input, and the dark-sector section is rewritten as a phenomenological continuation instead of a recovered-core derivation. The MOND-like response and Tully-Fisher discussion are kept, but clearly marked as continuation-level language.

Chapter 14 includes one genuine technical correction: the hypercharge derivation now consistently uses the physical right-handed singlet hypercharges instead of mixing that convention with left-handed-conjugate wording. The chapter also fixes `Schrödinger`, removes interpretation-heavy quantum-mechanics phrasing, narrows the chirality discussion, and aligns the generation-count language with the realized one-Higgs branch result.

Chapter 15 now states the Lorentz and Einstein recovery as the conditional geometric/scaling branch they are in the paper, not as an unconditional fixed-cutoff identity. The dark-sector discussion is likewise marked as a D12 continuation, while preserving the high-level OPH narrative.