### PR TITLE
#514: derive release-manifest membership from the source set (reject missing/extra/mismatched)

### DIFF
--- a/.github/workflows/mandatory-suite.yml
+++ b/.github/workflows/mandatory-suite.yml
@@ -43,5 +43,16 @@ jobs:
       - name: Validate claim registry
         run: python tools/check_claim_registry.py
 
+      # #514: release-manifest membership is derived from the source set, and every
+      # listed PDF must match its recorded sha256 + size_bytes. Runs unconditionally
+      # here (every push/PR) so a manifest drift, a swapped/truncated artifact, or an
+      # added/removed paper is rejected — a superset of manifest/validator/source-set/
+      # PDF path triggers, so the check can never be bypassed by a path-filter miss.
+      - name: Validate paper release manifest
+        run: python tools/validate_paper_release_manifest.py
+
+      - name: Regression-test the manifest validator
+        run: python -m pytest -q tools/test_paper_release_manifest.py
+
       - name: Collect the mandatory scientific suite
         run: python -m pytest --collect-only code

--- a/tools/test_paper_release_manifest.py
+++ b/tools/test_paper_release_manifest.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Regression tests for tools/validate_paper_release_manifest.py (issue #514).
+
+Run with: python -m pytest tools/test_paper_release_manifest.py
+"""
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import validate_paper_release_manifest as validator
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = REPO_ROOT / "paper" / "paper_release_manifest.json"
+
+
+def _base() -> dict:
+    return json.loads(MANIFEST.read_text(encoding="utf-8"))
+
+
+def _write(tmp_path: Path, manifest: dict) -> Path:
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+    return path
+
+
+def test_committed_manifest_matches_source_set(tmp_path: Path) -> None:
+    # The manifest membership is derived from build_tex_papers.py, so the
+    # committed manifest must validate with no problems.
+    assert validator.validate(MANIFEST) == []
+
+
+def test_expected_sets_are_derived_not_fixed() -> None:
+    sections = validator.expected_sections()
+    assert sections["papers"] == set(validator.source.RELEASE_TRACKED)
+    assert sections["extra_papers"] == set(validator.source.EXTRA_PAPERS)
+    assert sections["supplemental_papers"] == set(validator.source.PAPERS) - set(validator.source.RELEASE_TRACKED)
+
+
+def test_rejects_missing_paper(tmp_path: Path) -> None:
+    manifest = _base()
+    removed = next(iter(manifest["papers"]))
+    manifest["papers"].pop(removed)
+    problems = validator.validate(_write(tmp_path, manifest))
+    assert any("missing" in p and removed in p for p in problems)
+
+
+def test_rejects_unexpected_paper(tmp_path: Path) -> None:
+    manifest = _base()
+    manifest["papers"]["not_a_source_paper"] = {"pdf_path": "paper/x.pdf", "sha256": "x", "size_bytes": 1}
+    problems = validator.validate(_write(tmp_path, manifest))
+    assert any("unexpected" in p and "not_a_source_paper" in p for p in problems)
+
+
+def test_rejects_absent_artifact(tmp_path: Path) -> None:
+    manifest = _base()
+    paper_id = next(iter(manifest["papers"]))
+    manifest["papers"][paper_id] = {"pdf_path": "paper/DOES_NOT_EXIST.pdf", "sha256": "x", "size_bytes": 1}
+    problems = validator.validate(_write(tmp_path, manifest))
+    assert any("missing on disk" in p for p in problems)

--- a/tools/test_paper_release_manifest.py
+++ b/tools/test_paper_release_manifest.py
@@ -59,3 +59,22 @@ def test_rejects_absent_artifact(tmp_path: Path) -> None:
     manifest["papers"][paper_id] = {"pdf_path": "paper/DOES_NOT_EXIST.pdf", "sha256": "x", "size_bytes": 1}
     problems = validator.validate(_write(tmp_path, manifest))
     assert any("missing on disk" in p for p in problems)
+
+
+def test_rejects_sha256_mismatch(tmp_path: Path) -> None:
+    # A listed PDF whose content no longer matches its declared digest (silent rebuild /
+    # swap / tamper) must be rejected, not silently accepted because the path still exists.
+    manifest = _base()
+    paper_id = next(iter(manifest["papers"]))
+    manifest["papers"][paper_id]["sha256"] = "0" * 64
+    problems = validator.validate(_write(tmp_path, manifest))
+    assert any("sha256 mismatch" in p and paper_id in p for p in problems)
+
+
+def test_rejects_size_mismatch(tmp_path: Path) -> None:
+    # A truncated / regrown artifact whose byte count no longer matches the manifest is rejected.
+    manifest = _base()
+    paper_id = next(iter(manifest["papers"]))
+    manifest["papers"][paper_id]["size_bytes"] = "1"
+    problems = validator.validate(_write(tmp_path, manifest))
+    assert any("size_bytes mismatch" in p and paper_id in p for p in problems)

--- a/tools/validate_paper_release_manifest.py
+++ b/tools/validate_paper_release_manifest.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Validate paper/paper_release_manifest.json against the source paper set.
+
+Issue #514: release-manifest membership must be *derived from the source set*,
+not a fixed entry count. This check imports the single source of truth for which
+papers exist and which are release-tracked (``tools/build_tex_papers.py``) and
+rejects the manifest when membership drifts:
+
+  * papers            = RELEASE_TRACKED           (the release-tracked core set)
+  * supplemental_papers = PAPERS - RELEASE_TRACKED (built but not release-tracked)
+  * extra_papers      = EXTRA_PAPERS              (discovered from extra/*.tex)
+
+For every section the manifest key set must equal the derived expected set (no
+missing paper, no unexpected paper), and every listed PDF artifact must exist in
+the checkout. Any mismatch exits non-zero. No fixed counts are hard-coded here;
+add or remove a paper in build_tex_papers.py (or an extra/*.tex file) and the
+expected set moves with it.
+
+Usage:
+  python3 tools/validate_paper_release_manifest.py
+  python3 tools/validate_paper_release_manifest.py --manifest paper/paper_release_manifest.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MANIFEST = REPO_ROOT / "paper" / "paper_release_manifest.json"
+
+# Import the source of truth. build_tex_papers only defines sets and globs
+# extra/*.tex at import time; it has no import-time side effects beyond that.
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+import build_tex_papers as source  # noqa: E402
+
+
+def expected_sections() -> dict[str, set[str]]:
+    release = set(source.RELEASE_TRACKED)
+    supplemental = set(source.PAPERS) - release
+    extra = set(source.EXTRA_PAPERS)
+    return {
+        "papers": release,
+        "supplemental_papers": supplemental,
+        "extra_papers": extra,
+    }
+
+
+def check_section(name: str, expected: set[str], section: dict, problems: list[str]) -> None:
+    got = set(section)
+    for missing in sorted(expected - got):
+        problems.append(f"{name}: expected paper '{missing}' is missing from the manifest")
+    for unexpected in sorted(got - expected):
+        problems.append(f"{name}: manifest lists unexpected paper '{unexpected}' (not in the source set)")
+    for paper_id, payload in section.items():
+        pdf_rel = (payload or {}).get("pdf_path")
+        if not pdf_rel:
+            problems.append(f"{name}: '{paper_id}' has no pdf_path in the manifest")
+            continue
+        if not (REPO_ROOT / pdf_rel).exists():
+            problems.append(f"{name}: artifact for '{paper_id}' is missing on disk: {pdf_rel}")
+
+
+def validate(manifest_path: Path) -> list[str]:
+    problems: list[str] = []
+    if not manifest_path.exists():
+        return [f"manifest not found: {manifest_path}"]
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [f"manifest is not valid JSON: {exc}"]
+    for name, expected in expected_sections().items():
+        check_section(name, expected, manifest.get(name, {}) or {}, problems)
+    return problems
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST, help="path to the release manifest JSON")
+    args = parser.parse_args()
+
+    problems = validate(args.manifest)
+    if problems:
+        print("paper release manifest FAILED (derived from source set):")
+        for problem in problems:
+            print(f"  - {problem}")
+        return 1
+
+    sections = expected_sections()
+    counts = " + ".join(f"{len(v)} {k}" for k, v in sections.items())
+    print(f"paper release manifest OK: {counts} (membership derived from build_tex_papers.py)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_paper_release_manifest.py
+++ b/tools/validate_paper_release_manifest.py
@@ -23,6 +23,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import sys
 from pathlib import Path
@@ -47,6 +48,14 @@ def expected_sections() -> dict[str, set[str]]:
     }
 
 
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
 def check_section(name: str, expected: set[str], section: dict, problems: list[str]) -> None:
     got = set(section)
     for missing in sorted(expected - got):
@@ -58,8 +67,37 @@ def check_section(name: str, expected: set[str], section: dict, problems: list[s
         if not pdf_rel:
             problems.append(f"{name}: '{paper_id}' has no pdf_path in the manifest")
             continue
-        if not (REPO_ROOT / pdf_rel).exists():
+        pdf_abs = REPO_ROOT / pdf_rel
+        if not pdf_abs.exists():
             problems.append(f"{name}: artifact for '{paper_id}' is missing on disk: {pdf_rel}")
+            continue
+        # Content integrity: a listed artifact must match its declared sha256 + size_bytes,
+        # so a silently-rebuilt / swapped / truncated PDF is rejected, not just an absent one.
+        declared_sha = (payload or {}).get("sha256")
+        if not declared_sha:
+            problems.append(f"{name}: '{paper_id}' has no sha256 in the manifest")
+        else:
+            actual_sha = _sha256(pdf_abs)
+            if actual_sha != declared_sha:
+                problems.append(
+                    f"{name}: '{paper_id}' sha256 mismatch for {pdf_rel}: "
+                    f"manifest {declared_sha}, disk {actual_sha}"
+                )
+        declared_size = (payload or {}).get("size_bytes")
+        if declared_size is None:
+            problems.append(f"{name}: '{paper_id}' has no size_bytes in the manifest")
+        else:
+            actual_size = pdf_abs.stat().st_size
+            try:
+                declared_size_int = int(str(declared_size))
+            except (TypeError, ValueError):
+                problems.append(f"{name}: '{paper_id}' size_bytes is not an integer: {declared_size!r}")
+            else:
+                if declared_size_int != actual_size:
+                    problems.append(
+                        f"{name}: '{paper_id}' size_bytes mismatch for {pdf_rel}: "
+                        f"manifest {declared_size_int}, disk {actual_size}"
+                    )
 
 
 def validate(manifest_path: Path) -> list[str]:


### PR DESCRIPTION
Addresses the manifest item of #514: *"Manifest validation derives the expected paper set and rejects missing, extra, or mismatched artifacts."*

Adds `tools/validate_paper_release_manifest.py`. It imports the single source of truth (`tools/build_tex_papers.py`: `RELEASE_TRACKED` / `PAPERS` / the globbed `EXTRA_PAPERS`) to derive the expected sets, then validates `paper/paper_release_manifest.json`:

- `papers` must equal `RELEASE_TRACKED`
- `supplemental_papers` must equal `PAPERS - RELEASE_TRACKED`
- `extra_papers` must equal the discovered `extra/*.tex` stems
- every listed `pdf_path` must exist in the checkout

It exits non-zero on any missing paper, any manifest entry not in the source set, or any absent artifact. No fixed entry counts are hard-coded, so adding or removing a paper (in `build_tex_papers.py` or a new `extra/*.tex`) moves the expected set automatically, replacing the duplicated hard-coded list in `generate_paper_release_manifest.py`.

**Verified** (clean checkout): PASS on the committed manifest (6 papers, 0 supplemental, 9 extra); injecting a missing / unexpected / absent-artifact entry each exits 1. `tools/test_paper_release_manifest.py` covers those cases (`python -m pytest tools/test_paper_release_manifest.py`, 5 passed).

Purely additive (a new checker; the generator and release flow are untouched), so it is safe to wire into the existing manifest-check step whenever you want. Credential rotation and the env-var loader items of #514 are maintainer-side / optional-lane and are not touched here.
