### PR TITLE
Refresh the matter-lift negative-control manifest pin

### DIFF
--- a/code/a5_closure/negative_controls/issue_314_negative_controls.json
+++ b/code/a5_closure/negative_controls/issue_314_negative_controls.json
@@ -117,6 +117,6 @@
     }
   ],
   "issue": 314,
-  "manifest_sha256": "aa7a5ff9df31f937ce9dbb9627e9321d5b832afa7d9f159f5162c17e3bfc6ecb",
+  "manifest_sha256": "9cb35bf57e01de287023d307b9d481740709477801e45fc44bbbccb93b3a1e21",
   "schema": "oph.super_tannakian_matter_negative_controls.v2"
 }


### PR DESCRIPTION
Follow-up to #601 after its merge raced the final Windows CI result.

The claim-boundary correction changed the source-manifest description and therefore its deterministic SHA-256. The receipt was regenerated in #601, but the committed negative-control bundle still carried the previous manifest hash. Windows correctly caught that exact mismatch; the other 28 matter-lift tests passed.

This updates only `manifest_sha256` in the stored negative-control bundle to the hash already recorded by the regenerated receipt. No verifier, theorem, or claim-boundary logic changes.
