### PR TITLE
fix: Finish the six-paper OPH audit pass and tighten stale paper-surface wording

### DIFF
--- a/paper/appendix_B_bft_qecc_extensions.tex
+++ b/paper/appendix_B_bft_qecc_extensions.tex
@@ -82,7 +82,7 @@ Under assumptions (A1)--(A6), any consensus protocol satisfying
 Suppose $O_a$ and $O_b$ finalise $s_a\neq s_b$ in the same view.
 By (P2), each required a certificate of $q=2f+1$ votes: sets $Q_a,Q_b$.
 By (A3): $|Q_a\cap Q_b|\geq(2f+1)+(2f+1)-(3f+1)=f+1$.
-By (A2), at most $f$ are Byzantine, so $Q_a\cap Q_b$ contains an
+By (A2), at most $f$ are Byzantine, so $Q_a\cap Q_b$ contains a
 nonfaulty $O^*$.
 By (A4), $O^*$'s signed vote is path-reachable within both quorums.
 By (P1), $O^*$ voted for at most one value --- contradiction.

--- a/paper/deriving_the_particle_zoo_from_observer_consistency.tex
+++ b/paper/deriving_the_particle_zoo_from_observer_consistency.tex
@@ -347,8 +347,8 @@ Chain & OPH output & Role \\
 \(P\)-closure and fine structure & \(\alpha^{-1}(0)=137.035999177(21)\), \(P=1.630968209403959324879279847782648941\ldots\) & local fixed-point scale \\
 Structural massless carriers & \(m_\gamma=m_g=m_{\mathrm{grav}}=0\) & symmetry-protected zeros \\
 Electroweak \(W/Z\) & \(80.377~\mathrm{GeV}\), \(91.18797809193725~\mathrm{GeV}\) & weak-sector validation pair \\
-Higgs/top surface & \(m_H=125.1995304097179~\mathrm{GeV}\), \(m_t=172.35235532883115~\mathrm{GeV}\) & scalar/top split surface \\
-Charged leptons & \(m_e,m_\mu,m_\tau\) witness values & same-family charged readback \\
+Higgs/top surface & \(m_H=125.1995304097179~\mathrm{GeV}\), \(m_t=172.35235532883115~\mathrm{GeV}\) & declared D10/D11 split surface \\
+Charged leptons & \(m_e,m_\mu,m_\tau\) witness values & target-anchored same-family witness \\
 Selected-class quarks & exact running sextet on \(f_P\) & selected public quark frame \\
 Neutrino absolute attachment & \(0.017454720257976796,0.019481987935919015,0.05307522145074924~\mathrm{eV}\) & weighted-cycle absolute branch \\
 Hadrons & source-only strong-binding descent plus empirical \(e^+e^-\to\mathrm{hadrons}\) closure surface & OPH hadron backend for source-only masses; measured hadron data for empirical closure rows \\

--- a/paper/observers_are_all_you_need.tex
+++ b/paper/observers_are_all_you_need.tex
@@ -231,6 +231,8 @@ Gibbons--Hawking entropy capacity and \(N_{\mathrm{patch}}\) for the bare horizo
 
 The second achievement is the Standard Model structure. Under the stated
 coherent transportable-sector refinement ladder, \(3+1\)D symmetry, and compatible bosonic finite-fiber premises, edge sectors reconstruct the
+bosonic compact-gauge branch. On the realized low-energy branch with the explicit
+one-generation/one-Higgs matter package, minimal admissible realization then selects the
 compact gauge quotient
 \[
 \SU(3)\times\SU(2)\times\U(1)/\mathbb Z_6.
@@ -286,8 +288,9 @@ assumed from outside.
 recoverable generalized entropy supplies the Einstein relation. The de Sitter capacity relation
 then ties the cosmological constant to \(N_{\mathrm{scr}}\).
 \item \textbf{The Standard Model quotient is selected.} Under the stated coherent transportable-sector
-refinement premises, edge sectors reconstruct the compact gauge quotient, and the realized low-energy branch
-then fixes exact hypercharge, three generations, three colors, and the structural absence of
+refinement premises, edge sectors reconstruct the bosonic compact-gauge branch, and the realized low-energy branch
+with the explicit one-generation/one-Higgs matter package then selects the compact gauge quotient, exact hypercharge,
+three generations, three colors, and the structural absence of
 gauge-mediated proton decay.
 \item \textbf{The local particle scale is computed by fixed-point closure.} The pixel ratio \(P\) is
 fixed by matching a screen cell's outer entropy detuning to its inner electromagnetic observation
@@ -302,9 +305,10 @@ records the source-side diagnostic trunk and endpoint residual.
 \item \textbf{The framework has a regulated implementation surface.} The microphysics paper turns
 the observer language into explicit finite screen registers, edge observables, records, and repair
 cycles.
-\item \textbf{Edge sectors also admit worldsheet-style effective descriptions.} The heat-kernel
-edge partition function reorganizes the same boundary data into a controlled two-dimensional
-Yang--Mills worldsheet description in the appropriate large-edge regime.
+\item \textbf{Edge sectors also admit Yang--Mills and worldsheet-style effective descriptions.} The heat-kernel
+edge partition function first reorganizes the same boundary data into the two-dimensional
+Yang--Mills form, and on the declared large-edge branch this yields a controlled worldsheet
+effective description.
 \end{enumerate}
 
 \subsection*{Particle Prediction Surface}
@@ -323,7 +327,7 @@ Lane & Output & Role & Ledger note \\
 Massless carriers & \(m_\gamma=m_g=m_{\mathrm{grav}}=0\) & structural theorem & symmetry-protected zeros \\
 \(W/Z\) & \(80.377~\mathrm{GeV}\), \(91.18797809193725~\mathrm{GeV}\) & weak-sector validation pair & ledger records exact scope \\
 Fine structure & \(\alpha^{-1}(0)=137.035999177(21)\), \(P=1.630968209403959324879279847782648941\ldots\) & fixed-point derivation & ledger records source audit and empirical hadron closure class \\
-Higgs/top & \(125.1995304097179~\mathrm{GeV}\), \(172.35235532883115~\mathrm{GeV}\) & declared electroweak calibration surface & direct-top auxiliary conversion has a no-go boundary in the available corpus \\
+Higgs/top & \(125.1995304097179~\mathrm{GeV}\), \(172.35235532883115~\mathrm{GeV}\) & declared D10/D11 split surface & direct-top auxiliary conversion has a no-go boundary in the available corpus \\
 Charged leptons & \(0.0005109989499999994\), \(0.10565837550000004\), \(1.7769324651340912~\mathrm{GeV}\) & target-anchored witness & determinant trace-lift landing from \(P\) to physical charged data has a no-go boundary in the available corpus \\
 Quarks & \(u,d,s,c,b,t=(0.00216,0.00470,0.0935,1.273,4.183,172.35235532883115)~\mathrm{GeV}\) & selected-class exact theorem & global public-frame classification has a no-go boundary in the available corpus; strong CP remains open \\
 Neutrinos & \(0.017454720257976796\), \(0.019481987935919015\), \(0.05307522145074924~\mathrm{eV}\) & weighted-cycle absolute branch & absolute masses are not directly measured; PMNS comparison tension remains visible \\

--- a/paper/reality_as_consensus_protocol.tex
+++ b/paper/reality_as_consensus_protocol.tex
@@ -1249,7 +1249,7 @@ mechanism. A universality claim would require an explicit uniform family of patc
 simulates arbitrary circuits or machines with stated encoding overhead and robustness under
 asynchronous schedules. No such theorem is supplied here.
 
-With those boundaries explicit, five downstream directions are:
+With those boundaries explicit, six downstream directions are:
 
 \begin{enumerate}
 \item \textbf{Sharper RG-shadowing estimates.} Theorem~\ref{thm:coarse-grain-consensus} closes the abstract reconciliation/coarse-graining square once its normal-form and obstruction defects are supplied. The open quantitative task is to derive model-specific or uniform bounds for \(\varepsilon^n_{sr}\) and \(\varepsilon^h_{sr}\) from concrete OPH coarse-graining channels and recovery decoders.

--- a/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
+++ b/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
@@ -81,7 +81,7 @@ The results emphasized in this paper are ordered below by a combination of impac
 is recovered on the realized MAR-admissible branch of the bosonic compact-gauge theorem; this is a realized-branch gauge result with explicit matter-package and admissibility premises.
 \item On the realized one-generation chiral matter plus one-Higgs package, anomaly constraints and Yukawa invariance fix the hypercharge lattice, the realized color triplet fixes \(N_c=3\), and the same one-Higgs quark branch then fixes \(N_g=3\) from CKM phase counting, weak-sector asymptotic freedom, and MAR.
 \item The quantitative implementation used here uses one Phase-II pixel variable \(P\) together with one external continuous input \(N_{\mathrm{scr}}\).
-\item Downstream matter-sector continuations, including the charged-lepton centered-readback / centered-to-affine frontier, are visible but explicitly outside this SM/GR derivation paper's recovered-core theorem package.
+\item Downstream matter-sector continuations, including the charged-lepton exact centered-readback / common-shift frontier, are visible but explicitly outside this SM/GR derivation paper's recovered-core theorem package.
 \item The same Einstein branch closes globally once the external screen-capacity input and the D6 screen-capacity identification are supplied, tying the cosmological-constant branch to global screen capacity rather than local vacuum energy.
 \item Exclusion of gauge-mediated proton decay follows from product-group structure; any stronger proton-lifetime claim is UV/EFT/QCD-dependent.
 \item Dark-sector, heuristic baryogenesis continuations, string, and spectroscopy branches are kept visible only as phenomenological continuations or, where additional ans\"atze are involved, conjectural phenomenology.
@@ -145,7 +145,7 @@ Node & Output & Immediate internal ingredients & Standard mathematics used & Dec
 \textbf{D8} & Product gauge structure up to finite quotient (Lemmas~\ref{lem:mincontent}--\ref{lem:commutant}, Theorem~\ref{thm:sm}) & D7 + Axiom~\ref{ax:mar} & compact Lie representation classification; Schur's lemma & the same ordinary or central-defect bosonic branch as D7, together with a connected positive-dimensional Lie admissible class, one connected abelian factor, and faithful action on the minimal coupled carrier & Phase I realized-branch theorem \\
 \textbf{D9} & Realized Standard Model quotient, hypercharges, \(N_c=3\), \(N_g=3\), and product-group corollaries (Theorem~\ref{thm:hypercharge}, Corollaries~\ref{cor:nc}, \ref{cor:ng}, Proposition~\ref{prop:z6}) & D8 & anomaly-cancellation algebra; Witten global-anomaly argument; CKM CP counting & realized one-generation chiral matter plus one Higgs package, with the CP-capability and weak-sector UV clauses contained in Axiom~\ref{ax:mar}; no extra post-MAR selector is used & Phase I realized-branch theorem/corollary chain \\
 \textbf{D10} & Forward gauge-coupling closure and declared electroweak readout of the integrated D10 quantitative-closure package & D9 + pixel ratio \(P\) & printed RG evolution, matching, and scheme-conversion conventions & pixel constraint and the source-only forward transmutation solve \(\mathcal F(\alpha_U;P)=0\); the fixed-cutoff edge heat-kernel / Casimir theorem on the microphysics surface together with the compact-group / Peter--Weyl lift used on the D10 lane; printed beta-function, threshold, and scheme-conversion conventions & Phase II quantitative-closure sector \\
-\textbf{D12} & Charged-lepton centered-readback / centered-to-affine frontier, strong-CP branch, texture, dark-sector, heuristic baryogenesis continuations, black-hole spectroscopy, proton-spin, proton-lifetime estimates beyond the gauge-channel exclusion, controlled large-\(N_{\mathrm{edge}}\) string/worldsheet effective descriptions, conjectural critical-superstring extensions, and other continuations & various subsets of D6, D9, and D10 & branch-specific EFT and phenomenological manipulations & additional ans\"atze such as the uniform \(\mathbb Z_6\) center-label ensemble, discrete texture choices, dark-sector response assumptions, discrete-horizon assumptions, a distinct large-\(N_{\mathrm{edge}}\) regime with fixed \(\tau=tN_{\mathrm{edge}}\) window and uniform genus-remainder control, or extra worldsheet/CFT premises & Phase III phenomenological continuation branch \\
+\textbf{D12} & Charged-lepton exact centered-readback / common-shift frontier, strong-CP branch, texture, dark-sector, heuristic baryogenesis continuations, black-hole spectroscopy, proton-spin, proton-lifetime estimates beyond the gauge-channel exclusion, controlled large-\(N_{\mathrm{edge}}\) string/worldsheet effective descriptions, conjectural critical-superstring extensions, and other continuations & various subsets of D6, D9, and D10 & branch-specific EFT and phenomenological manipulations & additional ans\"atze such as the uniform \(\mathbb Z_6\) center-label ensemble, discrete texture choices, dark-sector response assumptions, discrete-horizon assumptions, a distinct large-\(N_{\mathrm{edge}}\) regime with fixed \(\tau=tN_{\mathrm{edge}}\) window and uniform genus-remainder control, or extra worldsheet/CFT premises & Phase III phenomenological continuation branch \\
 \end{longtable}
 \endgroup
 
@@ -413,7 +413,7 @@ Gauge group & model input & conditional construction of the refinement-limit bos
 Hypercharge lattice & matter-assignment input & solved from anomaly cancellation and Yukawa invariance on the realized one-generation chiral matter plus one-Higgs package \\
 Color and generation count & empirical input & color triplet fixed by the D8 minimal coupled carrier; generation count fixed by CKM phase counting, weak-sector asymptotic freedom, and MAR; Witten parity retained as a consistency check \\
 Flavor hierarchy unit & model-dependent small parameter & phenomenological ansatz \(\varepsilon=1/6\) motivated by a uniform \(\mathbb Z_6\) center-label ensemble \\
-Charged-lepton continuation & Koide-style phenomenological fit & exact centered readback plus an open centered-to-affine frontier above \(\widehat C_e^{\mathrm{cand}}\); any \(\delta=2/9\) phase relation is continuation-only \\
+Charged-lepton continuation & Koide-style phenomenological fit & exact centered readback plus the closed common-shift no-go above \(\widehat C_e^{\mathrm{cand}}\); any \(\delta=2/9\) phase relation is continuation-only \\
 Cosmological constant & local vacuum-energy puzzle & global screen-capacity term after the input-dependent capacity identification \\
 \bottomrule
 \end{tabular}
@@ -764,7 +764,7 @@ Fix a regulator-scale finite patch cover of a cap neighborhood and let \(R\) be 
 K_\Sigma\subset U(\tilde{\mathcal H}_\Sigma);
 \]
 before the choice of reference chart, the same data form a compact unitary groupoid of overlap-preserving transitions;
-\item if triple-overlap defects are central, the projective composition law of item 2 lifts to an direct action of a compact central extension \(\widehat K_\Sigma\); a genuinely noncentral defect is the only obstruction to reducing the transition system to an ordinary compact group action;
+\item if triple-overlap defects are central, the projective composition law of item 2 lifts to a direct action of a compact central extension \(\widehat K_\Sigma\); a genuinely noncentral defect is the only obstruction to reducing the transition system to an ordinary compact group action;
 \item in the invariant-state realization of the quotient, the chart-independent endomorphisms of the lifted presentation form the boundary-invariant algebra
 \[
 \mathcal A_{\mathrm{inv}}(R)=\widetilde{\mathcal A}(R)^{\widehat K_{\partial R}},
@@ -4125,7 +4125,7 @@ by the same cell. Within the printed quantitative implementation, that \(P\) fir
 one-dimensional pixel-closure solve fixes \(\alpha_U(P)\), equivalently the internal transmutation
 data \(t_U(P)\) and \(t_{\mathrm{tr}}(P)\), and only then do \(t_2(P)\), \(t_3(P)\), \(v(P)\), and
 the running electroweak outputs appear. Quantities algebraically entangled with that quantitative
-branch is on the Phase-II implementation surface: they are forward-emitted there, and
+branch are on the Phase-II implementation surface: they are forward-emitted there, and
 comparison with observation checks that printed implementation rather than enlarging the
 recovered-core claim set.
 

--- a/paper/screen_microphysics_and_observer_synchronization.tex
+++ b/paper/screen_microphysics_and_observer_synchronization.tex
@@ -1596,7 +1596,7 @@ g(t)=0\ \text{for all post-verify cycles},
 \qquad
 N_{\mathrm{plat}}\le 8,
 \end{equation}
-and the residual label must are unchanged for the final $10$ cycles. A run that oscillates
+and the residual label must remain unchanged for the final $10$ cycles. A run that oscillates
 indefinitely, or that reports $\Phi=0$ while the forced stale source is present, fails
 this gate.
 \item \textbf{$S_3$ nonabelian gate.}


### PR DESCRIPTION
This PR completes the current top-level paper pass across all six OPH paper sources and tightens only genuine paper-surface defects: stale claim shorthands, summary compression, section-count drift, and plain wording errors.

The compact paper and the synthesis paper were already aligned to the current claim ledger: charged-lepton wording now reflects the exact centered-readback / common-shift boundary, the Higgs/top lane is named on its declared `D10/D11` surface, and the synthesis summary now keeps bosonic compact-gauge reconstruction, realized matter-branch selection, and the large-edge worldsheet branch separated at the right tier.

This continuation finishes the remaining four sources. The particle paper’s opening status table now states the charged-lepton row as a target-anchored same-family witness and names the Higgs/top row on the declared `D10/D11` split surface. The consensus paper fixes an internal section-count drift in its downstream-directions wrapper. The screen-microphysics paper fixes the residual-obstruction validation gate wording, and the QBFT/QECC appendix fixes a grammar defect inside the safety proof.

Validation was rerun at the paper surface: the five standalone papers under `paper/` compile from the `paper/` directory, and `appendix_B_bft_qecc_extensions.tex` is validated through its inclusion in `paper/reality_as_consensus_protocol.tex`.