### PR TITLE
Correct clean-clone requirements and reproduction scope

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,8 @@
 # Normalize committed text to LF in the working tree on every platform.
 # The scientific receipt suite verifies JSON artifacts by sha256/byte equality;
 # without this, a Windows checkout (core.autocrlf=true) gets CRLF and every
-# byte/hash check fails. Every committed text blob is already LF, so this only
-# stabilizes checkout and changes no committed content.
+# byte/hash check fails. Committed text blobs use LF in the index. This rule
+# stabilizes checkout without changing committed content.
 * text=auto eol=lf
 
 # External data table committed with CRLF; keep its exact bytes (never rewrite).

--- a/REPRODUCE.md
+++ b/REPRODUCE.md
@@ -1,13 +1,12 @@
 # Reproducing the mandatory scientific suite
 
-This is the single clean-clone path for the mandatory OPH scientific receipt
-suite. It does not prove any physics claim. It makes the existing machine
-receipts runnable and auditable from a fresh checkout, so a green claim
-registry is not mistaken for a green scientific reproduction.
+This is the clean-clone path for the mandatory OPH scientific receipt suite.
+It makes the machine receipts runnable and auditable from a fresh checkout.
+The gate checks reproducibility infrastructure and carries no physics claim.
 
 ## Environment
 
-- CPython 3.11 or newer (verified on 3.12).
+- CPython 3.12 or newer (verified on 3.12 and 3.13).
 - A clean virtual environment.
 
 ## Mandatory suite
@@ -21,9 +20,9 @@ python -m pytest --collect-only code
 ```
 
 `requirements.txt` pins the core dependencies. Two of them, `mpmath` and
-`sympy`, are imported across `code/` but were previously undeclared, so a fresh
-clone failed at pytest collection before any test ran. With them declared, the
-mandatory command above collects 918 tests and exits 0.
+`sympy`, are imported across `code/` and require explicit declarations. With
+them declared, the mandatory command above collects the repository test set
+and exits 0.
 
 ## Optional lanes (opt-in extras)
 
@@ -40,9 +39,9 @@ mandatory collection unless explicitly enabled:
 
 ## Scope
 
-This PR makes the mandatory suite **collectable** from a clean clone. The
-acceptance bar for this path is a green claim registry plus a clean
-`--collect-only` (zero import errors, 918 tests).
+The mandatory suite is **collectable** from a clean clone. The acceptance bar
+for this path is a green claim registry plus a clean `--collect-only` run with
+zero import errors.
 
 Full test execution (`python -m pytest code`) is **not** expected to be green
 from a clean clone, so it is not the documented gate here. Individual scientific

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Core dependencies for the mandatory scientific receipt suite (pytest.ini: testpaths = code).
 # Pinned and verified from a clean clone on CPython 3.12.
 #
-# mpmath and sympy are imported across code/ but were previously undeclared, so a
-# fresh clone could not collect the suite (see the clean-clone reproduction report).
+# mpmath and sympy are imported across code/ and require explicit declarations
+# for clean-clone collection (see the reproduction guide).
 #
 # Optional lanes keep their own extras and stay opt-in:
 #   code/ibm_quantum_cloud/requirements-ibm.txt   IBM / Qiskit hardware lane (OPH_RUN_IBM=1)


### PR DESCRIPTION
## Scope

- Corrects the documented interpreter floor to CPython 3.12, matching the pinned NumPy and SciPy metadata.
- Removes the hardcoded collection count from the permanent reproduction guide.
- States the collection gate and EOL policy without release-history language.

## Validation

- An isolated CPython 3.13 environment installed every pinned dependency.
- The claim registry passed with 28 claims and 15 owner papers.
- `python -m pytest --collect-only -q code` collected 853 tests with zero errors.
- A `core.autocrlf=true` checkout retained LF receipt files and the single protected CRLF data file.
- The hierarchy manifest validator passed in that checkout.
- Four targeted receipt and byte-reproducibility tests passed.
- All changed Python files compiled.
- `git diff --check` passed.
