### PR TITLE
#568: machine-checked orbit/stabilizer/faithfulness receipts for the A5 vertex action

### DIFF
--- a/Lean/ObserverPatchHolography/Source/ObserverPatchHolography.lean
+++ b/Lean/ObserverPatchHolography/Source/ObserverPatchHolography.lean
@@ -14,6 +14,7 @@ import ObserverPatchHolography.CollarStatesBridge
 import ObservableNormalForms
 import ObserverPatchHolography.Bridges.ObservableNormalForms
 import ObserverPatchHolography.IcosahedralAntibridge
+import ObserverPatchHolography.IcosahedralOrbitStabilizer
 import EventAlgebra
 
 /-!

--- a/Lean/ObserverPatchHolography/Source/ObserverPatchHolography/IcosahedralOrbitStabilizer.lean
+++ b/Lean/ObserverPatchHolography/Source/ObserverPatchHolography/IcosahedralOrbitStabilizer.lean
@@ -1,0 +1,82 @@
+import ObserverPatchHolography.IcosahedralAntibridge
+import Mathlib.GroupTheory.SpecificGroups.Alternating
+import Mathlib.GroupTheory.GroupAction.Quotient
+
+/-!
+# Icosahedral orbit–stabilizer receipts for the `A5` vertex action
+
+Companion to `IcosahedralAntibridge`.  That file builds the concrete
+transitive `A5`-action on the twelve-point homogeneous space
+`DefectSpace = A5 ⧸ H5` and proves the anti-bridge no-go.  This file adds
+the finite **orbit / stabilizer / faithfulness** computations that the
+`A5` formalization lane requires
+(`FloatingPragma/observer-patch-holography#568`, acceptance item
+"finite orbit, stabilizer, character, rank, and kernel computations are
+checked by the prover"):
+
+* `stabilizer_coe_one_eq_H5` — the stabilizer of the base vertex `⟦1⟧`
+  is exactly `H5` (so vertex stabilizers are the order-5 rotation
+  subgroups), and `card_stabilizer_coe_one = 5`.
+* `orbit_stabilizer_defectSpace` — the orbit–stabilizer identity on the
+  twelve vertices: `|A5| = 12 * 5`, i.e. `60 = 12 * 5`.
+* `defectSpace_action_faithful` — the kernel of the action is trivial
+  (`H5.normalCore = ⊥`), because `A5` is simple and `H5` is a proper
+  subgroup.  This is the "kernel computation" the lane asks for.
+
+Claim discipline: these are finite facts about the abstract icosahedral
+model `A5 ⧸ H5`.  They do not by themselves establish any physical
+current, compact Lie-algebra classification, cover, or matter claim; the
+`#568` lane keeps those as explicit theorem boundaries and open items.
+-/
+
+namespace OPH
+
+open MulAction
+
+/-- The stabilizer of the base vertex `⟦1⟧ : A5 ⧸ H5` is exactly `H5`.
+    Physically: the vertex stabilizers are the order-5 rotation
+    subgroups. -/
+theorem stabilizer_coe_one_eq_H5 :
+    stabilizer A5 ((1 : A5) : DefectSpace) = H5 := by
+  simp [stabilizer_quotient]
+
+/-- The base vertex stabilizer has order 5. -/
+theorem card_stabilizer_coe_one :
+    Nat.card (stabilizer A5 ((1 : A5) : DefectSpace)) = 5 := by
+  rw [stabilizer_coe_one_eq_H5, card_H5]
+
+/-- **Orbit–stabilizer on the twelve vertices.**  The order of `A5`
+    factors as `(number of vertices) * (order of a vertex stabilizer)`:
+    `60 = 12 * 5`.  Uses transitivity (orbit `= univ`, size 12) and the
+    order-5 vertex stabilizer. -/
+theorem orbit_stabilizer_defectSpace :
+    Nat.card A5 = Nat.card DefectSpace * Nat.card (stabilizer A5 ((1 : A5) : DefectSpace)) := by
+  rw [card_defectSpace, card_stabilizer_coe_one, nat_card_A5]
+
+/-- **The vertex action is faithful.**  The kernel of the `A5`-action on
+    the twelve vertices is the normal core of `H5`, which is trivial
+    because `A5` is simple and `H5 ≠ ⊤`.  Hence `A5` embeds into the
+    permutations of the twelve icosahedral vertices. -/
+theorem defectSpace_action_faithful : H5.normalCore = ⊥ := by
+  rcases (IsSimpleGroup.eq_bot_or_eq_top_of_normal (H5.normalCore)
+      (Subgroup.normalCore_normal H5)) with h | h
+  · exact h
+  · exfalso
+    have hle : H5.normalCore ≤ H5 := Subgroup.normalCore_le H5
+    rw [h, top_le_iff] at hle
+    have h60 : Nat.card H5 = 60 := by
+      rw [hle]; simpa using (Subgroup.card_top (G := A5)).trans nat_card_A5
+    rw [card_H5] at h60
+    omega
+
+/-! ## Axiom audit
+
+Expected footprint for every entry: `[propext, Classical.choice,
+Quot.sound]`.  No `sorry`, no `native_decide`, no extra axioms. -/
+
+#print axioms stabilizer_coe_one_eq_H5
+#print axioms card_stabilizer_coe_one
+#print axioms orbit_stabilizer_defectSpace
+#print axioms defectSpace_action_faithful
+
+end OPH


### PR DESCRIPTION
Addresses part of #568 (A5 formalization lane), specifically the acceptance item "finite orbit, stabilizer, character, rank, and kernel computations are checked by the prover."

## What this adds

A new file `IcosahedralOrbitStabilizer.lean` that builds on the existing `IcosahedralAntibridge.lean` (reusing its `A5`, `H5`, and `DefectSpace = A5 ⧸ H5` with `card_defectSpace = 12`) and machine-checks:

- `stabilizer_coe_one_eq_H5` — the stabilizer of the base vertex `⟦1⟧` is exactly `H5`, so vertex stabilizers are the order-5 rotation subgroups.
- `card_stabilizer_coe_one` — that stabilizer has order 5.
- `orbit_stabilizer_defectSpace` — the orbit-stabilizer identity on the twelve vertices, stated over the actual cardinalities: `Nat.card A5 = Nat.card DefectSpace * Nat.card (stabilizer ...)`, i.e. `60 = 12 * 5`.
- `defectSpace_action_faithful` — the kernel of the action (`H5.normalCore`) is trivial, because `A5` is simple and `H5` is a proper subgroup. Hence `A5` embeds into the permutations of the twelve vertices (the "kernel computation").

The umbrella module `ObserverPatchHolography.lean` imports the new file.

## Verification

- `lake build` passes clean on the full project (8284 jobs) with the pinned toolchain (`leanprover/lean4:v4.29.1`, mathlib `v4.29.1`).
- No `sorry`, `admit`, or `native_decide`. Every theorem's `#print axioms` footprint is exactly `[propext, Classical.choice, Quot.sound]`; the audit block is in the file.

## Scope boundary (honest)

This is a partial of #568. It covers the orbit / stabilizer / kernel computations on the concrete `A5 ⧸ H5` vertex model. It does not yet cover the other required objects: the twelve coefficient units and inverse pairing, the six axes and port frame, the equivariant-endomorphism commutant decomposition, the compact Lie-algebra classification, or the trace-balanced cover and its kernel. Those stay open, on purpose. I kept to what the prover checks today rather than add definitions that would move a physical hypothesis behind the type checker.

Natural next objects in the same file style: the antipodal inverse-pairing and the six axes via the order-10 normalizer `N(H5)`, then the commutant decomposition. I can take those next if this framing and file placement work for you.
