### PR TITLE
#507: CI workflow running the mandatory suite from a clean checkout (ubuntu + windows)

### DIFF
--- a/.github/workflows/mandatory-suite.yml
+++ b/.github/workflows/mandatory-suite.yml
@@ -1,0 +1,47 @@
+name: Mandatory Suite
+
+# Closes the last open acceptance item of #507: "CI runs the same command from a
+# clean checkout." This workflow runs the documented mandatory command from
+# REPRODUCE.md on a fresh runner (setup-python provides the clean isolated
+# environment the guide gets from a venv), so the reproducibility infrastructure
+# from #555 / #581 / #584 is regression-guarded on every push and PR.
+#
+# Scope: this gate checks reproducibility infrastructure only and carries no
+# physics claim. It runs `--collect-only`, the documented green mandatory command;
+# a clean collection also proves the optional hardware/cloud lanes (IBM/Qiskit,
+# CAMB, legacy D10) stay opt-in and fail closed without their credentials, since
+# an accidentally-collected optional test would break the import and fail this job.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  mandatory:
+    name: mandatory collection (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install pinned dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Validate claim registry
+        run: python tools/check_claim_registry.py
+
+      - name: Collect the mandatory scientific suite
+        run: python -m pytest --collect-only code


### PR DESCRIPTION
Closes the last open acceptance item of #507.

The clean-checkout infrastructure from #555 / #581 / #584 is merged and the mandatory command in `REPRODUCE.md` collects green, but the remaining acceptance box was **"CI runs the same command from a clean checkout"** (your note on #507: *"No CI workflow covers the mandatory suite"*).

## What this adds
`.github/workflows/mandatory-suite.yml`, which runs the documented mandatory command from `REPRODUCE.md` on a fresh runner:

```
pip install -r requirements.txt
python tools/check_claim_registry.py
python -m pytest --collect-only code
```

- Matrix over `ubuntu-latest` and `windows-latest` (Python 3.12). The Windows leg regression-guards the cross-platform path fix from #581.
- `setup-python` provides the clean isolated environment the guide gets from a venv.
- Triggers on push to main, all PRs, and manual dispatch.

## Scope / honesty
Reproducibility infrastructure gate only, no physics claim (matches the `REPRODUCE.md` framing). It runs `--collect-only`, the documented green mandatory command, not the full suite (which needs the opt-in IBM/CAMB/legacy lanes). A clean collection also demonstrates those optional lanes stay opt-in and fail closed, since an accidentally-collected optional test would break the import and fail the job (exactly the original #507 failing condition).

Verified locally on Windows before pushing: `check_claim_registry.py` exit 0 (29 claims, 16 owner papers), `pytest --collect-only code` exit 0 (867 tests collected).
