### PR TITLE
Fix Windows byte-reproducibility of the receipt suite on a clean checkout (LF + POSIX paths)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Normalize committed text to LF in the working tree on every platform.
+# The scientific receipt suite verifies JSON artifacts by sha256/byte equality;
+# without this, a Windows checkout (core.autocrlf=true) gets CRLF and every
+# byte/hash check fails. Every committed text blob is already LF, so this only
+# stabilizes checkout and changes no committed content.
+* text=auto eol=lf
+
+# External data table committed with CRLF; keep its exact bytes (never rewrite).
+code/dark_matter/data/external/SPARC_MassModels_Lelli2016c.mrt -text

--- a/code/P_derivation/empirical_thomson_endpoint.py
+++ b/code/P_derivation/empirical_thomson_endpoint.py
@@ -191,7 +191,7 @@ def evaluate() -> dict:
             "measured_alpha_in_solve_path": False,
         },
         "inputs": {
-            "payload": str(PAYLOAD_PATH.relative_to(ROOT.parent)),
+            "payload": PAYLOAD_PATH.relative_to(ROOT.parent).as_posix(),
             "payload_release": payload["data_release"]["release_id"],
             "delta_alpha_had_5_MZ": str(delta_had),
             "delta_alpha_had_5_MZ_uncertainty": str(delta_had_unc),
@@ -201,7 +201,7 @@ def evaluate() -> dict:
                 "self-consistent form; the solved additive insertion "
                 "A_Th = A_L + delta A_Th coincides with it",
             "hadronic_spectral_measure_export": {
-                "path": str(MEASURE_PATH.relative_to(ROOT.parent)),
+                "path": MEASURE_PATH.relative_to(ROOT.parent).as_posix(),
                 "artifact": measure["artifact"],
                 "profile_id": measure["profile_id"],
                 "representation": measure["rho_had_or_measure"]["representation"],
@@ -220,7 +220,7 @@ def evaluate() -> dict:
             "lepton_transport_delta_inv_alpha": str(LEPTON_TRANSPORT_DELTA_INV_ALPHA),
             "hadronic_spectral_object": {
                 "artifact": measure["artifact"],
-                "path": str(MEASURE_PATH.relative_to(ROOT.parent)),
+                "path": MEASURE_PATH.relative_to(ROOT.parent).as_posix(),
                 "delta_alpha_had_5_MZ_timelike": str(
                     measure["transport_moments"]["timelike_on_shell_mz"]["value"]),
                 "delta_alpha_had_5_MZ_spacelike": str(

--- a/code/P_derivation/source_spectral_theorem.py
+++ b/code/P_derivation/source_spectral_theorem.py
@@ -40,9 +40,9 @@ def _now_utc() -> str:
 
 def _load_optional(path: Path) -> dict[str, Any]:
     if not path.exists():
-        return {"artifact_path": str(path.relative_to(ROOT)), "exists": False}
+        return {"artifact_path": path.relative_to(ROOT).as_posix(), "exists": False}
     payload = json.loads(path.read_text(encoding="utf-8"))
-    payload.setdefault("artifact_path", str(path.relative_to(ROOT)))
+    payload.setdefault("artifact_path", path.relative_to(ROOT).as_posix())
     payload.setdefault("exists", True)
     return payload
 
@@ -209,7 +209,7 @@ def build_source_spectral_theorem(
             "fixed_point_map": "P=phi+sqrt(pi)/A_T(P)",
         },
         "accepted_source_payload_contract": {
-            "schema": str(DEFAULT_SCHEMA.relative_to(ROOT)),
+            "schema": DEFAULT_SCHEMA.relative_to(ROOT).as_posix(),
             "required_artifact": "oph_qcd_ward_projected_hadronic_spectral_measure",
             "required_transport_wrapper": "oph_source_ward_projected_thomson_transport",
             "required_fields": list(THEOREM_GRADE_REQUIRED_FIELDS),

--- a/code/P_derivation/thomson_endpoint_interval_certificate.py
+++ b/code/P_derivation/thomson_endpoint_interval_certificate.py
@@ -160,7 +160,7 @@ def build_interval_certificate(
             },
             "R_Q_certificate": {
                 "status": "missing_source_artifact",
-                "contract_artifact": str(DEFAULT_R_Q_OUT.relative_to(DEFAULT_OUT.parent.parent)),
+                "contract_artifact": DEFAULT_R_Q_OUT.relative_to(DEFAULT_OUT.parent.parent).as_posix(),
                 "R_Q_image_required": r_required.to_json(),
                 "R_Q_prime_abs_target": +l_r_target,
                 "source_only": True,

--- a/code/P_derivation/transport_theorem_manifest.py
+++ b/code/P_derivation/transport_theorem_manifest.py
@@ -89,7 +89,7 @@ def build_manifest(report: dict[str, Any]) -> dict[str, Any]:
         "required_transport_delta_alpha_inv": audit["required_transport_delta_alpha_inv"],
         "missing_transport_delta_alpha_inv": audit["missing_transport_delta_alpha_inv"],
         "endpoint_package": {
-            "path": str(ENDPOINT_PACKAGE.relative_to(Path(__file__).resolve().parents[1])),
+            "path": ENDPOINT_PACKAGE.relative_to(Path(__file__).resolve().parents[1]).as_posix(),
             "exists": ENDPOINT_PACKAGE.exists(),
         },
         "theorems": THEOREM_STATUSES,

--- a/code/geometry/realized_branch_receipts.py
+++ b/code/geometry/realized_branch_receipts.py
@@ -156,7 +156,7 @@ def build_report() -> dict:
 
     evaluations = {
         "verified_tree_packet_net_domain": {
-            "source": str(TREE_ARTIFACT.relative_to(ROOT)),
+            "source": TREE_ARTIFACT.relative_to(ROOT).as_posix(),
             "provenance": "consensus_product (issue #238 verified export)",
             **tree,
         },

--- a/code/particles/calibration/derive_qme_source_action_rigidity_mechanism.py
+++ b/code/particles/calibration/derive_qme_source_action_rigidity_mechanism.py
@@ -307,7 +307,7 @@ def build_artifact(certificate: Mapping[str, Any]) -> dict[str, Any]:
         },
         "branch": {
             "P_cand": str(p_cand_raw),
-            "P_cand_source": str(PIXEL_CERTIFICATE.relative_to(ROOT)),
+            "P_cand_source": PIXEL_CERTIFICATE.relative_to(ROOT).as_posix(),
             "phi": _text(phi),
             "p_definition": "(P - phi)/sqrt(pi)",
             "p": _text(p),

--- a/code/particles/flavor/quark_rscc_completion_candidate.py
+++ b/code/particles/flavor/quark_rscc_completion_candidate.py
@@ -115,7 +115,7 @@ def load_repository_inputs() -> tuple[dict[str, object], dict[str, Any]]:
     ]
     provenance = {
         "dependency_files": {
-            str(path.relative_to(CODE_ROOT)): {"sha256": _sha256(path)}
+            path.relative_to(CODE_ROOT).as_posix(): {"sha256": _sha256(path)}
             for path in dependency_paths
         },
         "pixel_branch_status": pixel.get("status"),

--- a/code/particles/flavor/quark_s3_d12_template_postdiction.py
+++ b/code/particles/flavor/quark_s3_d12_template_postdiction.py
@@ -96,7 +96,7 @@ def load_repository_inputs() -> tuple[dict[str, object], dict[str, Any]]:
     p_source = P_DERIVATION.read_text(encoding="utf-8")
     provenance = {
         "dependency_files": {
-            str(path.relative_to(CODE_ROOT)): {"sha256": _sha256(path)} for path in source_files
+            path.relative_to(CODE_ROOT).as_posix(): {"sha256": _sha256(path)} for path in source_files
         },
         "family_transport_kernel_status": kernel.get("status"),
         "family_transport_kernel_proof_status": kernel.get("proof_status"),

--- a/code/particles/flavor/verify_quark_flavor_source_closure.py
+++ b/code/particles/flavor/verify_quark_flavor_source_closure.py
@@ -408,7 +408,7 @@ def build_artifact(proof_bundle: Path | None = None) -> dict[str, Any]:
             "physical scale, and RG packet, nonconstant on the rescaling orbit"
         ),
         "dependency_files": {
-            str(path.relative_to(CODE_ROOT)): {"sha256": _sha256(path)}
+            path.relative_to(CODE_ROOT).as_posix(): {"sha256": _sha256(path)}
             for path in dependency_paths
         },
     }

--- a/code/particles/hadron/derive_ward_projected_spectral_measure_contract.py
+++ b/code/particles/hadron/derive_ward_projected_spectral_measure_contract.py
@@ -24,7 +24,7 @@ def build_artifact() -> dict[str, Any]:
         "artifact": "oph_ward_projected_spectral_measure_contract",
         "generated_utc": _now_utc(),
         "status": "constructive_contract_emitted_not_production_data",
-        "schema": str(SCHEMA.relative_to(ROOT)),
+        "schema": SCHEMA.relative_to(ROOT).as_posix(),
         "promotion_allowed": False,
         "current_local_scope": "closed_out_of_scope_computationally_blocked",
         "github_issues_closed_out_of_scope": [153, 157],

--- a/code/particles/hadron/derive_ward_projected_spectral_measure_obstruction.py
+++ b/code/particles/hadron/derive_ward_projected_spectral_measure_obstruction.py
@@ -39,9 +39,9 @@ def _now_utc() -> str:
 
 def _load_optional(path: Path) -> dict[str, Any]:
     if not path.exists():
-        return {"artifact_path": str(path.relative_to(ROOT)), "exists": False}
+        return {"artifact_path": path.relative_to(ROOT).as_posix(), "exists": False}
     payload = json.loads(path.read_text(encoding="utf-8"))
-    payload.setdefault("artifact_path", str(path.relative_to(ROOT)))
+    payload.setdefault("artifact_path", path.relative_to(ROOT).as_posix())
     payload.setdefault("exists", True)
     return payload
 
@@ -179,14 +179,14 @@ def build_obstruction(
         "source_only": True,
         "external_inputs_used": False,
         "inspected_artifacts": {
-            "schema": str(DEFAULT_SCHEMA.relative_to(ROOT)),
-            "contract": str(DEFAULT_CONTRACT.relative_to(ROOT)),
-            "full_unquenched": str(DEFAULT_FULL_UNQUENCHED.relative_to(ROOT)),
-            "rho_levels": str(DEFAULT_RHO_LEVELS.relative_to(ROOT)),
-            "rho_phase_shift": str(DEFAULT_RHO_PHASE_SHIFT.relative_to(ROOT)),
-            "stable_payload": str(DEFAULT_STABLE_PAYLOAD.relative_to(ROOT)),
-            "closure": str(DEFAULT_CLOSURE.relative_to(ROOT)),
-            "audit": str(DEFAULT_AUDIT.relative_to(ROOT)),
+            "schema": DEFAULT_SCHEMA.relative_to(ROOT).as_posix(),
+            "contract": DEFAULT_CONTRACT.relative_to(ROOT).as_posix(),
+            "full_unquenched": DEFAULT_FULL_UNQUENCHED.relative_to(ROOT).as_posix(),
+            "rho_levels": DEFAULT_RHO_LEVELS.relative_to(ROOT).as_posix(),
+            "rho_phase_shift": DEFAULT_RHO_PHASE_SHIFT.relative_to(ROOT).as_posix(),
+            "stable_payload": DEFAULT_STABLE_PAYLOAD.relative_to(ROOT).as_posix(),
+            "closure": DEFAULT_CLOSURE.relative_to(ROOT).as_posix(),
+            "audit": DEFAULT_AUDIT.relative_to(ROOT).as_posix(),
         },
         "schema_contract": {
             "required_artifact": (schema.get("properties") or {}).get("artifact", {}).get("const"),

--- a/code/particles/leptons/audit_charged_cfq_carrier_v1.py
+++ b/code/particles/leptons/audit_charged_cfq_carrier_v1.py
@@ -331,13 +331,13 @@ def build_review(archive_path: Path, canonical_cfq_path: Path) -> dict[str, Any]
         "public_prediction_promotion_allowed": False,
         "provenance": {
             "archive_path": (
-                str(archive_path.relative_to(WORKSPACE))
+                archive_path.relative_to(WORKSPACE).as_posix()
                 if archive_path.is_relative_to(WORKSPACE)
                 else archive_path.name
             ),
             "archive_sha256": sha256(archive_raw),
             "narrative_attachment_sha256": EXPECTED_NARRATIVE_SHA256,
-            "canonical_conditional_receipt": str(canonical_cfq_path.relative_to(REPO)),
+            "canonical_conditional_receipt": canonical_cfq_path.relative_to(REPO).as_posix(),
             "canonical_conditional_receipt_sha256": sha256(canonical_raw),
         },
         "archive": {

--- a/code/particles/leptons/audit_charged_face_incidence_theorem_bundle.py
+++ b/code/particles/leptons/audit_charged_face_incidence_theorem_bundle.py
@@ -134,7 +134,7 @@ def build_review(archive_path: Path, canonical_path: Path) -> dict[str, Any]:
         "runtime_dependency": {"mpmath": mp.__version__},
         "archive": {
             "path": (
-                str(archive_path.relative_to(WORKSPACE))
+                archive_path.relative_to(WORKSPACE).as_posix()
                 if archive_path.is_relative_to(WORKSPACE)
                 else archive_path.name
             ),
@@ -155,7 +155,7 @@ def build_review(archive_path: Path, canonical_path: Path) -> dict[str, Any]:
             ),
         },
         "canonical_conditional_receipt": {
-            "path": str(canonical_path.relative_to(REPO)),
+            "path": canonical_path.relative_to(REPO).as_posix(),
             "sha256": sha256(canonical_raw),
             "status": canonical["status"],
             "checks_pass": canonical["checks_pass"],

--- a/code/particles/leptons/audit_charged_icosahedral_completion_v1.py
+++ b/code/particles/leptons/audit_charged_icosahedral_completion_v1.py
@@ -274,7 +274,7 @@ def build_review(archive_path: Path) -> dict[str, Any]:
     tau_used_mev = 1000.0 * references[2]
     tau_candidate_mev = 1000.0 * candidate_masses[2]
     try:
-        archive_display_path = str(archive_path.relative_to(WORKSPACE))
+        archive_display_path = archive_path.relative_to(WORKSPACE).as_posix()
     except ValueError:
         archive_display_path = archive_path.name
 
@@ -314,11 +314,11 @@ def build_review(archive_path: Path) -> dict[str, Any]:
             ),
         },
         "upstream_receipts": {
-            str(PUBLIC_PIXEL.relative_to(REPO)): sha256(PUBLIC_PIXEL.read_bytes()),
-            str(SOURCE_PIXEL.relative_to(REPO)): sha256(SOURCE_PIXEL.read_bytes()),
-            str(D10_GAP.relative_to(REPO)): sha256(D10_GAP.read_bytes()),
-            str(KRAWCZYK.relative_to(REPO)): sha256(KRAWCZYK.read_bytes()),
-            str(LEGACY_D10_SOURCE.relative_to(REPO)): sha256(LEGACY_D10_SOURCE.read_bytes()),
+            PUBLIC_PIXEL.relative_to(REPO).as_posix(): sha256(PUBLIC_PIXEL.read_bytes()),
+            SOURCE_PIXEL.relative_to(REPO).as_posix(): sha256(SOURCE_PIXEL.read_bytes()),
+            D10_GAP.relative_to(REPO).as_posix(): sha256(D10_GAP.read_bytes()),
+            KRAWCZYK.relative_to(REPO).as_posix(): sha256(KRAWCZYK.read_bytes()),
+            LEGACY_D10_SOURCE.relative_to(REPO).as_posix(): sha256(LEGACY_D10_SOURCE.read_bytes()),
         },
         "three_coordinate_inverse_audit": {
             "coordinate_count": 3,

--- a/code/particles/leptons/audit_charged_nature_pole_theorem_v1.py
+++ b/code/particles/leptons/audit_charged_nature_pole_theorem_v1.py
@@ -336,13 +336,13 @@ def build_review(archive_path: Path, parent_review_path: Path = PARENT_REVIEW) -
         "public_prediction_promotion_allowed": False,
         "provenance": {
             "archive_path": (
-                str(archive_path.relative_to(WORKSPACE))
+                archive_path.relative_to(WORKSPACE).as_posix()
                 if archive_path.is_relative_to(WORKSPACE)
                 else archive_path.name
             ),
             "archive_sha256": sha256(archive_raw),
             "narrative_attachment_sha256": EXPECTED_NARRATIVE_SHA256,
-            "parent_candidate_review": str(parent_review_path.relative_to(REPO)),
+            "parent_candidate_review": parent_review_path.relative_to(REPO).as_posix(),
         },
         "archive": {
             "member_count": len(infos),

--- a/code/particles/leptons/audit_charged_source_law_rigidity_v1.py
+++ b/code/particles/leptons/audit_charged_source_law_rigidity_v1.py
@@ -255,7 +255,7 @@ def build_review(
         "runtime_dependency": {"mpmath": mp.__version__},
         "archive": {
             "path": (
-                str(archive_path.relative_to(WORKSPACE))
+                archive_path.relative_to(WORKSPACE).as_posix()
                 if archive_path.is_relative_to(WORKSPACE)
                 else archive_path.name
             ),
@@ -274,7 +274,7 @@ def build_review(
             ),
         },
         "canonical_conditional_receipt": {
-            "path": str(canonical_cfq_path.relative_to(REPO)),
+            "path": canonical_cfq_path.relative_to(REPO).as_posix(),
             "sha256": sha256(canonical_raw),
             "status": canonical["status"],
             "checks_pass": canonical["checks_pass"],

--- a/code/particles/leptons/derive_charged_cfq_central_record_model.py
+++ b/code/particles/leptons/derive_charged_cfq_central_record_model.py
@@ -206,7 +206,7 @@ def build_artifact(schema: dict[str, Any], schema_sha256: str) -> dict[str, Any]
         "mass_scheme_certified": False,
         "public_prediction_promotion_allowed": False,
         "provenance": {
-            "conditional_cfq_schema": str(CONDITIONAL_CFQ.relative_to(CODE_ROOT)),
+            "conditional_cfq_schema": CONDITIONAL_CFQ.relative_to(CODE_ROOT).as_posix(),
             "conditional_cfq_schema_sha256": schema_sha256,
             "submitted_carrier_archive_sha256": SUBMITTED_CARRIER_ARCHIVE_SHA256,
         },

--- a/code/particles/leptons/derive_charged_current_oph_moduli_independence.py
+++ b/code/particles/leptons/derive_charged_current_oph_moduli_independence.py
@@ -132,7 +132,7 @@ def _receipt_bindings() -> list[dict[str, Any]]:
         payload = json.loads(raw)
         bindings.append(
             {
-                "path": str(path.relative_to(ROOT)),
+                "path": path.relative_to(ROOT).as_posix(),
                 "sha256": hashlib.sha256(raw).hexdigest(),
                 "artifact": payload.get("artifact", payload.get("certificate_id")),
                 "status": payload.get("status", payload.get("proof_status")),

--- a/code/particles/leptons/derive_charged_koide_orientation_isometry.py
+++ b/code/particles/leptons/derive_charged_koide_orientation_isometry.py
@@ -329,12 +329,12 @@ def build_artifact(
         "checks_pass": checks_pass,
         "source_receipts": {
             "orientation_pair": {
-                "path": str(ORIENTATION_CERTIFICATE.relative_to(ROOT)),
+                "path": ORIENTATION_CERTIFICATE.relative_to(ROOT).as_posix(),
                 "sha256": sha256(ORIENTATION_CERTIFICATE),
                 "status": orientation.get("status"),
             },
             "geometric_C3_carrier": {
-                "path": str(FACE_CARRIER.relative_to(ROOT)),
+                "path": FACE_CARRIER.relative_to(ROOT).as_posix(),
                 "sha256": sha256(FACE_CARRIER),
                 "status": face.get("status"),
             },

--- a/code/particles/leptons/derive_charged_source_law_rigidity_conditional.py
+++ b/code/particles/leptons/derive_charged_source_law_rigidity_conditional.py
@@ -538,9 +538,9 @@ def build_artifact(
         "public_prediction_promotion_allowed": False,
         "runtime_dependency": {"mpmath": mp.__version__, "external_graph_library": None},
         "provenance": {
-            "geometric_face_receipt": str(FACE_RECEIPT.relative_to(CODE_ROOT)),
+            "geometric_face_receipt": FACE_RECEIPT.relative_to(CODE_ROOT).as_posix(),
             "geometric_face_receipt_sha256": face_receipt_sha256,
-            "declared_map_receipt": str(DECLARED_MAP_RECEIPT.relative_to(CODE_ROOT)),
+            "declared_map_receipt": DECLARED_MAP_RECEIPT.relative_to(CODE_ROOT).as_posix(),
             "declared_map_receipt_sha256": declared_map_receipt_sha256,
             "submitted_rigidity_archive_sha256": RIGIDITY_ARCHIVE_SHA256,
             "submitted_narrative_attachment_sha256": RIGIDITY_NARRATIVE_SHA256,

--- a/code/particles/neutrino/build_neutrino_precision_candidate_lock.py
+++ b/code/particles/neutrino/build_neutrino_precision_candidate_lock.py
@@ -75,7 +75,7 @@ def _sha256(path: pathlib.Path) -> str:
 
 
 def _relative(path: pathlib.Path) -> str:
-    return str(path.resolve().relative_to(ROOT.resolve()))
+    return path.resolve().relative_to(ROOT.resolve()).as_posix()
 
 
 def _artifact_node(node_id: str, path: pathlib.Path) -> dict[str, Any]:

--- a/code/particles/neutrino/derive_neutrino_exact_adapter_bridge_coordinate.py
+++ b/code/particles/neutrino/derive_neutrino_exact_adapter_bridge_coordinate.py
@@ -50,7 +50,7 @@ def _load_json(path: Path) -> dict[str, Any]:
 
 
 def _repo_ref(path: Path) -> str:
-    return str(path.relative_to(ROOT.parent))
+    return path.relative_to(ROOT.parent).as_posix()
 
 
 def build_payload(

--- a/code/particles/qcd/build_hadron_source_backend_receipts.py
+++ b/code/particles/qcd/build_hadron_source_backend_receipts.py
@@ -95,10 +95,10 @@ def sha256_text(text: str) -> str:
 
 def read_optional_json(path: Path) -> dict[str, Any]:
     if not path.is_file():
-        return {"exists": False, "path": str(path.relative_to(ROOT))}
+        return {"exists": False, "path": path.relative_to(ROOT).as_posix()}
     payload = json.loads(path.read_text(encoding="utf-8"))
     payload.setdefault("exists", True)
-    payload.setdefault("path", str(path.relative_to(ROOT)))
+    payload.setdefault("path", path.relative_to(ROOT).as_posix())
     return payload
 
 
@@ -301,7 +301,7 @@ def build_payloads(*, claim: str, tier: str, lambda_payload: dict[str, Any]) -> 
         },
         "controls/frozen_code_hashes.json": {
             "artifact": "frozen_code_hashes",
-            "builder": str(Path(__file__).relative_to(ROOT)),
+            "builder": Path(__file__).relative_to(ROOT).as_posix(),
             "builder_sha256": sha256_text(Path(__file__).read_text(encoding="utf-8")),
         },
         "controls/replay_receipts.json": {

--- a/code/particles/scripts/build_conditional_candidate_surface.py
+++ b/code/particles/scripts/build_conditional_candidate_surface.py
@@ -44,7 +44,7 @@ def _require(payload: dict[str, Any], key: str, context: str) -> Any:
 
 
 def _rel(path: pathlib.Path) -> str:
-    return str(path.relative_to(ROOT.parent))
+    return path.relative_to(ROOT.parent).as_posix()
 
 
 def build_gev_chart_candidates() -> list[dict[str, Any]]:

--- a/code/particles/scripts/build_derivation_gap_ledger.py
+++ b/code/particles/scripts/build_derivation_gap_ledger.py
@@ -53,14 +53,14 @@ def _now_utc() -> str:
 def _load_p_trunk_summary() -> dict[str, Any]:
     if not P_TRUNK.exists():
         return {
-            "artifact_path": str(P_TRUNK.relative_to(ROOT)),
+            "artifact_path": P_TRUNK.relative_to(ROOT).as_posix(),
             "exists": False,
             "claim_status": "not_emitted",
             "may_feed_live_particle_predictions": False,
         }
     payload = json.loads(P_TRUNK.read_text(encoding="utf-8"))
     return {
-        "artifact_path": str(P_TRUNK.relative_to(ROOT)),
+        "artifact_path": P_TRUNK.relative_to(ROOT).as_posix(),
         "exists": True,
         "claim_status": payload.get("claim_status"),
         "P": payload.get("fixed_point_candidate", {}).get("P"),
@@ -84,7 +84,7 @@ def _load_hierarchy_summary() -> dict[str, Any]:
     )
     if not all(path.exists() for path in required):
         return {
-            "artifact_path": str(HIERARCHY_ROOT.relative_to(ROOT)),
+            "artifact_path": HIERARCHY_ROOT.relative_to(ROOT).as_posix(),
             "exists": False,
             "claim_status": "not_emitted",
             "may_feed_local_hierarchy_claim": False,
@@ -100,7 +100,7 @@ def _load_hierarchy_summary() -> dict[str, Any]:
     source_audit = witness["source_audit_branch"]
     exact_capacity = ew_capacity["exact_capacity_fixed_point"]
     return {
-        "artifact_path": str(HIERARCHY_ROOT.relative_to(ROOT)),
+        "artifact_path": HIERARCHY_ROOT.relative_to(ROOT).as_posix(),
         "exists": True,
         "claim_status": "exact_conditional_local_global_hierarchy_and_closed_naturality_certificate",
         "may_feed_local_hierarchy_claim": False,
@@ -162,7 +162,7 @@ def _is_singleton_zero_interval(value: Any) -> bool:
 
 def _artifact_path(path: Path) -> str:
     try:
-        return str(path.relative_to(ROOT))
+        return path.relative_to(ROOT).as_posix()
     except ValueError:
         return str(path)
 

--- a/code/particles/scripts/build_exact_fit_surface.py
+++ b/code/particles/scripts/build_exact_fit_surface.py
@@ -53,7 +53,7 @@ def _load_optional_json(path: pathlib.Path) -> dict[str, Any] | None:
 
 
 def _repo_ref(path: pathlib.Path) -> str:
-    return str(path.relative_to(ROOT.parent))
+    return path.relative_to(ROOT.parent).as_posix()
 
 
 def _max_abs(values: list[float]) -> float:

--- a/code/particles/scripts/build_exact_nonhadron_mass_bundle.py
+++ b/code/particles/scripts/build_exact_nonhadron_mass_bundle.py
@@ -63,7 +63,7 @@ def _load_optional_json(path: pathlib.Path) -> dict[str, Any] | None:
 
 
 def _repo_ref(path: pathlib.Path) -> str:
-    return str(path.relative_to(ROOT.parent))
+    return path.relative_to(ROOT.parent).as_posix()
 
 
 def _carrier_summary(entry: dict[str, Any]) -> dict[str, Any]:

--- a/code/particles/scripts/build_final_end_to_end_predictions.py
+++ b/code/particles/scripts/build_final_end_to_end_predictions.py
@@ -86,7 +86,7 @@ def _load_optional_json(path: Path) -> dict[str, Any] | None:
 
 
 def _rel(path: Path) -> str:
-    return str(path.relative_to(ROOT))
+    return path.relative_to(ROOT).as_posix()
 
 
 def _display_status(status: str) -> str:
@@ -469,8 +469,8 @@ def build_payload() -> dict[str, Any]:
             "source_only_hadron_predictions_emitted": False,
             "empirical_hadron_closure_allowed_for_display": True,
             "policy_artifact": "docs/HADRON.md",
-            "source_registry": str(EMPIRICAL_EE_REGISTRY.relative_to(ROOT)),
-            "empirical_payload_schema": str(EMPIRICAL_EE_SCHEMA.relative_to(ROOT)),
+            "source_registry": EMPIRICAL_EE_REGISTRY.relative_to(ROOT).as_posix(),
+            "empirical_payload_schema": EMPIRICAL_EE_SCHEMA.relative_to(ROOT).as_posix(),
             "reason": (
                 "Source-only hadron outputs require a working OPH hadron backend. Empirical "
                 "hadron closure values stay in a separate output class; the e+e- spectral payload "

--- a/code/particles/scripts/build_particle_pipeline_closure_status.py
+++ b/code/particles/scripts/build_particle_pipeline_closure_status.py
@@ -72,7 +72,7 @@ def _now_utc() -> str:
 
 
 def _rel(path: Path) -> str:
-    return str(path.relative_to(ROOT))
+    return path.relative_to(ROOT).as_posix()
 
 
 def _load_json(path: Path) -> dict[str, Any] | None:

--- a/code/particles/scripts/build_source_only_mass_prediction_surface.py
+++ b/code/particles/scripts/build_source_only_mass_prediction_surface.py
@@ -571,7 +571,7 @@ def build() -> dict[str, Any]:
     ]
 
     input_receipts = {
-        key: {"path": str(path.relative_to(PARTICLES)), "exists": path.exists()}
+        key: {"path": path.relative_to(PARTICLES).as_posix(), "exists": path.exists()}
         for key, path in INPUTS.items()
     }
 

--- a/code/particles/scripts/validate_non_circularity_policy.py
+++ b/code/particles/scripts/validate_non_circularity_policy.py
@@ -225,7 +225,7 @@ def validate() -> dict[str, Any]:
         "artifact": "oph_particle_non_circularity_policy_validation",
         "pass": not failures,
         "failures": failures,
-        "checked_artifacts": {name: str(path.relative_to(ROOT)) for name, path in ARTIFACTS.items()},
+        "checked_artifacts": {name: path.relative_to(ROOT).as_posix() for name, path in ARTIFACTS.items()},
     }
 
 

--- a/code/particles/test_predictive_builders_reference_free.py
+++ b/code/particles/test_predictive_builders_reference_free.py
@@ -53,7 +53,7 @@ def _production_files() -> list[pathlib.Path]:
 
 
 def _relative(path: pathlib.Path) -> str:
-    return str(path.relative_to(ROOT / "particles"))
+    return path.relative_to(ROOT / "particles").as_posix()
 
 
 def _failures() -> list[str]:


### PR DESCRIPTION
## Problem

The scientific receipt suite verifies committed JSON artifacts by sha256/byte equality, and those artifacts use LF endings and `/` path separators. On Windows a clean clone fails these checks for two mechanical reasons that have nothing to do with the science:

1. **No `.gitattributes`.** With `core.autocrlf=true`, every text file checks out as CRLF, so `code/particles/hierarchy/validators/validate_manifest.py` reports `pass: false` with ~60 sha256 mismatches on a fresh clone, and the byte-reproducibility tests fail.
2. **OS-native path separators.** Several receipt generators serialized repo-relative paths with `str(Path.relative_to(...))`, which yields `\` on Windows versus the committed `/`.

## Fix (2 commits)

1. **`.gitattributes`** — `* text=auto eol=lf`, with a `-text` guard for the single file committed with CRLF (`code/dark_matter/data/external/SPARC_MassModels_Lelli2016c.mrt`, external data table). `git ls-files --eol` reports the index as 1866 LF / 1 CRLF / 45 binary, so this changes **no committed content**; it only stabilizes the working-tree checkout.
2. **`as_posix()` normalization** — 64 one-line swaps across 32 files, each `str(X.relative_to(...))` becomes `X.relative_to(...).as_posix()`. This matches the convention already used elsewhere in the repo (`code/particles/conftest.py`, the `uv/` scaffolds). On POSIX, `as_posix()` is byte-identical to `str()`, so there is **no golden-receipt change and no behavior change on Linux**.

## Verification (Windows 10, Python 3.12, fresh checkout)

- Before: `validate_manifest.py` pass=false (~60 sha mismatches); `test_hierarchy_bundle_validators_pass`, both `test_committed_receipt_is_byte_reproducible`, and `test_particle_builder_directories_have_no_undeclared_reference_consumers` all fail.
- After: manifest pass=true, 0 mismatches; those four checks pass.
- All 32 changed files compile (`py_compile`).

## Why this is safe on Linux

There is no Linux pytest CI to lean on, so the safety argument is byte-level, not "CI is green":

- `eol=lf` touches no committed blob (every text blob is already LF; the one CRLF file is guarded `-text`).
- `as_posix()` equals `str()` on POSIX, so every swapped line is a byte-level no-op on Linux. The whole `.py` diff is pure `str(X)` to `X.as_posix()` pairs: `git diff main -- '*.py' | grep '^[+-]' | grep -v as_posix` returns only file headers.

## Out of scope (honest residuals)

This PR fixes **clean-checkout** verification. It does not make a full `python -m pytest code` run green on Windows, which is separately blocked by:

- **Write-time EOL.** When the suite regenerates tracked receipts, text-mode writes emit CRLF on Windows, leaving the tree dirty and breaking in-run sha checks. A complete fix spans hundreds of writer sites and is left for a follow-up.
- **numpy/scipy version sensitivity.** Regenerated receipts differ at the last float ULP under different numpy/scipy builds (also the cause of the two `neutrino` adapter test failures). Pinning versions or widening tolerances is a maintainer decision, not touched here.
- **Missing external tree.** Two `test_runtime_surface_*` tests require the untracked sibling `../arXiv/RC1/ancillary/code/particles`, which a clean clone cannot provide.

## Related

- Addresses the clean-checkout byte-reproducibility item of #507 and the cross-platform leg of #553.
- Complementary to #555 (dependency declaration / collection health); disjoint files, either can merge first.
