### PR TITLE
feat: Harden particle-lane claim boundaries across paper and book summaries

### DIFF
--- a/book/appendix-chapter-ledger.md
+++ b/book/appendix-chapter-ledger.md
@@ -645,7 +645,7 @@ Higgs gets a vacuum expectation value.
 The generation-count diagram marks a theorem-grade OPH claim: the window begins
 at three for intrinsic CP capability and closes above five from weak-sector
 ultraviolet consistency. The chapter is careful about which rows are
-theorem-grade, which are validation rows, which are target anchored, and
+theorem-grade, which are compare-only validation rows, which are target anchored, and
 which require external empirical payloads.
 
 The builders are too many for a short list, but the relay includes Dirac,

--- a/book/appendix-extended-interludes.md
+++ b/book/appendix-extended-interludes.md
@@ -984,7 +984,7 @@ claim, the reader should be able to see the relay behind it.
 This relay also explains the book's caution around open particle derivations.
 The fine-structure branch, electroweak rows, Higgs/top surface, neutrino
 branch, quark sector, strong-CP boundary, and hadron payloads do not all have
-the same status. Some rows are structural. Some are validation rows. Some
+the same status. Some rows are structural. Some are compare-only validation rows. Some
 depend on empirical payloads. Some are work in progress. A public fact built
 from a long chain has to show which links are welded and which links are
 scaffolds.

--- a/book/chapter-14-standard-model.md
+++ b/book/chapter-14-standard-model.md
@@ -698,10 +698,10 @@ the algebra net closes on itself.
 The particle picture can be told as one continuous line. The framework fixes the Standard Model
 quotient, the hypercharge lattice, and the generation-color counting. The same
 structure keeps the photon, gluons, and graviton on protected zero lines. From
-there the pixel fixed point organizes the electroweak surface, the Higgs-top
-surface, the selected-class running quark masses, and the weighted-cycle
-neutrino family. The status ledger records the weak-boson validation row,
-the charged-lepton witness surface, the global public quark-frame
+there the pixel fixed point organizes the electroweak compare-only validation surface, the Higgs/top
+quantitative surface, the selected-class running quark masses, and the weighted-cycle
+neutrino theorem branch. The status ledger records the weak-boson compare-only validation row,
+the charged-lepton target-anchored witness surface, the global public quark-frame
 classification boundary, the strong-CP branch, and the auxiliary direct-top
 compare-only codomain.
 
@@ -905,9 +905,9 @@ Let's step back and see what the framework actually accounts for.
 
 **The particle structure.** Section 14.14 gives the concrete structure. The
 framework fixes the massless carriers. The particle surface carries the
-fine-structure fixed point, a weak-boson validation pair, a Higgs-top surface,
+fine-structure fixed point, a weak-boson compare-only validation pair, a Higgs/top quantitative surface,
 a selected-class six-quark running-mass sector with Yukawas,
-and one weighted-cycle neutrino family with definite masses and Majorana
+and one weighted-cycle neutrino theorem branch with definite masses and Majorana
 phases. That selected-class quark sector leaves strong CP open: the available
 corpus does not derive $\theta_{\mathrm{QCD}}$, does not emit physical
 $\bar\theta$, and does not prove that the physical strong-CP phase vanishes. It
@@ -920,7 +920,7 @@ them with one local fixed-point structure. The same pixel ratio feeds the
 electroweak scale, the low-energy electromagnetic endpoint, and the effective
 gravitational coupling. The reader does not need
 every intermediate symbol to see the point. OPH is attempting to tie
-electroweak masses, the Higgs/top surface, electromagnetism at low energy, and
+electroweak validation rows, the Higgs/top quantitative surface, electromagnetism at low energy, and
 Newton's constant to one common structure without treating them as unrelated
 constants, while keeping the open endpoint and matching gates visible.
 
@@ -957,8 +957,8 @@ ultraviolet consistency.
 
 It is a remarkably concrete result. The book points to a specific gauge
 structure, charge pattern, color count, and generation count. It also reaches
-the massless carriers, the $W$ and $Z$, a Higgs-top surface, one
-weighted-cycle neutrino family, and a running quark sector on a selected
+the massless carriers, the compare-only $W$ and $Z$ row, a Higgs/top quantitative surface, one
+weighted-cycle neutrino theorem branch, and a running quark sector on a selected
 physical basis. Strongly coupled bound states add the QCD problem on top of
 that particle-level structure.
 

--- a/book/chapter-16-matter.md
+++ b/book/chapter-16-matter.md
@@ -123,12 +123,12 @@ the Ward-projected electromagnetic channel.
 The value is forced because the pixel has one geometry and one electromagnetic
 readout, and those two descriptions meet at a single fixed point.
 
-The weak-boson pair and the familiar low-energy electromagnetic strength come
+The weak-boson compare-only validation pair and the familiar low-energy electromagnetic strength come
 from one continuous construction. The status table records the diagnostic
 source trunk, the endpoint residual, and the empirical hadron closure row that
 uses a separate \(e^+e^-\to\mathrm{hadrons}\) payload class.
 
-The same electroweak core carries the declared Higgs/top surface
+The same electroweak core carries the declared Higgs/top quantitative surface
 
 $$
 (m_H,m_t)=(125.1995304097179,\ 172.3523553288312)\,\mathrm{GeV}.
@@ -172,10 +172,10 @@ $$
 
 together with definite Majorana phases in that construction. Taken together,
 the particle picture is larger than a handful of isolated numbers. The OPH
-status table carries structural massless carriers, the weak-sector validation pair,
-the declared Higgs/top surface, the selected-class running quark sextet with
-Yukawas, and one weighted-cycle neutrino family. The late status ledger
-records the fine-structure audit trunk, the charged-lepton witness surface, the
+status table carries structural massless carriers, the weak-sector compare-only validation pair,
+the declared Higgs/top quantitative surface, the selected-class running quark sextet with
+Yukawas, and one weighted-cycle neutrino theorem branch. The late status ledger
+records the fine-structure audit trunk, the charged-lepton target-anchored witness surface, the
 global public quark-frame classification boundary, and the auxiliary direct-top
 compare-only codomain.
 The selected-class quark theorem leaves strong CP open: the
@@ -353,7 +353,7 @@ action is the classical limit of quantum interference. The deterministic world
 of everyday life is the public face of a quantum reality that becomes
 shareable only after decoherence and redundancy have done their work.
 
-Ledger details: the weak-boson pair is a validation row, charged-lepton rows
+Ledger details: the weak-boson pair is a compare-only validation row, charged-lepton rows
 are target-anchored same-family witnesses rather than source-emitted public
 masses, source-only hadron masses require the OPH strong-binding backend with
 production spectral data and systematics, and empirical hadron closure checks

--- a/book/chapter-18-synthesis.md
+++ b/book/chapter-18-synthesis.md
@@ -94,9 +94,9 @@ three-generation count follows from CKM phase counting, weak-sector
 consistency, and minimality on the same low-energy branch. The photon,
 gluons, and graviton stay massless because they ride on redundancy directions
 the architecture cannot break. The broader particle table then carries the
-weak-sector validation pair, the low-energy electromagnetic endpoint, the
+weak-sector compare-only validation pair, the low-energy electromagnetic endpoint, the
 declared Higgs/top quantitative surface, the selected-class quark sector, and
-one weighted-cycle neutrino family. The technical status ledger separates charged-lepton
+one weighted-cycle neutrino theorem branch. The technical status ledger separates charged-lepton
 witnesses, the global public quark-frame classification boundary, the
 auxiliary direct-top compare-only codomain, source-only hadron calculations,
 and empirical hadron closure checks. Hadrons add the strong-binding problem on

--- a/paper/observers_are_all_you_need.tex
+++ b/paper/observers_are_all_you_need.tex
@@ -170,10 +170,10 @@ Ward-projected Thomson endpoint and \(P=\varphi+\sqrt{\pi}/A_T(P)\). The value
 is forced because the same cell must satisfy both readings at once: geometric
 detuning outside, electromagnetic observation width inside. On this branch OPH
 has no remaining local scale with which to tune the fine-structure constant. The particle
-surface carries structural massless carriers, a weak-sector validation pair, a declared
-Higgs/top surface, selected-class quarks, and a weighted-cycle neutrino absolute branch. The
-status discussion separates the charged-lepton witness surface, the global public quark-frame
-classification boundary, the auxiliary direct-top codomain, and hadron calculations requiring
+surface carries structural massless carriers, a weak-sector compare-only validation pair, a declared
+Higgs/top quantitative surface, selected-class quarks, and a weighted-cycle neutrino theorem branch. The
+status discussion separates the charged-lepton target-anchored witness surface, the global public quark-frame
+classification boundary, the auxiliary direct-top compare-only codomain, and hadron calculations requiring
 strong-binding input.
 \end{abstract}
 
@@ -254,10 +254,10 @@ entropy balance point \(\varphi=(1+\sqrt5)/2\). From inside, the same cell appea
 electromagnetic observation step available in the encoded world. The local scale is the value of
 \(P\) where those two readings coincide.
 
-With the \(P\) fixed point in place, the same scale organizes the weak-boson pair,
-the low-energy electromagnetic endpoint, the Higgs/top surface, the running quark package,
-a neutrino family, and the local gravity-facing readout. The status table records the scope of the
-weak validation row, charged-lepton witnesses, and hadron backend.
+With the \(P\) fixed point in place, the same scale organizes the weak-boson compare-only validation pair,
+the low-energy electromagnetic endpoint, the Higgs/top quantitative surface, the running quark package,
+a weighted-cycle neutrino theorem branch, and the local gravity-facing readout. The status table records the scope of the
+weak compare-only validation row, charged-lepton target-anchored witnesses, and hadron backend.
 
 The fourth achievement is implementation. The screen-microphysics construction makes patches,
 overlaps, edge observables, records, repair maps, and observer checkpoints explicit at finite
@@ -330,10 +330,10 @@ Lane & Output & Role & Status note \\
 Massless carriers & \(m_\gamma=m_g=m_{\mathrm{grav}}=0\) & structural theorem & symmetry-protected zeros \\
 \(W/Z\) & \(80.377~\mathrm{GeV}\), \(91.18797809193725~\mathrm{GeV}\) & weak-sector validation pair & declared compare-only validation surface; ledger records exact scope \\
 Fine structure & \(\alpha^{-1}(0)=137.035999177(21)\), \(P=1.630968209403959324879279847782648941\ldots\) & fixed-point derivation & ledger records source audit and empirical hadron closure class \\
-Higgs/top & \(125.1995304097179~\mathrm{GeV}\), \(172.35235532883115~\mathrm{GeV}\) & declared D10/D11 split surface & auxiliary direct-top PDG codomain remains compare-only in the available corpus \\
-Charged leptons & \(0.0005109989499999994\), \(0.10565837550000004\), \(1.7769324651340912~\mathrm{GeV}\) & same-family exact witness & source landing from \(P\) to physical charged data lacks a theorem-grade uncentered trace lift in the available corpus \\
+Higgs/top & \(125.1995304097179~\mathrm{GeV}\), \(172.35235532883115~\mathrm{GeV}\) & declared D10/D11 quantitative surface & auxiliary direct-top PDG codomain remains compare-only in the available corpus \\
+Charged leptons & \(0.0005109989499999994\), \(0.10565837550000004\), \(1.7769324651340912~\mathrm{GeV}\) & target-anchored same-family exact witness & source landing from \(P\) to physical charged data lacks a theorem-grade uncentered trace lift in the available corpus \\
 Quarks & \(u,d,s,c,b,t=(0.00216,0.00470,0.0935,1.273,4.183,172.35235532883115)~\mathrm{GeV}\) & selected-class exact theorem & exact only on the selected public quark frame class; global public-frame classification has a no-go boundary in the available corpus; strong CP remains open \\
-Neutrinos & \(0.017454720257976796\), \(0.019481987935919015\), \(0.05307522145074924~\mathrm{eV}\) & weighted-cycle absolute branch & absolute masses are not directly measured; PMNS comparison tension remains visible \\
+Neutrinos & \(0.017454720257976796\), \(0.019481987935919015\), \(0.05307522145074924~\mathrm{eV}\) & weighted-cycle theorem branch & absolute masses are not directly measured; PMNS comparison tension remains visible \\
 Hadrons & no source-only prediction emitted; empirical closure rows separate & source backend absent; empirical closure policy emitted & source-only masses require a working OPH hadron backend, such as GLORB/Echosahedron; empirical closure uses a separate \(e^+e^-\to\mathrm{hadrons}\) payload class \\
 \bottomrule
 \end{tabular}

--- a/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
+++ b/paper/recovering_relativity_and_standard_model_structure_from_observer_overlap_consistency_compact.tex
@@ -3891,8 +3891,8 @@ Thus the branch runs from OPH input \(P\) to the internal transmutation data
 
 Every quoted D10 electroweak number is downstream of this forward map. In particular, the
 source-locked running-family anchor \(a_0(P)=\alpha_{\mathrm{em}}^{-1}(m_Z^2;P)\), the
-declared electromagnetic transport family \(\alpha_{\mathrm{em}}^{-1}(q^2;P)\) and \(\sin^2\theta_W(q^2;P)\), and the public
-\(W/Z\) pair are source-branch outputs on the printed quantitative surface. The Thomson endpoint
+declared electromagnetic transport family \(\alpha_{\mathrm{em}}^{-1}(q^2;P)\) and \(\sin^2\theta_W(q^2;P)\), and the frozen public
+compare-only \(W/Z\) validation rows sit on the printed quantitative surface. The Thomson endpoint
 \[
 \alpha_{\mathrm{Th}}^{-1}(P)=\lim_{q^2\to0}\alpha_{\mathrm{em}}^{-1}(q^2;P)
 \]


### PR DESCRIPTION
This PR tightens the particle-status wording across the summary surfaces without changing any theorem content.

Problem/gap:

- some late-summary surfaces still compressed distinct particle row classes;
- in particular, the compact paper still described the public \(W/Z\) pair too much like a source-branch output;
- overview surfaces also blurred the difference between compare-only validation rows, target-anchored charged-lepton witnesses, declared Higgs/top quantitative surfaces, and weighted-cycle neutrino theorem branches.

What this PR does:

- marks the public \(W/Z\) lane consistently as a frozen compare-only validation row on the printed quantitative surface;
- keeps Higgs/top wording on the declared D10/D11 quantitative surface rather than a looser generic surface label;
- makes the charged-lepton summaries explicitly target anchored and the neutrino summaries explicitly theorem-branch based;
- updates the relevant book recap and ledger language so the status taxonomy matches the particle paper and compact-paper authority split.

Net effect:

- the particle summaries now keep validation, theorem, witness, and backend rows more clearly separated;
- reviewers are less likely to misread compare-only or target-anchored rows as source-emitted prediction theorems;
- the book and paper overview surfaces track the current particle-status ledger more faithfully.