### PR TITLE
fix: Align observers status surfaces with the closed BW and compact-gauge theorem branches

### DIFF
--- a/paper/tex_fragments/OBSERVERS_APPENDICES.tex
+++ b/paper/tex_fragments/OBSERVERS_APPENDICES.tex
@@ -209,7 +209,7 @@ companion-paper theorem surfaces.
 Claim & Status & Boundary \\
 \midrule
 Quantum gravity consistency & Proved corollary of earlier theorems & Lorentz and Jacobson-type Einstein branches follow from the support-visible BW scaling theorem together with the stated null-bridge and fixed-cap conditions. \\
-UV completion / microscopic uniqueness & Explicit future program & Fixed-cutoff theorem packages exist, but a unique microscopic representative, the continuum BW lift on the extracted geometric subnet, and the refinement-limit transportable compact-gauge lift remain open. \\
+UV completion / microscopic uniqueness & Explicit future program & Fixed-cutoff theorem packages exist, but a unique microscopic representative is not identified. The support-visible BW scaling theorem and the realized zero-obstruction bosonic compact-gauge branch are closed on their declared companion-paper theorem surfaces; the remaining future-program boundary is microscopic representative uniqueness rather than a missing recovered-core lift. \\
 Measurement problem & Explicit future program & Ref.~\cite{ophmicrophysics} closes the fixed-cutoff central-record / Born-L\"uders interface, but a full philosophical or continuum-level measurement closure is not derived here. \\
 Cosmological principle and horizon homogeneity & Explicit future program & MaxEnt symmetry inheritance is suggestive only; an independent derivation of cosmological isotropy and homogeneity remains outside the recovered-core theorems. \\
 Observer-relative modular time & Proved corollary of earlier theorems & On the BW\(_{S^2}\) geometric branch, observer-relative time is read from the cap modular automorphism parameter of the observer's accessible algebra/state pair. This is the D3 reading only. \\

--- a/paper/tex_fragments/OBSERVERS_SYNTHESIS_SECTIONS.tex
+++ b/paper/tex_fragments/OBSERVERS_SYNTHESIS_SECTIONS.tex
@@ -247,7 +247,8 @@ record-event surface. Fourth, the fixed-cutoff
 Bell/CHSH package is closed on the declared two-wing surface. Fifth, the
 checkpoint/restoration observer package is closed. The external burdens on this lane are the final
 packet-level quotient closure where one wants an autonomous exported dynamics, the compact
-heat-kernel lift, global consensus analysis, and refinement-stable universality. The
+heat-kernel lift on that same microphysics lane, global consensus analysis, and refinement-stable
+universality. The
 support-visible BW / geometric-modular / local-Einstein closure lives on the companion recovered-core
 papers rather than on this fixed-cutoff engineering lane. A reconstruction of Hilbert, \(C^*\)- or von Neumann algebra
 structure, Born probabilities, trace structure, and entropy from operational records alone remains

--- a/paper/tex_fragments/PAPER.tex
+++ b/paper/tex_fragments/PAPER.tex
@@ -3745,7 +3745,8 @@ one-Higgs branch select the realized Standard Model quotient, \(N_c=3\), and \(N
 \item \textbf{Microscopic theory}: finite quantum-link style presentations give concrete
 fixed-cutoff examples. They do not select a unique microscopic representative.
 \item \textbf{Noncentral gluing}: the crossed-module higher-gauge package closes the fixed-cutoff
-topological branch. The refinement-limit compact-gauge lift is a separate theorem branch.
+topological branch. The realized zero-obstruction bosonic compact-gauge branch is carried by a
+separate theorem stack on the ordinary or central branch.
 \end{itemize}
 
 \subsubsection{Testable Items and Phenomenological Branches}\label{83-novel-testable-predictions}
@@ -3775,8 +3776,7 @@ The recovered core does not derive the following:
 \item dark-sector response laws, heuristic baryogenesis continuations, strong-CP proposals, proton-spin fractions, and
 late-stage spectroscopy templates;
 \item Page-curve/island closure, PBH/LIGO comb claims, or critical-superstring completion;
-\item a unique microscopic representative, a fully internalized geometric scaling-limit branch,
-or a full fermionic/super-Tannakian gauge reconstruction.
+\item a unique microscopic representative or a full fermionic/super-Tannakian gauge reconstruction.
 \end{itemize}
 
 \(N_{\mathrm{scr}}\) is an external capacity input for the cosmological branch. \(P\) is selected
@@ -3852,7 +3852,7 @@ The cosmological constant problem is a graveyard of unified theories: local QFT 
 
 Unified programs struggle to give sharp, finite microscopic definitions. Formal continuum structures, infinite entropies, and regularization dependence abound.
 
-\emph{Resolution:} The regulator construction uses local patch algebras that are type-I and finite-dimensional, with a MaxEnt branch whose generator is quasi-local and obeys a Lieb-Robinson bound. So the fixed-cutoff UV branch is interacting in the ordinary finite-range sense, and the fundamental degrees of freedom are finite and live on the screen. The framework does \emph{not} claim a unique microscopic UV completion: physical uniqueness is only modulo gauge or implementation hiding together with inert ancillary stabilization. The genuinely noncentral topological branch is also closed at fixed cutoff by the higher-gauge crossed-module collar theorem, while the continuum BW lift is supplied by the support-visible scaling theorem and the refinement-limit transportable gauge branch is stated through its zero-obstruction theorem stack.
+\emph{Resolution:} The regulator construction uses local patch algebras that are type-I and finite-dimensional, with a MaxEnt branch whose generator is quasi-local and obeys a Lieb-Robinson bound. So the fixed-cutoff UV branch is interacting in the ordinary finite-range sense, and the fundamental degrees of freedom are finite and live on the screen. The framework does \emph{not} claim a unique microscopic UV completion: physical uniqueness is only modulo gauge or implementation hiding together with inert ancillary stabilization. The genuinely noncentral topological branch is also closed at fixed cutoff by the higher-gauge crossed-module collar theorem, while the support-visible BW scaling branch is closed by theorem and the realized zero-obstruction bosonic compact-gauge branch is carried by its declared theorem stack.
 
 \textbf{12. Predictivity vs. parameter explosion.}
 


### PR DESCRIPTION
This PR tightens the observers paper status language so it matches the current OPH theorem stack.

Problem/gap:

- the observers appendix status table still said the continuum BW lift and the refinement-limit transportable compact-gauge lift remained open;
- that wording conflicted with the current companion corpus, where the support-visible BW scaling theorem closes the modular/geometric Lorentz branch and the realized zero-obstruction bosonic compact-gauge branch is carried by the transportability, fixed-cutoff sector-category, refinement/fiber descent, sector-colimit, and realized-witness theorems;
- the synthesis fragments needed narrower wording cues so the remaining engineering burdens stay local to the fixed-cutoff microphysics lane rather than sounding like recovered-core gaps.

What this PR does:

- rewrites the `UV completion / microscopic uniqueness` row in the observers appendix so the future-program boundary is unique microscopic representative selection, not a missing BW or compact-gauge lift;
- tightens the observers synthesis fragment so the compact heat-kernel lift is explicitly local to the microphysics lane while the BW / geometric-modular / local-Einstein closure stays identified as a companion recovered-core surface;
- tightens adjacent observers synthesis bullets so the noncentral-gluing and gap summaries do not imply a missing geometric scaling branch or unresolved compact-gauge lift elsewhere in the same paper;
- regenerates the observers paper markdown export after the source edit.

Net effect:

- the observers paper no longer reports the closed BW branch as open;
- the observers paper no longer reports the realized zero-obstruction bosonic compact-gauge branch as an unresolved lift;
- remaining future-program language stays focused on genuine unfinished lanes rather than stale recovered-core status.
