### PR TITLE
feat: Re-mark D6 cosmology and dark-sector claim tiers across book and overview summaries

### DIFF
--- a/book/appendix-chapter-ledger.md
+++ b/book/appendix-chapter-ledger.md
@@ -584,8 +584,8 @@ the entropy formula divides by $4\ell_P^2$.
 
 The chapter's capacity numbers are enormous but finite, around
 $10^{122}$ to $10^{123}$ depending on convention. OPH reads the cosmological
-constant as a global capacity parameter: it fixes the size of the screen on
-which finite observer-patch physics is organized.
+constant as an input-dependent global capacity parameter: it fixes the size of
+the screen on which finite observer-patch physics is organized.
 
 The modular-anomaly continuation introduces an effective dark component. The
 benchmark acceleration

--- a/book/appendix-extended-interludes.md
+++ b/book/appendix-extended-interludes.md
@@ -345,8 +345,8 @@ found that distant supernovae were dimmer than expected in a decelerating
 universe. The simplest fit is a positive cosmological constant or dark energy
 component. In de Sitter language, a positive $\Lambda$ gives a horizon radius
 $r_{dS}=\sqrt{3/\Lambda}$ and a finite entropy capacity. For OPH that capacity
-is the global screen size, the large-number boundary condition for the finite observer-patch
-picture.
+acts as the input-dependent global screen size, the large-number boundary
+condition for the finite observer-patch picture.
 
 The dark-sector continuation is deliberately careful. The modular anomaly
 idea ties residual mismatch in modular-geometric bookkeeping to an effective

--- a/book/chapter-13-desitter.md
+++ b/book/chapter-13-desitter.md
@@ -197,16 +197,19 @@ construction cannot erase.
 
 The symbol $\Lambda$ is the cosmological constant, the part of Einstein's
 equation that acts like a uniform large-scale tendency for space to accelerate.
-OPH reads it as global capacity data, not as one more local particle-physics
-coupling.
+It is global capacity data on the input-dependent screen-capacity branch, not
+one more local particle-physics coupling.
 
-So on the cosmological-capacity branch Lambda is fixed by a **global** constraint: the total capacity of the screen. In natural units, once $N_{\mathrm{scr}}=\log(\dim \mathcal{H}_{\text{tot}})$ is supplied, the relationship is:
+So on the input-dependent cosmological-capacity branch Lambda is fixed by a
+**global** constraint: the total capacity of the screen. In natural units,
+once $N_{\mathrm{scr}}=\log(\dim \mathcal{H}_{\text{tot}})$ is supplied, the
+relationship is:
 
 $$\Lambda = \frac{3\pi}{G \cdot \log(\dim \mathcal{H}_{\text{tot}})}$$
 
-In the book's reading, the observed $\Lambda$ is the way the world announces
-its total screen capacity once that global input is identified. It is the
-global size parameter carried by every consistent patch.
+With that global input declared, the observed $\Lambda$ is the way the world
+announces its total screen capacity. It is the global size parameter carried
+by every consistent patch.
 
 The symbol $\mathcal H_{\text{tot}}$ means the total Hilbert space available to
 the screen, and $\dim$ means its dimension, the number of independent quantum
@@ -219,7 +222,11 @@ positive cosmological constant.
 
 The philosophical stance of OPH, no objective camera angle and only perspectives that must agree on overlaps, maps naturally onto de Sitter static-patch intuition. Each timelike observer has a horizon and a patch. There is no operational access to a single global description.
 
-Lambda is the one thing that **can** be shared across overlaps. It is a global capacity constraint that all consistent overlapping descriptions inherit. Different observers see different patches, and they all see the same Lambda encoded in the finite size of their horizons.
+On that same input-dependent branch, Lambda is the global quantity that
+**can** be shared across overlaps. It is a capacity constraint that all
+consistent overlapping descriptions inherit. Different observers see
+different patches, and they all see the same Lambda encoded in the finite
+size of their horizons.
 
 ### The Cosmology Picture
 

--- a/book/chapter-18-synthesis.md
+++ b/book/chapter-18-synthesis.md
@@ -226,8 +226,9 @@ therefore a natural screen.
 
 Different observers carry different horizons, yet those horizons overlap
 enormously. The consistency conditions are severe. The total state space is
-finite. The cosmological constant ceases to look like an awkward vacuum-energy
-leftover and starts looking like a global capacity statement about the screen.
+finite. On that same input-dependent branch, the cosmological constant stops
+looking like an awkward vacuum-energy leftover and instead looks like a global
+capacity statement about the screen.
 
 The de Sitter chapter mattered so much because it did not break the thread. It
 revealed the stage on which the observer-first picture reads most

--- a/paper/observers_are_all_you_need.tex
+++ b/paper/observers_are_all_you_need.tex
@@ -153,8 +153,8 @@ triplet \(N_c=3\), and the generation count \(N_g=3\). The basis is quantum-alge
 patch algebras, states, trace/Born event probabilities on declared record surfaces, and
 generalized entropy are ingredients of the formalism. The synthesis claim is that this
 algebraic-information basis can recover the observed effective universe from overlap
-consistency, with its mathematical ingredients stated explicitly. The quantitative side uses only two scales. The global capacity
-\(N_{\mathrm{scr}}=\log\dim\mathcal H_{\mathrm{tot}}\) is read from the de Sitter horizon entropy. For the observed
+consistency, with its mathematical ingredients stated explicitly. Beyond the recovered core, the quantitative side uses only two scales. On the input-dependent
+screen-capacity branch, the global capacity \(N_{\mathrm{scr}}=\log\dim\mathcal H_{\mathrm{tot}}\) is read from the de Sitter horizon entropy. For the observed
 horizon, the bare ratio \((R_{\mathrm{dS}}/\ell_P)^2\) is about \(1.05\times10^{122}\);
 the entropy capacity used by OPH is the \(\pi\)-larger value \(N_{\mathrm{scr}}\simeq
 3.31\times10^{122}\), giving \(\Lambda=3\pi/(G N_{\mathrm{scr}})\). The local pixel ratio
@@ -243,8 +243,9 @@ The realized low-energy branch then fixes exact hypercharge, three generations, 
 masslessness of the photon, gluons, and graviton, integer charge for color singlets, and the absence
 of gauge-mediated proton decay.
 
-The third achievement is quantitative. OPH uses one global capacity scale and one local pixel scale.
-The global scale is \(N_{\mathrm{scr}}\). The local scale is
+The third achievement is quantitative and sits outside the recovered core. OPH uses one
+input-dependent global capacity scale and one local pixel scale. The global scale is
+\(N_{\mathrm{scr}}\) on the separate screen-capacity branch. The local scale is
 \[
 P:=\frac{a_{\mathrm{cell}}}{\ell_P^2}.
 \]


### PR DESCRIPTION
This PR tightens the de Sitter and cosmology status language on the summary surfaces without changing any theorem content.

Problem/gap:

- several recap passages still stated the cosmological-capacity lane too directly;
- in those surfaces, the de Sitter capacity relation and the dark-sector benchmark could read too close to recovered-core gravity claims unless the separate D6 input-dependent branch stayed visible;
- the overview paper also summarized the two OPH scales without clearly restating that the global capacity scale sits outside the recovered core.

What this PR does:

- marks the \(\Lambda\)/screen-capacity relation as an input-dependent branch on the relevant book recap surfaces;
- keeps the dark-sector and de Sitter recap language tied to that same non-core status boundary;
- updates the overview paper so the global capacity scale is explicitly described as belonging to the separate input-dependent screen-capacity branch rather than the recovered core.

Net effect:

- the cosmology summaries now keep recovered-core gravity, D6 input-dependent closure, and later continuation language more clearly separated;
- reviewers are less likely to misread the de Sitter capacity relation or dark-sector benchmark as if they were part of the recovered-core theorem package;
- the book and overview paper track the compact-paper claim-tier split more faithfully.
