### PR TITLE
feat: Sync recovered-core vs input-dependent vs continuation claim tiers across synthesis and book recap surfaces

### DIFF
--- a/book/appendix-chapter-ledger.md
+++ b/book/appendix-chapter-ledger.md
@@ -597,7 +597,8 @@ $$
 
 uses the de Sitter radius to set a deep-infrared scale. The proximity to the
 empirical MOND scale is the reason the chapter treats galaxy-scale anomalies
-as a serious assumption-dependent continuation.
+as a serious assumption-dependent continuation rather than as part of the
+recovered-core theorem package.
 
 The builders include de Sitter, Friedmann, Lemaitre, Hubble, Slipher,
 Gamow, Penzias, Wilson, Guth, Starobinsky, Linde, Riess, Perlmutter, Schmidt,
@@ -793,9 +794,10 @@ quark theorem does not derive its vanishing.
 
 The synthesis chapter is also where status language matters most. A
 reconstruction can be impressive without being uniform in theorem status.
-Some parts are structural consequences. Some are assumption-dependent continuations.
-Some are empirical validations. Some depend on external payloads. A serious
-book should not flatten those categories.
+Some parts are recovered-core structural consequences. Some are input-dependent
+Phase-II closures. Some are assumption-dependent continuations. Some are
+empirical validations. Some depend on external payloads. A serious book should
+not flatten those categories.
 
 The human lineage here is the full relay. No one builds a theory of this
 scope alone. The synthesis is made possible by thermodynamicists, quantum

--- a/book/chapter-13-desitter.md
+++ b/book/chapter-13-desitter.md
@@ -277,7 +277,7 @@ OPH suggests a different route.
 
 ### The Modular Anomaly
 
-In Chapter 11, we saw that a first-variation Einstein relation emerges from an entanglement-equilibrium argument in the scaling regime, and that the same branch can be upgraded to the semiclassical Einstein equation. The continuation below asks what happens when one moves away from the ideal recoverability limit.
+In Chapter 11, we saw that a first-variation Einstein relation emerges from an entanglement-equilibrium argument in the scaling regime, and that the same branch can be upgraded to the semiclassical Einstein equation. The continuation below is not part of that recovered-core gravity chain. It asks what happens when one moves away from the ideal recoverability limit.
 
 In the phenomenological continuation considered here, the Markov condition is treated as only approximate. Some residual correlation is then not perfectly captured by the boundary alone. That imperfection is packaged as an extra term:
 
@@ -349,10 +349,12 @@ The same picture yields the baryonic Tully-Fisher relation:
 $$V^4 = G \cdot M_b \cdot a_0^{(\text{OPH})}$$
 
 This is the observed Tully-Fisher form that the continuation aims to
-reproduce, with its normalization set by screen capacity. In that
+reproduce, with its normalization benchmark set by screen capacity. In that
 phenomenological branch, the dark sector is read as an infrared correction to
 gravity rather than a new species of particle. The cosmological constant and
-the galaxy-scale anomaly then sit inside one de Sitter picture.
+the galaxy-scale anomaly then sit inside one de Sitter picture, but the
+galaxy-scale response law itself is not part of the recovered-core theorem
+package.
 
 ---
 

--- a/book/chapter-15-relativity.md
+++ b/book/chapter-15-relativity.md
@@ -618,9 +618,10 @@ gravitational pull may come from imperfect information recovery.
 
 The underlying logic is simple. In the ideal Markov limit, information on one
 side of a boundary is perfectly recoverable from the boundary itself, and the
-recovered branch follows the Einstein relation. In the dark-sector continuation
-considered here, one moves away from that ideal limit and some correlation
-sits out of reach. That leftover correlation can feed an extra effective term.
+recovered gravity branch follows the Einstein relation. In the dark-sector
+continuation considered here, one moves away from that ideal limit and some
+correlation sits out of reach. That leftover correlation can feed an extra
+effective term.
 
 It gravitates because missing recoverability has physical weight in the
 bookkeeping. This supplies a structural ingredient for a dark sector without
@@ -644,7 +645,9 @@ $$a_0 = \frac{15}{8\pi^2} c^2 \sqrt{\frac{\Lambda}{3}} \approx 1.0 \times 10^{-1
 
 This lands near the empirical MOND acceleration scale. The proximity matters
 because it ties galaxy-scale anomalies back to the same de Sitter capacity
-logic that shaped the horizon from the start.
+logic that shaped the horizon from the start. That benchmark is
+continuation-level: it does not by itself derive a full galaxy-scale
+source/response law.
 
 ## 15.13 Reverse Engineering Summary
 

--- a/book/chapter-16-matter.md
+++ b/book/chapter-16-matter.md
@@ -80,8 +80,8 @@ structure also blocks gauge-mediated proton decay, because the realized gauge
 group is a product group and does not contain the extra leptoquark gauge
 bosons required by simple-group unification.
 
-The electroweak transport family records the weak-sector validation pair
-through a target-free continuation row
+The electroweak transport family records the weak-sector validation pair on a
+declared compare-only validation surface
 
 $$
 M_W = 80.37700001539531\,\mathrm{GeV}, \qquad

--- a/book/chapter-18-synthesis.md
+++ b/book/chapter-18-synthesis.md
@@ -94,9 +94,9 @@ three-generation count follows from CKM phase counting, weak-sector
 consistency, and minimality on the same low-energy branch. The photon,
 gluons, and graviton stay massless because they ride on redundancy directions
 the architecture cannot break. The broader particle table then carries the
-weak validation pair, the low-energy electromagnetic endpoint, the declared
-Higgs-top surface, the selected-class quark sector, and one weighted-cycle
-neutrino family. The technical status ledger separates charged-lepton
+weak-sector validation pair, the low-energy electromagnetic endpoint, the
+declared Higgs/top quantitative surface, the selected-class quark sector, and
+one weighted-cycle neutrino family. The technical status ledger separates charged-lepton
 witnesses, the global public quark-frame classification boundary, the
 auxiliary direct-top compare-only codomain, source-only hadron calculations,
 and empirical hadron closure checks. Hadrons add the strong-binding problem on
@@ -116,7 +116,7 @@ observer records close.
 The quantitative side of the framework turns on two scales with very different
 roles.
 
-The first is global. On the screen-capacity identification branch, the observed
+The first is global. On the input-dependent screen-capacity identification branch, the observed
 cosmological constant fixes the total screen capacity, about
 $3.31\times10^{122}$ natural entropy units, or about $4.77\times10^{122}$
 bits. That gives the size of the accessible computation and sets the de Sitter
@@ -312,12 +312,12 @@ tracked electroweak, Higgs-top, quark, and neutrino surfaces form one
 organized reconstruction, not a catalog of unrelated facts.
 
 The local-ruler ledger records five technical boundaries. The weak pair is a
-validation row. Charged-lepton rows are target-anchored same-family witnesses
-rather than source-emitted public masses. The selected-class quark theorem
-closes only on its declared public frame class, so global public quark-frame
-classification remains open. The auxiliary direct-top PDG row remains
-compare-only. Hadron masses require the OPH strong-binding backend with
-production spectral data and systematics.
+validation row on a declared compare-only surface. Charged-lepton rows are
+target-anchored same-family witnesses rather than source-emitted public
+masses. The selected-class quark theorem closes only on its declared public
+frame class, so global public quark-frame classification remains open. The
+auxiliary direct-top PDG row remains compare-only. Hadron masses require the
+OPH strong-binding backend with production spectral data and systematics.
 The selected-class quark theorem leaves strong CP open: the available corpus
 does not derive $\theta_{\mathrm{QCD}}$, does not emit physical $\bar\theta$,
 and does not prove that the physical strong-CP phase vanishes.

--- a/book/chapter-19-metaphysics.md
+++ b/book/chapter-19-metaphysics.md
@@ -253,8 +253,9 @@ self-consistency condition.
 
 The humility here is important. The metaphysical reading is a continuation of
 the physics, not a replacement for it. If the overlap conditions fail, if the
-particle ledger fails, if the dark-sector continuation fails, or if the
-recoverability claims cannot be sharpened, the interpretation must change.
+particle ledger fails on its declared surfaces, if the dark-sector
+continuation fails, or if the recoverability claims cannot be sharpened, the
+interpretation must change.
 That is a feature. A metaphysics worthy of physics should remain exposed to
 physics.
 

--- a/paper/observers_are_all_you_need.tex
+++ b/paper/observers_are_all_you_need.tex
@@ -288,8 +288,8 @@ record algebras, repair maps, and observer checkpoints are represented on the sc
 assumed from outside.
 \item \textbf{Spacetime is reconstructed.} On the support-visible BW scaling branch, modular time
 supplies Lorentz kinematics, and recoverable generalized entropy together with the null modular
-bridge and bounded-interval transport supplies the Einstein relation. The de Sitter capacity relation
-then ties the cosmological constant to \(N_{\mathrm{scr}}\).
+bridge and bounded-interval transport supplies the Einstein relation. The separate input-dependent
+screen-capacity branch then ties the cosmological constant to \(N_{\mathrm{scr}}\).
 \item \textbf{The Standard Model quotient is selected.} Under the stated coherent transportable-sector
 refinement conditions, edge sectors reconstruct the bosonic compact-gauge branch, and the realized low-energy branch
 with the explicit one-generation/one-Higgs matter package then selects the compact gauge quotient, exact hypercharge,
@@ -328,7 +328,7 @@ bundle reports the following status:
 Lane & Output & Role & Status note \\
 \midrule
 Massless carriers & \(m_\gamma=m_g=m_{\mathrm{grav}}=0\) & structural theorem & symmetry-protected zeros \\
-\(W/Z\) & \(80.377~\mathrm{GeV}\), \(91.18797809193725~\mathrm{GeV}\) & weak-sector validation pair & ledger records exact scope \\
+\(W/Z\) & \(80.377~\mathrm{GeV}\), \(91.18797809193725~\mathrm{GeV}\) & weak-sector validation pair & declared compare-only validation surface; ledger records exact scope \\
 Fine structure & \(\alpha^{-1}(0)=137.035999177(21)\), \(P=1.630968209403959324879279847782648941\ldots\) & fixed-point derivation & ledger records source audit and empirical hadron closure class \\
 Higgs/top & \(125.1995304097179~\mathrm{GeV}\), \(172.35235532883115~\mathrm{GeV}\) & declared D10/D11 split surface & auxiliary direct-top PDG codomain remains compare-only in the available corpus \\
 Charged leptons & \(0.0005109989499999994\), \(0.10565837550000004\), \(1.7769324651340912~\mathrm{GeV}\) & same-family exact witness & source landing from \(P\) to physical charged data lacks a theorem-grade uncentered trace lift in the available corpus \\


### PR DESCRIPTION
This PR tightens the reader-facing status language after closure of the core OPH paper stack.

Problem/gap:

- late-book recap chapters and the synthesis paper still compressed some distinct claim tiers;
- in particular, D6 input-dependent cosmology and dark-sector continuation language could read too close to recovered-core gravity claims;
- some summary surfaces also described the weak electroweak lane too loosely, instead of keeping its declared compare-only validation status visible.

What this PR does:

- aligns the synthesis paper and late-book recap surfaces with the compact-paper authority split between recovered core, input-dependent Phase-II closure, and Phase-III continuation;
- marks the de Sitter screen-capacity relation as a separate input-dependent branch rather than folding it into the recovered-core gravity statement;
- keeps the modular-anomaly dark-sector lane explicitly continuation-level, including the MOND-scale benchmark and galaxy-response wording;
- sharpens summary wording for the weak-sector validation pair, Higgs/top quantitative surface, and related particle-status recaps;
- updates the chapter ledger so its status taxonomy matches the paper stack more closely.

Net effect:

- the late-book and synthesis surfaces now describe the OPH claim tiers more consistently;
- reviewers are less likely to read D6 or dark-sector continuation material as if it were part of the recovered core;
- the book summaries now track the final paper stack more faithfully without weakening the core claims.
