### PR TITLE
fix: Tighten book chapters 16-19 and align the closing summaries with current OPH status tiers

### DIFF
--- a/book/chapter-16-matter.md
+++ b/book/chapter-16-matter.md
@@ -55,11 +55,12 @@ the zoo stops looking like a zoo.
 The first bridge is symmetry. Once Lorentz kinematics is recovered, a durable
 excitation is sorted by the familiar labels of relativistic physics: mass,
 spin, and helicity. Once the gauge structure is recovered, the charge bookkeeping
-also stops looking arbitrary. The realized sector fixes the Standard Model
-quotient $SU(3)\times SU(2)\times U(1)/\mathbb Z_6$, the exact hypercharge
-lattice, the realized color triplet $N_c=3$, and the generation count $N_g=3$.
-Those are structural
-answers about what kinds of matter can exist at all.
+also stops looking arbitrary. On the realized one-Higgs low-energy branch, the
+sector fixes the Standard Model quotient
+$SU(3)\times SU(2)\times U(1)/\mathbb Z_6$, the exact hypercharge lattice, the
+realized color triplet $N_c=3$, and the generation count $N_g=3$. Those are
+structural answers about what kinds of matter can exist on that realized
+branch.
 
 This is where the book leans heavily on the collective history of particle
 physics. Rutherford showed that atoms have small nuclei. Chadwick found the
@@ -79,7 +80,8 @@ structure also blocks gauge-mediated proton decay, because the realized gauge
 group is a product group and does not contain the extra leptoquark gauge
 bosons required by simple-group unification.
 
-The electroweak transport family records a target-free weak-boson continuation
+The electroweak transport family records the weak-sector validation pair
+through a target-free continuation row
 
 $$
 M_W = 80.37700001539531\,\mathrm{GeV}, \qquad
@@ -126,7 +128,7 @@ from one continuous construction. The status ledger records the diagnostic
 source trunk, the endpoint residual, and the empirical hadron closure row that
 uses a separate \(e^+e^-\to\mathrm{hadrons}\) payload class.
 
-The same electroweak core continues into the scalar and companion top values
+The same electroweak core carries the declared Higgs/top surface
 
 $$
 (m_H,m_t)=(125.1995304097179,\ 172.3523553288312)\,\mathrm{GeV}.
@@ -136,7 +138,7 @@ $m_H$ is the Higgs-boson mass and $m_t$ is the top-quark mass on this
 calculation surface. They are paired because the Higgs and top sectors are
 strongly linked in the electroweak bookkeeping.
 
-The quark sector gives the running mass structure
+The selected-class quark sector gives the running mass structure
 
 $$
 \begin{aligned}
@@ -161,7 +163,7 @@ triplet. The aligned equation layout keeps the two families readable, but the
 important physical point is that these are quark-level running masses before
 strong binding turns quarks into hadrons.
 
-The neutrino sector is concrete as well:
+On the weighted-cycle absolute branch, the neutrino sector is concrete as well:
 
 $$
 (m_{\nu_e},m_{\nu_\mu},m_{\nu_\tau})=
@@ -169,15 +171,15 @@ $$
 $$
 
 together with definite Majorana phases in that construction. Taken together,
-the particle picture is larger than a handful of isolated numbers. OPH fixes
-the structural gauge reconstruction, the exact massless carriers, the declared
-Higgs/top surface, the selected-class running quark sextet with Yukawas, and one
-weighted-cycle neutrino family. The late status ledger records the weak
-validation pair, the fine-structure audit trunk, and the charged-lepton
-absolute-mass no-go boundary. The selected-class quark theorem leaves strong
-CP open: the available corpus does not derive $\theta_{\mathrm{QCD}}$, does
-not emit physical $\bar\theta$, and does not prove that the physical strong-CP
-phase vanishes.
+the particle picture is larger than a handful of isolated numbers. The OPH
+ledger carries structural massless carriers, the weak-sector validation pair,
+the declared Higgs/top surface, the selected-class running quark sextet with
+Yukawas, and one weighted-cycle neutrino family. The late status ledger
+records the fine-structure audit trunk and the charged-lepton witness surface.
+The selected-class quark theorem leaves strong CP open: the
+available corpus does not derive $\theta_{\mathrm{QCD}}$, does not emit
+physical $\bar\theta$, and does not prove that the physical strong-CP phase
+vanishes.
 Hadrons require a separate nonperturbative bound-state step
 because protons, neutrons, and mesons are QCD composites, not elementary
 particle rows. Source-only hadron masses require an OPH backend. Empirical
@@ -329,7 +331,10 @@ This resolves an old puzzle: why does the quantum world give rise to classical p
 
 In the standard picture, classical physics is an approximation that breaks down at small scales. OPH inverts this: classical physics is what emerges when consistency constraints are satisfied. The classical world is not fundamental reality poorly approximating quantum mechanics. It is the consistent core that multiple observers can share.
 
-The quantum world is larger but less shareable. Superpositions exist, but they can't be consistently communicated. When you try to share quantum information broadly, decoherence kicks in, and you're left with classical correlations.
+The quantum world is larger but less shareable. Superpositions exist, but broad
+decohered superpositions do not survive as public records that many observers
+can compare. When quantum information is spread broadly into the environment,
+decoherence leaves classical correlations behind.
 
 **Classical physics is the public face of quantum reality.** It is the stable consistency regime that many observers can share.
 

--- a/book/chapter-17-darwin.md
+++ b/book/chapter-17-darwin.md
@@ -41,8 +41,9 @@ design. One says we won a cosmic lottery. One says there is selection across a
 space of possible laws, so observers inevitably see the conditions that permit
 observers. That third route is the anthropic principle in its bare form.
 
-Fine-tuning reveals that laws are not unique. There are many possible laws,
-and what we observe is filtered by the fact that we are here to observe it.
+Fine-tuning at least suggests that the realized laws are not the only
+conceivable ones, and that what we observe is filtered by the fact that we are
+here to observe it.
 
 This line of thought was shaped by many different communities. Dicke and
 Carter made anthropic reasoning part of modern cosmology. Weinberg used it to
@@ -73,11 +74,15 @@ a new region of spacetime, the daughter region inherits parameters close to
 those of the parent, small mutations occur in the bounce, and the universes
 that produce more black holes leave more descendants.
 
-This is Darwin on a cosmic scale. After countless generations, we should find ourselves in a universe near a fitness peak-one optimized for black hole production.
+This is Darwin on a cosmic scale. In Smolin's proposal, after countless
+generations we should find ourselves in a universe near a fitness peak-one
+optimized for black hole production.
 
 ### A Testable Prediction
 
-CNS makes a directly testable prediction: **you cannot change any physical constant by a small amount and increase the number of black holes our universe would produce**.
+In Smolin's proposal, CNS makes a directly testable prediction: **you cannot
+change any physical constant by a small amount and increase the number of black
+holes our universe would produce**.
 
 If you could, our universe wouldn't be at a fitness peak.
 
@@ -126,7 +131,9 @@ Pointer states are the winners of quantum natural selection. They survive the pr
 
 Another way to think about the evolution of laws starts with compression.
 
-The holographic screen has limited capacity: A/4G bits. It can't encode infinite complexity. It must compress.
+The holographic screen has limited capacity: roughly $A/(4G)$ in natural
+entropy units, often translated loosely into bits. It cannot encode infinite
+complexity. It must compress.
 
 Here $A$ is the area of the boundary and $G$ is Newton's gravitational constant.
 The formula is the black-hole entropy scaling in plain form: storage capacity
@@ -165,11 +172,11 @@ The electron is a vibration pattern that persists. The muon is a pattern that pe
 The "particle zoo" is a census of vibrational survivors.
 
 Within OPH, that census is uneven. Some particles sit on especially clean
-structural results: photon, gluons, graviton, $W$, and $Z$. The Higgs and top
-are tied together on one electroweak surface, and the neutrino sector
-has definite masses of its own. Quarks close on a selected public frame class.
-Charged leptons have a determinant-character attachment boundary before a
-promoted physical mass-scale row. Composite particles like hadrons demand
+structural or near-structural surfaces: photon, gluons, graviton, and the weak
+validation pair. The Higgs and top are tied together on one declared
+electroweak surface, the neutrino sector sits on a weighted-cycle absolute
+branch, and quarks close on a selected public frame class. Charged leptons
+remain more target-anchored, and composite particles like hadrons demand
 stronger computational control of the strong interaction; empirical hadron
 closure values use a separate \(e^+e^-\to\mathrm{hadrons}\) payload class.
 
@@ -267,11 +274,17 @@ The laws are not imposed from outside. They are the conditions that make agreeme
 
 Observers and laws select each other. Neither is primary.
 
-Observers that fit into the consensus survive and replicate. An observer whose internal model contradicts the shared reality cannot maintain stable correlations with other observers. It loses coherence and dissolves.
+Observers that fit into the consensus survive and replicate. An observer whose
+internal model persistently contradicts the shared reality cannot maintain
+stable public coordination with other observers. It drops out of the shared
+description.
 
 Laws that allow observers to agree proliferate. A law that prevents consistent gluing between patches cannot support stable observers. No observers means no one to instantiate that law in their shared description.
 
-The outcome of this mutual selection is the physics that permits stable, self-consistent observers to exist and to agree with each other. The universe is governed by laws that are maximally hospitable to the existence of observers who can verify those laws.
+The outcome of this mutual selection is the physics that permits stable,
+self-consistent observers to exist and to agree with each other. On this
+selection picture, the surviving laws are those hospitable enough to the
+existence of observers who can verify them.
 
 ### Laws as Coordination Protocols
 

--- a/book/chapter-18-synthesis.md
+++ b/book/chapter-18-synthesis.md
@@ -59,7 +59,7 @@ Once cap modular flow becomes geometric, time stops looking imported from
 outside. It becomes the internal flow attached to a restricted state. When
 those local flows fit together across the smooth screen, Lorentz kinematics
 appears. When generalized entropy sits at equilibrium under the allowed
-MaxEnt variations of a fixed cap, Einstein gravity appears as the public
+MaxEnt variations of a fixed cap, the Einstein relation appears as the public
 large-scale grammar of that equilibrium.
 
 Read that sentence as a compressed recap. Modular flow is the clock a restricted
@@ -77,7 +77,7 @@ The particle world follows the same logic from another angle. Once fixed-cutoff
 charge sectors can fuse, split, carry duals, persist coherently under
 refinement, and descend with compatible finite-dimensional multiplicity spaces,
 the gauge group is reconstructed from that persistent charge bookkeeping
-itself. The group that emerges is
+itself. On the realized one-Higgs matter branch, the group that emerges is
 
 $$
 SU(3)\times SU(2)\times U(1)/\mathbb Z_6.
@@ -93,12 +93,13 @@ The color triplet follows from the minimal coupled carrier, and the
 three-generation count follows from CKM phase counting, weak-sector
 consistency, and minimality on the same low-energy branch. The photon,
 gluons, and graviton stay massless because they ride on redundancy directions
-the architecture cannot break. The weak pair, the low-energy electromagnetic
-coupling, the Higgs-top surface, a running quark sector, and one
-weighted-cycle neutrino family all sit inside the same reconstruction. The
-technical status ledger separates weak validation, charged-lepton witnesses,
-source-only hadron calculations, and empirical hadron closure checks. Hadrons
-add the strong-binding problem on top of that particle-level picture.
+the architecture cannot break. The broader particle ledger then carries the
+weak validation pair, the low-energy electromagnetic endpoint, the declared
+Higgs-top surface, the selected-class quark sector, and one weighted-cycle
+neutrino family. The technical status ledger separates charged-lepton
+witnesses, source-only hadron calculations, and empirical hadron closure
+checks. Hadrons add the strong-binding problem on top of that particle-level
+picture.
 
 The particle words here refer to roles explained in Chapters 12-16: color is the
 three-way strong-force bookkeeping, CKM phases describe quark mixing under the
@@ -114,10 +115,11 @@ observer records close.
 The quantitative side of the framework turns on two scales with very different
 roles.
 
-The first is global. The observed cosmological constant fixes the total screen
-capacity, about $3.31\times10^{122}$ natural entropy units, or about
-$4.77\times10^{122}$ bits. That gives the size of the accessible computation
-and sets the de Sitter horizon scale.
+The first is global. On the screen-capacity identification branch, the observed
+cosmological constant fixes the total screen capacity, about
+$3.31\times10^{122}$ natural entropy units, or about $4.77\times10^{122}$
+bits. That gives the size of the accessible computation and sets the de Sitter
+horizon scale.
 
 The second is local. The pixel ratio
 
@@ -271,9 +273,10 @@ By this point the central sentence of the book can be spoken plainly:
 
 **Reality is the consistency of observations across overlapping perspectives.**
 
-Everything else unfolds from that pressure. Space is the geometry of
-entanglement. Time is modular flow read from inside restricted states. Matter
-is the family of stable excitations that can survive transport across patches.
+Everything else unfolds from that pressure. Spatial geometry is organized by
+entanglement structure. Time is modular flow read from inside restricted
+states. Matter is the family of stable excitations that can survive transport
+across patches.
 Laws are the public regularities that endure repeated comparison. Objectivity
 is the residue left behind after many partial viewpoints are made to agree.
 
@@ -303,9 +306,9 @@ information theorist sees a code. A good theory earns its keep by making those
 views mutually legible without erasing their differences.
 
 The structure is not a flat list. The gauge quotient, charge lattice, counting
-chain, massless carriers, Lorentz geometry, Einstein relation, electroweak
-rows, Higgs-top surface, quark sector, and neutrino family form one organized
-reconstruction, not a catalog of unrelated facts.
+chain, massless carriers, Lorentz geometry, Einstein relation, and the
+ledgered electroweak, Higgs-top, quark, and neutrino surfaces form one
+organized reconstruction, not a catalog of unrelated facts.
 
 The local-ruler ledger records three technical boundaries. The weak pair is a
 validation row. Charged-lepton absolute masses are target-anchored witnesses.

--- a/book/chapter-19-metaphysics.md
+++ b/book/chapter-19-metaphysics.md
@@ -49,9 +49,19 @@ But what counts as a measurement? When exactly does collapse happen? Does consci
 
 OPH cuts through this by removing the problematic assumption: that the measurement problem is about a single observer-independent state description that must somehow connect to lived experience.
 
-The formalism can still contain a global quantum state, but no observer occupies a God's-eye position outside the system. What observers actually have are patch-level descriptions. A "superposition" isn't a bizarre state where something is really in two places at once; it's an incomplete description that admits multiple compatible continuations. When two patches that had no shared access come to share access to a system, their descriptions must agree on that overlap. That agreement is what we call "measurement." The "collapse" is just what consistency looks like from one patch's perspective.
+The formalism can still contain a global quantum state, but no observer occupies
+a God's-eye position outside the system. What observers actually have are
+patch-level descriptions. At book level, a superposition is a description that
+still admits multiple compatible continuations. When two patches that had no
+shared access come to share access to a system, their descriptions must agree
+on that overlap. That shared record relation is what the chapter is calling
+"measurement." "Collapse" is the patch-level update into a definite public
+record.
 
-The measurement problem evaporates because there was never an objective wavefunction needing to collapse. There were only perspectives needing to synchronize.
+At the observer-first level developed here, the measurement problem softens
+because there is no physically occupied view from nowhere whose wavefunction
+must then be connected to experience. There are perspectives that have to
+synchronize through shared records.
 
 ## 19.6 Why These Laws? Why This Universe?
 
@@ -154,8 +164,9 @@ persist, while a self-referential loop can.
 
 This loop is structural. It is a relation among reality, observers, and the
 simulation they eventually understand how to build. Time is subjective. It
-emerges from modular flow within observer patches. The strange loop exists
-*outside* time. The "cause" and the "effect" are aspects of the same
+emerges from modular flow within observer patches. The strange loop is not best
+pictured as an ordinary temporal sequence with one stage literally preceding
+the next. The "cause" and the "effect" are aspects of the same
 self-consistent structure.
 
 This resolves the apparent paradox of self-causation. You cannot cause yourself in time, because that would require existing before you exist. But you can be part of a self-consistent structure that has no temporal "before." The loop does not happen *in* time. Time happens *in* the loop.
@@ -170,7 +181,11 @@ The observer-first reading drops the view-from-nowhere assumption. There is no p
 
 ![Reality, observers, records, and models form a loop in which the world becomes partially explicit to itself.](../assets/book_diagrams/observer-loop.svg){width=78%}
 
-The consistency constraints are rigid. Not every perspective survives. The physics we discover is the physics that can be coherently maintained across all surviving perspectives. That's why it's so reliable, so predictive, so shockingly precise. It's been filtered by the harshest criterion imaginable: self-consistency across all possible observers.
+The consistency constraints are rigid. Not every perspective survives. The
+physics we discover is the physics that can be coherently maintained across the
+surviving network of perspectives. That's why it is so reliable and
+predictive. It has been filtered by the harsh criterion of public
+self-consistency.
 
 ## 19.9 The Hacker and the Hacked
 


### PR DESCRIPTION
This pass fixes the main chapter-16-to-19 places where the closing book summaries were flattening structural theorems, validation rows, declared quantitative surfaces, and continuation branches into one undifferentiated claim.

Chapter 16 now distinguishes the realized one-Higgs structural gauge branch from the later particle ledger, describes the weak row as the weak-sector validation pair, marks the quark row as selected-class and the neutrino row as weighted-cycle, and narrows one overly absolute sentence about communicating superpositions.

Chapter 17 keeps the selection narrative but removes a few attackable overstatements. Fine-tuning language is slightly softened, Smolin’s claims are explicitly kept as Smolin’s proposal, the screen-capacity sentence no longer mislabels `A/(4G)` as plain bits, the particle-status sentence now tracks the actual OPH tiering better, and the co-evolution section no longer reads as a teleological theorem about “maximally hospitable” laws.

Chapter 18 now states the spacetime summary in terms of the Einstein relation rather than blanket “Einstein gravity,” ties the gauge quotient to the realized one-Higgs matter branch, separates the particle ledger by status tier, marks the cosmological-capacity sentence as belonging to the screen-capacity-identification branch, and softens the overcompressed “space is the geometry of entanglement” line.

Chapter 19 keeps the metaphysical direction intact but tightens the measurement and strange-loop language. Measurement is now described as a patch-level update into a shared record rather than a blanket ontological dismissal of superposition, the text no longer says the loop literally exists “outside time,” and the closing precision sentence no longer overclaims self-consistency across “all possible observers.”
