### PR TITLE
feat: Package the finite packet-quotient closure theorem lane

### DIFF
--- a/paper/reality_as_consensus_protocol.tex
+++ b/paper/reality_as_consensus_protocol.tex
@@ -759,6 +759,107 @@ Therefore \(M^\eta(\operatorname{nf}_\lambda^\eta(s,k))=M(\operatorname{nf}_\lam
 Physical uniqueness therefore holds on the quotient by gauge or implementation hiding. The same
 statement is unchanged under inert ancillary stabilization.
 
+\begin{definition}[Finite packet closure simplex]\label{def:packet-closure-simplex}
+Assume the finite fixed-cutoff consensus branch of Theorems~\ref{thm:confluence} and
+\ref{thm:gauge}, so the physical quotient \(Q:=\Sigma/\Gamma\) is finite and carries the
+schedule-independent quotient normal-form map
+\[
+\overline{\operatorname{nf}}_\lambda:Q\to Q.
+\]
+Let
+\[
+N_\lambda:=\overline{\operatorname{nf}}_\lambda(Q)=q(C)
+\]
+be the quotient normal-form set. The \textbf{finite packet simplex} on \(Q\) is
+\[
+\Delta(Q):=
+\left\{
+\mu:Q\to\mathbb R_{\ge0}\ \middle|\ \sum_{x\in Q}\mu(x)=1
+\right\},
+\]
+and the \textbf{finite packet closure map} is the pushforward
+\[
+\mathcal C_\lambda:\Delta(Q)\to\Delta(Q),
+\qquad
+\mathcal C_\lambda(\mu):=
+\bigl(\overline{\operatorname{nf}}_\lambda\bigr)_*\mu,
+\]
+equivalently
+\[
+\mathcal C_\lambda(\mu)(y)
+=
+\sum_{\substack{x\in Q\\ \overline{\operatorname{nf}}_\lambda(x)=y}}\mu(x).
+\]
+\end{definition}
+
+\begin{theorem}[Finite packet-quotient closure map]\label{thm:finite-packet-closure}
+On the finite fixed-cutoff consensus branch of Definition~\ref{def:packet-closure-simplex}, the
+map \(\mathcal C_\lambda\) is an affine continuous idempotent self-map of \(\Delta(Q)\). Its
+image is exactly the normal-form simplex
+\[
+\Delta(N_\lambda)
+=
+\left\{
+\mu\in\Delta(Q)\ \middle|\ \operatorname{supp}(\mu)\subseteq N_\lambda
+\right\}.
+\]
+Hence the fixed points of \(\mathcal C_\lambda\) are exactly the packets supported on quotient
+normal forms. For every initial quotient state \([s]\in Q\),
+\[
+\mathcal C_\lambda(\delta_{[s]})
+=
+\delta_{\overline{\operatorname{nf}}_\lambda([s])}.
+\]
+\end{theorem}
+
+\begin{proof}
+Because \(\overline{\operatorname{nf}}_\lambda:Q\to Q\) is a set map on a finite set, its
+pushforward on probability packets is affine and continuous in the finite-dimensional simplex
+topology.
+
+By Theorems~\ref{thm:confluence} and \ref{thm:gauge}, the quotient normal form is
+schedule-independent and already terminal, so
+\[
+\overline{\operatorname{nf}}_\lambda\circ\overline{\operatorname{nf}}_\lambda
+=
+\overline{\operatorname{nf}}_\lambda.
+\]
+Pushforward therefore gives
+\[
+\mathcal C_\lambda^2
+=
+\bigl(\overline{\operatorname{nf}}_\lambda\bigr)_*
+\bigl(\overline{\operatorname{nf}}_\lambda\bigr)_*
+=
+\bigl(\overline{\operatorname{nf}}_\lambda\circ\overline{\operatorname{nf}}_\lambda\bigr)_*
+=
+\mathcal C_\lambda,
+\]
+so \(\mathcal C_\lambda\) is idempotent.
+
+If \(\nu=\mathcal C_\lambda(\mu)\), then every point in \(\operatorname{supp}(\nu)\) lies in the
+image of \(\overline{\operatorname{nf}}_\lambda\), namely \(N_\lambda\). Thus
+\(\operatorname{im}(\mathcal C_\lambda)\subseteq \Delta(N_\lambda)\). Conversely, if
+\(\nu\in\Delta(N_\lambda)\), then \(\overline{\operatorname{nf}}_\lambda(y)=y\) for every
+\(y\in N_\lambda\), so
+\[
+\mathcal C_\lambda(\nu)=\nu.
+\]
+Hence \(\Delta(N_\lambda)\subseteq \operatorname{im}(\mathcal C_\lambda)\), proving
+\(\operatorname{im}(\mathcal C_\lambda)=\Delta(N_\lambda)\). The same identity shows that
+\(\nu\) is a fixed point if and only if it is supported on \(N_\lambda\). The Dirac-mass formula
+is the pushforward of a point mass under \(\overline{\operatorname{nf}}_\lambda\).
+\end{proof}
+
+\begin{remark}[Boundary of the finite closure theorem]\label{rem:finite-packet-closure}
+Theorem~\ref{thm:finite-packet-closure} is an exact finite-branch result. It proves a closure map
+only on the finite packet simplex built from one fixed quotient carrier whose repair law is
+already terminating, confluent, and quotient-descended. It does not prove a habitat-level closure
+map for arbitrary OPH state-and-law data, does not identify a nonempty observer-supporting
+invariant sector inside the Appendix-B habitat, and does not supply uniqueness or stability
+estimates beyond this finite packet branch.
+\end{remark}
+
 
 \section{Refinement-Limit Consensus Classes}
 \label{sec:refinement-consensus}

--- a/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
+++ b/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
@@ -4060,7 +4060,7 @@ Phase III phenomenological continuations (D12 and beyond) & Flavor ans\"atze, ch
 \end{longtable}
 \endgroup
 
-Phase I is the recovered-core tier, Phase II is adjacent but non-core, and Phase III contains phenomenological continuations. The fixed-cutoff consensus surface does define an affine OPH closure map on any finite packet-closed quotient whose repair relation is terminating and confluent: the schedule-independent normal-form projection extends linearly to a continuous idempotent self-map of the finite packet simplex, with the normal-form simplex as invariant image. Interpretive strange-loop discussions and the full habitat theorem remain outside these tiers: the paper does not prove a closure map, uniqueness, or stability theorem for arbitrary OPH state-and-law data beyond the finite packet-quotient branch.
+Phase I is the recovered-core tier, Phase II is adjacent but non-core, and Phase III contains phenomenological continuations. On the exact finite packet-closed quotient branch, the fixed-cutoff consensus surface does define an affine OPH closure map: the schedule-independent normal-form projection pushes forward to a continuous idempotent self-map of the finite packet simplex, its image is exactly the normal-form simplex, and its fixed points are exactly the packets supported on quotient normal forms. Interpretive strange-loop discussions and the full habitat theorem remain outside these tiers: the paper does not prove a habitat-level closure map, a nonempty observer-supporting invariant sector, or uniqueness/stability theorems for arbitrary OPH state-and-law data beyond the finite packet-quotient branch.
 
 \subsection{Recovered-core discriminators}
 

--- a/paper/tex_fragments/OBSERVERS_APPENDICES.tex
+++ b/paper/tex_fragments/OBSERVERS_APPENDICES.tex
@@ -187,8 +187,11 @@ The habitat theorem supplies only the ambient Banach/compact-convex setting. It 
 canonical internal self-map, it does not identify any nonempty invariant observer-supporting subset,
 and it does not prove uniqueness or stability. In particular, nonemptiness and compact-convexity
 of the ambient habitat do not by themselves imply the existence of a nonempty invariant
-observer-supporting sector. Any further strange-loop reading of this habitat as a closure story
-for existence is interpretive only and is not part of the recovered theorem package.
+observer-supporting sector. This does not erase the exact finite packet branch proved on the
+consensus surface: there the quotient normal-form map already pushes forward to a continuous
+affine idempotent self-map of the finite packet simplex, with fixed points exactly the packets
+supported on quotient normal forms. Any further strange-loop reading of the ambient habitat as a
+closure story for existence is interpretive only and is not part of the recovered theorem package.
 
 \subsection{Additional Problem Closures}
 


### PR DESCRIPTION
This PR continues the higher-confidence gap pass on the next tractable lane: finite packet-quotient closure packaging.

The gap here was not missing mathematics in the finite fixed-cutoff branch, but missing packaging. The consensus paper already proved schedule-independent quotient normal forms, quotient descent, and refinement/coarse-graining compatibility. The compact paper then summarized this as an affine finite-packet closure map, but the theorem itself was still only implicit.

This update makes that finite branch explicit. The consensus paper now states the finite packet-quotient closure map directly on the quotient simplex and proves the exact properties the current corpus already supports: affine pushforward, continuity, idempotence, image equal to the normal-form simplex, and fixed points equal to packets supported on quotient normal forms.

The companion compact and appendix surfaces are tightened to match that theorem-grade boundary. They now say clearly that this exact closure result belongs only to the finite packet-quotient branch, while habitat-level closure, nonempty observer-supporting invariant sectors, and strange-loop uniqueness/stability remain open.