### PR TITLE
Prove an abstract rate no-go and locate why it does not reach OPH

### DIFF
--- a/Lean/ObserverPatchHolography.lean
+++ b/Lean/ObserverPatchHolography.lean
@@ -39,6 +39,7 @@ import ObserverPatchHolography.RepairWordSchedule
 import ObserverPatchHolography.A2EndpointCommutator
 import ObserverPatchHolography.DirectedSeamRepair
 import ObserverPatchHolography.DirectedSeamRepairProgress
+import ObserverPatchHolography.RateNonidentifiability
 
 /-!
 # Observer-Patch Holography : Lean 4 umbrella root

--- a/Lean/ObserverPatchHolography.lean
+++ b/Lean/ObserverPatchHolography.lean
@@ -40,6 +40,7 @@ import ObserverPatchHolography.A2EndpointCommutator
 import ObserverPatchHolography.DirectedSeamRepair
 import ObserverPatchHolography.DirectedSeamRepairProgress
 import ObserverPatchHolography.RateNonidentifiability
+import ObserverPatchHolography.RateBridgeObstruction
 
 /-!
 # Observer-Patch Holography : Lean 4 umbrella root

--- a/Lean/ObserverPatchHolography/RateBridgeObstruction.lean
+++ b/Lean/ObserverPatchHolography/RateBridgeObstruction.lean
@@ -1,0 +1,345 @@
+import Mathlib
+import ObserverPatchHolography.Primitives
+import ObserverPatchHolography.RateNonidentifiability
+
+/-!
+# The rate no-go does not reach the OPH repair layer: a located obstruction
+
+`ObserverPatchHolography.RateNonidentifiability` proves an abstract non-identifiability
+result: for a deterministic map `T : S → S`, a stutter extension leaves the declared
+reading (locked set, accepted-repair reachability, basin) fixed while multiplying the
+first-locking count by an arbitrary factor. This file asks the only question that makes
+that result repository-facing — **does it instantiate at the repository's own observable
+map and accepted-repair relation?** — and answers **no**, with the failure located at a
+single hypothesis.
+
+## The attempted bridge
+
+The repository's own definitions, all in `ObserverPatchHolography.Primitives`:
+
+* the carrier `OPHCarrier` and the state type `Records C` (`Primitives.lean:107`, `147`);
+* the declared observable map `obsMap C : Records C → Obs C` (`Primitives.lean:157`);
+* the accepted asynchronous repair relation `acceptedStep C` (`Primitives.lean:446`);
+* the single-site move `localRepair C` it is built from (`Primitives.lean:315`).
+
+These are the definitions the repository's own results use: `acceptedStep` carries
+`NormalForm`, `Confluence`, `Completeness`, `LyapunovDescent` and `Termination`
+(`Primitives.lean:456`–`499`), and `obsMap` carries `gaugeEquiv` and
+`repair_respects_gauge` (`Primitives.lean:506`, `564`). Nothing here is invented for
+this file.
+
+## The obstruction, in one line
+
+The abstract construction needs an accepted step that **moves the state while leaving the
+declared observable fixed**. The stutter extension has exactly such steps, and
+`RateNonidentifiability.stutter_has_projection_fixing_step` says so openly. The
+repository's `acceptedStep C` provably has **none**: `acceptedStep_changes_obs`.
+
+The reason is a chain of in-tree facts, none of them new:
+
+1. `brokenSet` is defined from `C.dist e (C.projSrc e (x (C.src e))) (C.projTgt e (x (C.tgt e)))`
+   (`Primitives.lean:194`), which is exactly the pair `obsMap C x e`. So the broken-edge
+   count is a function of the declared observable alone (`mismatchCount_congr`).
+2. Every accepted step strictly lowers that count — the in-tree Lyapunov descent
+   `mismatchCount_localRepair_lt` (`Primitives.lean:397`).
+3. Hence every accepted step strictly changes the declared observable.
+
+So the extension the abstract theorem builds cannot be an OPH repair dynamics: an
+observably-idle accepted step is not merely absent from the construction, it is
+impossible in the repository's model.
+
+## What holds instead: the observable *bounds* the rate, and in fact fixes it
+
+The obstruction is not a gap that better plumbing would close. The concrete layer
+satisfies the **opposite** of what the abstract no-go concludes:
+
+* `firstLock_le_mismatchCount` — the number of accepted repair steps to first locking is
+  at most `mismatchCount x`, a quantity determined by `obsMap C x` alone. The declared
+  observable therefore *bounds* the relaxation time. The abstract theorem's family of
+  arbitrarily slow systems with one reading has no counterpart here.
+* `firstLock_obs_determined` — two records with equal declared observable data have equal
+  first-locking counts. The count is a *function of the declared observable*, which is
+  precisely the functional the abstract `no_rate_functional` refutes for its own weaker
+  reading.
+
+## Why this is not a contradiction
+
+The abstract `DeclaredReading` (`RateNonidentifiability.lean:364`) is a triple of
+relations on the state space. The repository's `obsMap` is a *per-state* observable and is
+strictly finer: `obsMap` distinguishes records that the abstract reading cannot separate.
+The abstract theorem is true of its own reading, and remains so. What is established here
+is that it does **not** transfer to `obsMap`, and that transferring it is not merely
+unproved but impossible, because `obsMap` already determines the rate.
+
+## Scope
+
+Everything below concerns sense (2) of "speed" in `RateNonidentifiability`'s header —
+relaxation time as a count of accepted repair steps. Nothing here is a physical duration,
+a clock map, a spectral gap, or a control-parameter law, and no OPH physics claim is
+endorsed.
+
+The one-step scheduler `stepOnce` introduced below is *not* a new dynamics: it is the body
+of the in-tree `Repair` recursion (`Primitives.lean:423`–`426`) stopped after a single
+firing. `stepOnce_acceptedStep` proves every move it makes is an `acceptedStep C`, and
+`locked_stepOnce_iff_normalForm` proves its fixed points are exactly the in-tree
+`NormalForm C`. It is needed only because `FirstLock` counts iterations of a function
+while `acceptedStep` is a relation; see the discussion at `stepOnce`.
+-/
+
+open Function Relation OPH.AbstractRewriting OPH.RateNonidentifiability
+
+namespace OPH.RateBridgeObstruction
+
+variable {C : OPHCarrier}
+
+/-! ## Step 1: the declared observable determines the broken-edge count -/
+
+/-- The broken-edge set is a function of the declared observable data alone. `brokenSet`
+tests `C.dist e` on exactly the two components of `obsMap C x e`, so records with equal
+observable data break on the same edges. -/
+theorem brokenSet_congr {x y : Records C} (h : obsMap C x = obsMap C y) :
+    brokenSet x = brokenSet y := by
+  ext e
+  rw [mem_brokenSet_iff_not_consistent, mem_brokenSet_iff_not_consistent]
+  exact not_congr (edgeConsistentAt_congr h e)
+
+/-- The mismatch count is a function of the declared observable data alone. -/
+theorem mismatchCount_congr {x y : Records C} (h : obsMap C x = obsMap C y) :
+    mismatchCount x = mismatchCount y :=
+  congrArg Finset.card (brokenSet_congr h)
+
+/-! ## Step 2: the obstruction
+
+The abstract stutter construction requires an accepted step that leaves the declared
+projection fixed. The repository's accepted step relation admits none. -/
+
+/-- **THE OBSTRUCTION.** Every accepted asynchronous repair step strictly changes the
+declared observable data. Combining the in-tree Lyapunov descent
+`mismatchCount_localRepair_lt` with `mismatchCount_congr`: a step that left `obsMap`
+fixed would leave `mismatchCount` fixed, and no accepted step does. -/
+theorem acceptedStep_changes_obs {x y : Records C} (h : acceptedStep C x y) :
+    obsMap C x ≠ obsMap C y := by
+  obtain ⟨i, rfl, hfire⟩ := h
+  intro hobs
+  have h1 : mismatchCount x = mismatchCount (localRepair C i x) := mismatchCount_congr hobs
+  have h2 : mismatchCount (localRepair C i x) < mismatchCount x :=
+    mismatchCount_localRepair_lt C i x hfire
+  omega
+
+/-- The same fact stated as the hypothesis that fails. `stutterStep` has reachable steps
+that move an unlocked state while fixing the declared projection
+(`RateNonidentifiability.stutter_has_projection_fixing_step`); `acceptedStep C` has no such
+step, so no stutter extension of the repository's repair dynamics exists. -/
+theorem no_observably_idle_acceptedStep (x y : Records C) :
+    ¬ (acceptedStep C x y ∧ obsMap C x = obsMap C y) :=
+  fun h => acceptedStep_changes_obs h.1 h.2
+
+/-- **The obstruction is not an artefact of the one constructed operator.** It holds for
+the hypothesis-bearing relation `acceptedStepLR` that carries the repository's main
+dynamics theorems (`Primitives.termination`, `completeness`, `confluence_of_commute`), for
+*every* local move satisfying the declared laws H1–H3. The engine is the in-tree
+`mismatchCount_lt` (`Primitives.lean:905`). Any OPH repair dynamics obeying the declared
+local laws therefore fails the abstract construction's key hypothesis. -/
+theorem acceptedStepLR_changes_obs (lr : C.Patch → Records C → Records C)
+    (H1 : ∀ (i : C.Patch) (x : Records C) (j : C.Patch), j ≠ i → lr i x j = x j)
+    (H2 : ∀ (i : C.Patch) (x : Records C),
+      lr i x ≠ x ↔ ∃ e : C.Edge, (C.src e = i ∨ C.tgt e = i) ∧ ¬ edgeConsistentAt e x)
+    (H3 : ∀ (i : C.Patch) (x : Records C), lr i x ≠ x →
+      ∀ e : C.Edge, (C.src e = i ∨ C.tgt e = i) → edgeConsistentAt e (lr i x))
+    {x y : Records C} (h : acceptedStepLR lr x y) :
+    obsMap C x ≠ obsMap C y := by
+  intro hobs
+  have h1 : mismatchCount x = mismatchCount y := mismatchCount_congr hobs
+  have h2 : mismatchCount y < mismatchCount x := mismatchCount_lt lr H1 H2 H3 h
+  omega
+
+/-! ## Step 3: a one-step scheduler, so that `FirstLock` has something to count
+
+`FirstLock` counts iterations of a *function*; `acceptedStep C` is a *relation*,
+nondeterministic in the firing site. The in-tree `Repair C` is not usable either: it runs
+the schedule to a normal form in one application, so it locks after at most one step from
+anywhere and carries no rate.
+
+`stepOnce` is the in-tree `Repair` recursion body (`Primitives.lean:423`–`426`) stopped
+after a single firing: it fires the same choice-canonical site `Repair` would fire, once.
+Its faithfulness is discharged, not assumed — `stepOnce_acceptedStep` (every move is an
+`acceptedStep C`) and `locked_stepOnce_iff_normalForm` (its fixed points are exactly the
+in-tree `NormalForm C`). -/
+
+open Classical in
+/-- One firing of the choice-canonical site: the body of `Repair`'s recursion, run once. -/
+noncomputable def stepOnce (C : OPHCarrier) (x : Records C) : Records C :=
+  if h : ∃ i : Site C, localRepair C i x ≠ x then
+    localRepair C (Classical.choose h) x
+  else x
+
+theorem stepOnce_of_fire (C : OPHCarrier) (x : Records C)
+    (h : ∃ i : Site C, localRepair C i x ≠ x) :
+    stepOnce C x = localRepair C (Classical.choose h) x :=
+  dif_pos h
+
+theorem stepOnce_of_normal (C : OPHCarrier) (x : Records C)
+    (h : ¬ ∃ i : Site C, localRepair C i x ≠ x) :
+    stepOnce C x = x :=
+  dif_neg h
+
+/-- `stepOnce` moves exactly when some site fires. -/
+theorem stepOnce_ne_iff (C : OPHCarrier) (x : Records C) :
+    stepOnce C x ≠ x ↔ ∃ i : Site C, localRepair C i x ≠ x := by
+  constructor
+  · intro hne
+    by_contra hcon
+    exact hne (stepOnce_of_normal C x hcon)
+  · intro h
+    rw [stepOnce_of_fire C x h]
+    exact Classical.choose_spec h
+
+/-- **Faithfulness, half one.** Every move `stepOnce` makes is a genuine accepted
+asynchronous repair step of the repository's own relation. -/
+theorem stepOnce_acceptedStep (C : OPHCarrier) (x : Records C) (hx : stepOnce C x ≠ x) :
+    acceptedStep C x (stepOnce C x) := by
+  have h : ∃ i : Site C, localRepair C i x ≠ x := (stepOnce_ne_iff C x).1 hx
+  exact ⟨Classical.choose h, stepOnce_of_fire C x h, Classical.choose_spec h⟩
+
+/-- **Faithfulness, half two.** The locked states of `stepOnce` are exactly the in-tree
+`NormalForm C` — the states from which no accepted repair step applies. -/
+theorem locked_stepOnce_iff_normalForm (C : OPHCarrier) (x : Records C) :
+    Locked (stepOnce C) x ↔ NormalForm C x := by
+  constructor
+  · intro hlock y hstep
+    obtain ⟨i, _, hfire⟩ := hstep
+    exact (stepOnce_ne_iff C x).2 ⟨i, hfire⟩ hlock
+  · intro hnf
+    by_contra hne
+    exact hnf _ (stepOnce_acceptedStep C x hne)
+
+/-- Every `stepOnce` move strictly lowers the mismatch count: the in-tree descent lemma,
+transported along `stepOnce`. -/
+theorem mismatchCount_stepOnce_lt (C : OPHCarrier) {x : Records C}
+    (hx : ¬ Locked (stepOnce C) x) :
+    mismatchCount (stepOnce C x) < mismatchCount x := by
+  have h : ∃ i : Site C, localRepair C i x ≠ x := (stepOnce_ne_iff C x).1 hx
+  rw [stepOnce_of_fire C x h]
+  exact mismatchCount_localRepair_lt C (Classical.choose h) x (Classical.choose_spec h)
+
+/-- `stepOnce` terminates, through the in-tree descent lemma of the abstract layer. -/
+theorem stepOnce_terminating (C : OPHCarrier) : Terminating (stepRel (stepOnce C)) :=
+  descent_terminating (stepOnce C) mismatchCount fun x hne =>
+    mismatchCount_stepOnce_lt C (x := x) hne
+
+/-! ## Step 4: the declared observable bounds the relaxation time -/
+
+/-- Each unlocked iterate consumes at least one unit of the mismatch count. -/
+theorem mismatchCount_iterate_add_le (C : OPHCarrier) (x : Records C) :
+    ∀ k : ℕ, (∀ j < k, ¬ Locked (stepOnce C) ((stepOnce C)^[j] x)) →
+      mismatchCount ((stepOnce C)^[k] x) + k ≤ mismatchCount x := by
+  intro k
+  induction k with
+  | zero => intro _; simp
+  | succ k ih =>
+      intro hpre
+      have hk : ¬ Locked (stepOnce C) ((stepOnce C)^[k] x) := hpre k (Nat.lt_succ_self k)
+      have hstep : mismatchCount (stepOnce C ((stepOnce C)^[k] x))
+          < mismatchCount ((stepOnce C)^[k] x) := mismatchCount_stepOnce_lt C hk
+      have hih := ih fun j hj => hpre j (by omega)
+      rw [Function.iterate_succ_apply']
+      omega
+
+/-- **The declared observable bounds the rate.** The number of accepted repair steps to
+first locking is at most `mismatchCount x`, and `mismatchCount` is a function of
+`obsMap C x` alone (`mismatchCount_congr`). There is therefore no family of
+observably-identical OPH repair systems with unboundedly different relaxation times —
+which is exactly what the abstract stutter construction produces for its own reading. -/
+theorem firstLock_le_mismatchCount (C : OPHCarrier) {n : ℕ} {x : Records C}
+    (h : FirstLock (stepOnce C) n x) : n ≤ mismatchCount x := by
+  have := mismatchCount_iterate_add_le C x n h.2
+  omega
+
+/-! ## Step 5: the declared observable *determines* the relaxation time -/
+
+/-- `Classical.choose` picks the same witness from pointwise-equivalent predicates. This
+restates `Primitives.choose_eq_of_pred_iff`, which is `private` to that file and so cannot
+be referenced here; the proof is the same three lines and introduces no new content. -/
+private theorem choose_eq_of_pred_iff {α : Sort*} {p q : α → Prop}
+    (hpq : ∀ a, p a ↔ q a) (hp : ∃ a, p a) (hq : ∃ a, q a) :
+    Classical.choose hp = Classical.choose hq := by
+  have hpq' : p = q := funext fun a => propext (hpq a)
+  subst hpq'
+  rfl
+
+/-- Locking is a function of the declared observable data: whether any site fires is,
+by the in-tree `localRepair_fire_congr`. -/
+theorem locked_stepOnce_congr {x y : Records C} (h : obsMap C x = obsMap C y) :
+    Locked (stepOnce C) x ↔ Locked (stepOnce C) y := by
+  have key : (∃ i : Site C, localRepair C i x ≠ x) ↔ (∃ i : Site C, localRepair C i y ≠ y) :=
+    exists_congr fun i => localRepair_fire_congr C h i
+  constructor
+  · intro hlx
+    by_contra hny
+    exact ((stepOnce_ne_iff C x).2 (key.2 ((stepOnce_ne_iff C y).1 hny))) hlx
+  · intro hly
+    by_contra hnx
+    exact ((stepOnce_ne_iff C y).2 (key.1 ((stepOnce_ne_iff C x).1 hnx))) hly
+
+/-- `stepOnce` is a gauge congruence: it fires the same site and installs the same repair
+on records with equal declared observable data. This is `Primitives.obsMap_Repair_congr`'s
+single-step engine, stated for `stepOnce`. -/
+theorem obsMap_stepOnce_congr {x y : Records C} (h : obsMap C x = obsMap C y) :
+    obsMap C (stepOnce C x) = obsMap C (stepOnce C y) := by
+  by_cases hx : ∃ i : Site C, localRepair C i x ≠ x
+  · have hy : ∃ i : Site C, localRepair C i y ≠ y := by
+      obtain ⟨i, hi⟩ := hx
+      exact ⟨i, (localRepair_fire_congr C h i).1 hi⟩
+    have hsite : Classical.choose hx = Classical.choose hy :=
+      choose_eq_of_pred_iff (fun i => localRepair_fire_congr C h i) hx hy
+    rw [stepOnce_of_fire C x hx, stepOnce_of_fire C y hy, ← hsite]
+    exact obsMap_localRepair_congr C h (Classical.choose hx)
+  · have hy : ¬ ∃ i : Site C, localRepair C i y ≠ y := by
+      intro hy'
+      obtain ⟨i, hi⟩ := hy'
+      exact hx ⟨i, (localRepair_fire_congr C h i).2 hi⟩
+    rw [stepOnce_of_normal C x hx, stepOnce_of_normal C y hy]
+    exact h
+
+/-- Whole trajectories agree on the declared observable data. -/
+theorem obsMap_iterate_congr {x y : Records C} (h : obsMap C x = obsMap C y) :
+    ∀ n : ℕ, obsMap C ((stepOnce C)^[n] x) = obsMap C ((stepOnce C)^[n] y) := by
+  intro n
+  induction n with
+  | zero => simpa using h
+  | succ n ih =>
+      rw [Function.iterate_succ_apply', Function.iterate_succ_apply']
+      exact obsMap_stepOnce_congr ih
+
+/-- **The exact negation of the abstract no-go, at the repository's own observable.** The
+first-locking count is a function of the declared observable data: records exposing the
+same overlap data lock after the same number of accepted repair steps. A rate functional on
+`obsMap` therefore exists — the abstract `no_rate_functional` refutes one for the abstract
+`DeclaredReading`, and that refutation does not transfer here. -/
+theorem firstLock_obs_determined {x y : Records C} (h : obsMap C x = obsMap C y) {n : ℕ}
+    (hx : FirstLock (stepOnce C) n x) : FirstLock (stepOnce C) n y := by
+  refine ⟨(locked_stepOnce_congr (obsMap_iterate_congr h n)).1 hx.1, ?_⟩
+  intro m hm hcon
+  exact hx.2 m hm ((locked_stepOnce_congr (obsMap_iterate_congr h m)).2 hcon)
+
+/-- The uniqueness companion: observably-identical records cannot have different
+first-locking counts. Contrast `RateNonidentifiability.sameReading_differentFirstLock`,
+which produces exactly that for the abstract reading. -/
+theorem firstLock_eq_of_obs_eq {x y : Records C} (h : obsMap C x = obsMap C y) {m n : ℕ}
+    (hx : FirstLock (stepOnce C) m x) (hy : FirstLock (stepOnce C) n y) : m = n :=
+  firstLock_unique (firstLock_obs_determined h hx) hy
+
+end OPH.RateBridgeObstruction
+
+/- Axiom audit. -/
+
+#print axioms OPH.RateBridgeObstruction.mismatchCount_congr
+#print axioms OPH.RateBridgeObstruction.acceptedStep_changes_obs
+#print axioms OPH.RateBridgeObstruction.no_observably_idle_acceptedStep
+#print axioms OPH.RateBridgeObstruction.acceptedStepLR_changes_obs
+#print axioms OPH.RateBridgeObstruction.stepOnce_acceptedStep
+#print axioms OPH.RateBridgeObstruction.locked_stepOnce_iff_normalForm
+#print axioms OPH.RateBridgeObstruction.firstLock_le_mismatchCount
+#print axioms OPH.RateBridgeObstruction.obsMap_stepOnce_congr
+#print axioms OPH.RateBridgeObstruction.firstLock_obs_determined
+#print axioms OPH.RateBridgeObstruction.firstLock_eq_of_obs_eq

--- a/Lean/ObserverPatchHolography/RateNonidentifiability.lean
+++ b/Lean/ObserverPatchHolography/RateNonidentifiability.lean
@@ -2,11 +2,36 @@ import Mathlib
 import ObserverPatchHolography.AbstractRewriting
 
 /-!
-# Rate non-identifiability for finite locking systems
+# Rate non-identifiability for finite locking systems (abstract; **not** repository-facing)
 
-This file machine-checks a boundary the OPH corpus already states in prose: patch consistency
-data does not determine how *fast* a locking transition happens. It endorses no physical claim.
-A no-go is the result.
+This file proves an *abstract* non-identifiability result about deterministic maps on an
+arbitrary type. It endorses no physical claim. A no-go is the result.
+
+## SCOPE WARNING — read before quoting anything below
+
+**This result does not apply to the repository's own repair dynamics, and the companion module
+`ObserverPatchHolography.RateBridgeObstruction` proves that it cannot.**
+
+An earlier framing of this file described it as machine-checking a *corpus* boundary — that
+patch consistency data does not determine how fast a locking transition happens. That framing
+was wrong and has been withdrawn. The theorems below are about `T : S → S` for an opaque `S`
+and the generic rewriting relation `OPH.AbstractRewriting.stepRel`, which the abstract-rewriting
+module itself calls a skeleton that "does not commit to OPH-specific structure". They are *not*
+about `OPH.Records`, `OPH.obsMap`, or `OPH.acceptedStep`.
+
+The bridge to those definitions was attempted and **fails at a located hypothesis**. The
+construction below needs an accepted step that moves the state while leaving the declared
+observable fixed — `stutter_has_projection_fixing_step` supplies exactly such steps. The
+repository's `OPH.acceptedStep` has none: every accepted repair step strictly lowers
+`OPH.mismatchCount`, which is a function of `OPH.obsMap` alone, so every accepted step strictly
+changes the declared observable (`RateBridgeObstruction.acceptedStep_changes_obs`, and for every
+local move obeying the declared laws H1–H3, `acceptedStepLR_changes_obs`).
+
+The concrete layer in fact satisfies the **opposite** of the conclusion below: the declared
+observable *bounds* the relaxation time (`RateBridgeObstruction.firstLock_le_mismatchCount`) and
+indeed *determines* it (`RateBridgeObstruction.firstLock_obs_determined`). Read this file as a
+theorem about abstract transition systems and about the weaker `DeclaredReading` defined here,
+never as a statement about the OPH repair layer.
 
 ## Which sense of "speed"
 
@@ -15,8 +40,9 @@ The word "speed" names four separable quantities. **This file addresses exactly 
 1. *Sharpness in a control parameter* — a critical exponent, a critical-window width. **Static.**
    **Not addressed here.** The systems below carry no control parameter, so no statement here
    can be read as one about a critical exponent or window.
-2. *Relaxation time of the repair operator* — the number of accepted repair steps taken before
-   the state first locks. **This is the quantity addressed here**, as `FirstLock`.
+2. *Relaxation time of the operator* — the number of `stepRel T` steps taken before the state
+   first locks. **This is the quantity addressed here**, as `FirstLock`. It is a count of
+   abstract steps, not of `OPH.acceptedStep` steps.
 3. *Finite-size width of the ambiguous band*, and its scaling in a system size `L`.
    **Not addressed here.** No size parameter appears.
 4. *Contraction factor of the repair map* — a per-step gap. **Not addressed here**, and for a
@@ -28,13 +54,14 @@ in this file may be quoted across them.
 
 ## What is proved
 
-For a finite deterministic repair operator `T`, locking is `IsFixedPt T`, so locked states are
-exactly the normal forms of the in-tree accepted repair relation
-`OPH.AbstractRewriting.stepRel T`. Given any positive stutter factor `s + 1`, the stutter
-extension `stutterStep T s` on the finite carrier `S × Fin (s + 1)`:
+For a finite deterministic operator `T`, locking is `IsFixedPt T`, so locked states are exactly
+the normal forms of the in-tree **generic** rewriting relation `OPH.AbstractRewriting.stepRel T`.
+`stepRel` is defined over an opaque type and is not the repository's accepted repair relation
+`OPH.acceptedStep`; see the scope warning above. Given any positive stutter factor `s + 1`, the
+stutter extension `stutterStep T s` on the finite carrier `S × Fin (s + 1)`:
 
 * has exactly the same locked set, fibrewise, in both directions (`locked_stutter_iff`);
-* has the same projected accepted-repair reachability (`proj_reachable`, `lift_reachable`);
+* has the same projected `stepRel`-reachability (`proj_reachable`, `lift_reachable`);
 * has the same projected basin (`basin_stutter_iff`);
 * multiplies the first-locking step count by `s + 1` (`firstLock_stutter`).
 
@@ -44,19 +71,21 @@ Hence no function of the declared reading returns the first-locking count
 
 ## The projection, stated
 
-The declared observable projection is `Prod.fst`: forget the counter. This is the honest
-projection because the corpus declines to declare the forgotten coordinate observable.
-`README.md` lines 292--295 (sentence at 294): "No theorem identifies phase locking with
-consensus confluence, modular flow, or an observer clock"; and lines 299--300: "Record order
-supplies a candidate history, not a clock".
-`physics-problems/compact_record_transients.md` line 73: "a repair eigenvalue is not a physical
-duration without a clock map". The theorem is exactly as strong as that claim and no stronger.
+The projection used here is `Prod.fst`: forget the counter. It is *stipulated by this file*, not
+taken from the repository. The corpus prose that an earlier framing cited in its defence
+(`README.md` lines 292--295 and 299--300; `physics-problems/compact_record_transients.md` line
+73, "a repair eigenvalue is not a physical duration without a clock map") says only that no
+*physical clock* has been supplied. It does not say that an adjoined counter is invisible to the
+repository's declared observable, and `RateBridgeObstruction` shows it is not: `OPH.obsMap`
+strictly changes on every accepted repair step. Whatever `Prod.fst` is, it is not `OPH.obsMap`.
 
-## Why stuttering is admissible rather than smuggled in
+## Why stuttering is admissible for *this* file's reading
 
-`extra/observable_normal_forms.tex` lines 633--665 requires that a kernel sampling rewrite
-schedules have support consisting of permitted rewrite steps *or stuttering moves*. The
-admissible class therefore already permits the moves used here.
+`extra/observable_normal_forms.tex` lines 633--665 lets a kernel sampling rewrite schedules whose
+support consists of permitted rewrite steps *or stuttering moves*. That is a statement about a
+stochastic kernel in the TeX corpus; it has no Lean counterpart in this repository, and it does
+not license stuttering in `OPH.acceptedStep`, which provably admits none. The moves used below
+are admissible for the `DeclaredReading` defined in this file and for nothing else in tree.
 
 ## Conditionality
 
@@ -75,8 +104,8 @@ variable {S : Type*}
 /-! ## Locking, basins, and first-locking time -/
 
 /-- A state is locked when the repair operator no longer moves it. Locking is defined as
-fixed-point-ness so that it coincides with normal-form-ness of the in-tree accepted repair
-relation; see `locked_iff_normalForm`. -/
+fixed-point-ness so that it coincides with normal-form-ness of the in-tree *generic* rewriting
+relation `stepRel`; see `locked_iff_normalForm`. -/
 def Locked (T : S → S) (x : S) : Prop := IsFixedPt T x
 
 theorem locked_iff (T : S → S) (x : S) : Locked T x ↔ T x = x := Iff.rfl
@@ -95,8 +124,8 @@ theorem locked_iff_normalForm (T : S → S) (x : S) :
 def Basin (T : S → S) (x : S) : Prop := ∃ n, Locked T (T^[n] x)
 
 /-- **Sense (2) of "speed".** `FirstLock T n x` says the state `x` first locks after exactly `n`
-steps of the repair operator. It counts accepted repair steps. It is not a critical exponent,
-not a window width, and not a per-step contraction factor. -/
+steps of the operator. It counts `stepRel T` steps, not `OPH.acceptedStep` steps. It is not a
+critical exponent, not a window width, and not a per-step contraction factor. -/
 def FirstLock (T : S → S) (n : ℕ) (x : S) : Prop :=
   Locked T (T^[n] x) ∧ ∀ m < n, ¬ Locked T (T^[m] x)
 
@@ -154,7 +183,7 @@ theorem stutterStep_locked (T : S → S) (s : ℕ) (p : S × Fin (s + 1)) (h : L
   simp only [stutterStep]
   rw [if_pos h']
 
-/-- With the counter exhausted, one accepted repair step fires and the counter reloads. -/
+/-- With the counter exhausted, one base step fires and the counter reloads. -/
 theorem stutterStep_reload (T : S → S) (s : ℕ) {x : S} (hx : ¬ Locked T x)
     (c : Fin (s + 1)) (hc : c.val = 0) :
     stutterStep T s (x, c) = (T x, Fin.last s) := by
@@ -170,9 +199,11 @@ theorem stutterStep_idle (T : S → S) (s : ℕ) {x : S} (hx : ¬ Locked T x)
   simp only [stutterStep]
   rw [if_neg hx', if_neg hc]
 
-/-- **Failure mode 1, defeated.** The full fixed-point set of the extended system is pinned
-fibrewise and in both directions: the extension adds no locked state, removes none, and a fibre
-is locked exactly when its base state is. -/
+/-- **Failure mode 1, defeated.** The full fixed-point set of the extended system is pinned in
+both directions: an extended state is locked exactly when its base state is, so
+`Fix (stutterStep T s) = Fix T ×ˢ univ`, the full preimage of `Fix T` under `Prod.fst`. Stated
+precisely, because as a bare set claim "the fixed-point set is preserved" would be false — each
+locked base state has `s + 1` distinct locked lifts. What is exact is the projected predicate. -/
 theorem locked_stutter_iff (T : S → S) (s : ℕ) (p : S × Fin (s + 1)) :
     Locked (stutterStep T s) p ↔ Locked T p.1 := by
   obtain ⟨x, c⟩ := p
@@ -279,7 +310,7 @@ theorem firstLock_stutter (T : S → S) (s n : ℕ) (x : S) (h : FirstLock T n x
 
 /-! ## Preservation of the projected reading -/
 
-/-- Every extended run projects to a run of the base accepted repair relation. -/
+/-- Every extended run projects to a run of the base `stepRel`. -/
 theorem proj_reachable (T : S → S) (s : ℕ) {p q : S × Fin (s + 1)}
     (h : ReflTransGen (stepRel (stutterStep T s)) p q) :
     ReflTransGen (stepRel T) p.1 q.1 := by
@@ -359,8 +390,11 @@ theorem basin_stutter_iff (T : S → S) (s : ℕ) (p : S × Fin (s + 1)) :
 
 /-! ## The declared reading and the no-go -/
 
-/-- The three pieces of declared data: the locked set, the accepted repair relation, and the
-basin. Nothing here is a clock and nothing here is a per-step contraction factor. -/
+/-- The three pieces of data this file declares readable: the locked set, `stepRel`-reachability,
+and the basin. This is *this file's* stipulated reading, not the repository's observable
+`OPH.obsMap`, which is strictly finer and — unlike this reading — determines the rate
+(`RateBridgeObstruction.firstLock_obs_determined`). Nothing here is a clock and nothing here is
+a per-step contraction factor. -/
 structure DeclaredReading (S : Type*) where
   LockedSet : S → Prop
   Reach : S → S → Prop
@@ -425,13 +459,19 @@ theorem sameReading_differentFirstLock (T : S → S) (x : S) (n : ℕ)
   have hsucc : s₁ + 1 = s₂ + 1 := Nat.eq_of_mul_eq_mul_right hpos hcon
   exact hne (by omega)
 
-/-- **The no-go, sense (2).** No function whatsoever from the declared reading — locked set,
-accepted repair relation, basin — returns the first-locking step count. The reading is constant
-across the stutter family while the count is not.
+/-- **The no-go, sense (2), for `DeclaredReading` only.** No function from the reading declared
+in this file — locked set, `stepRel`-reachability, basin — returns the first-locking step count.
+The reading is constant across the stutter family while the count is not.
 
-In plain English: patch consistency together with endpoint and basin data forbids nothing about
-how many repair steps locking takes. Any number of steps is consistent with the same declared
-data. This is a statement about identifiability, not about physics. -/
+**This is not a statement about the OPH repair layer.** For the repository's own observable
+`OPH.obsMap` the corresponding functional *does* exist: see
+`RateBridgeObstruction.firstLock_obs_determined`, and `firstLock_le_mismatchCount` for the
+bound. The gap between the two is that `DeclaredReading` is a triple of relations on the state
+space while `obsMap` is a per-state observable that separates strictly more records.
+
+In plain English: locked-set, reachability and basin data alone forbid nothing about how many
+abstract steps locking takes. This is a statement about identifiability under one stipulated
+reading, not about physics and not about OPH. -/
 theorem no_rate_functional (T : S → S) (x : S) (n : ℕ)
     (hlock : FirstLock T n x) (hpos : 0 < n)
     (rate : DeclaredReading S → ℕ)
@@ -444,9 +484,12 @@ theorem no_rate_functional (T : S → S) (x : S) (n : ℕ)
   rw [projReading_eq] at e0 e1
   omega
 
-/-- **The positive half.** Supply the stutter factor separately — a clock, or equivalently a
-transition law fixing the cost of a repair step — and the rate becomes determinate: it is
-exactly `(s + 1) * n`. The datum missing from the no-go is precisely this one. -/
+/-- **A uniqueness corollary, not a construction.** Given that `m` already *is* a first-locking
+count for the extension, it equals `(s + 1) * n`. This is `firstLock_unique` against
+`firstLock_stutter` and nothing more: it does not take a clock map as input, does not build a
+rate functional, and does not show that the stutter factor plus the declared reading suffices to
+recover `n`. An earlier gloss called this "the positive half" proving clock-sufficiency; that
+was too strong and is withdrawn. -/
 theorem rate_determined_by_clock (T : S → S) (x : S) (n s m : ℕ)
     (hlock : FirstLock T n x)
     (hm : FirstLock (stutterStep T s) m (x, Fin.last s)) :
@@ -460,8 +503,12 @@ fixed while the base state is unlocked. A declared per-step contraction factor o
 would therefore distinguish the stutter family, and the no-go above would not apply to it.
 
 This is why nothing in this file may be read as a statement about sense (4). It is also why the
-no-go is conditional on no per-step gap being declared — a condition the corpus itself asserts
-at `extra/observable_normal_forms.tex` lines 1486--1495. -/
+no-go is conditional on no per-step gap being declared.
+
+**This lemma is the precise point at which the bridge to OPH fails.** It exhibits the
+observably-idle step the construction depends on. `RateBridgeObstruction.acceptedStep_changes_obs`
+proves the repository's `OPH.acceptedStep` admits no such step, so no stutter extension of the
+OPH repair dynamics exists. -/
 theorem stutter_has_projection_fixing_step (T : S → S) (s : ℕ) (x : S)
     (hx : ¬ Locked T x) (hs : 0 < s) :
     ∃ p : S × Fin (s + 1),

--- a/Lean/ObserverPatchHolography/RateNonidentifiability.lean
+++ b/Lean/ObserverPatchHolography/RateNonidentifiability.lean
@@ -1,0 +1,579 @@
+import Mathlib
+import ObserverPatchHolography.AbstractRewriting
+
+/-!
+# Rate non-identifiability for finite locking systems
+
+This file machine-checks a boundary the OPH corpus already states in prose: patch consistency
+data does not determine how *fast* a locking transition happens. It endorses no physical claim.
+A no-go is the result.
+
+## Which sense of "speed"
+
+The word "speed" names four separable quantities. **This file addresses exactly one of them.**
+
+1. *Sharpness in a control parameter* — a critical exponent, a critical-window width. **Static.**
+   **Not addressed here.** The systems below carry no control parameter, so no statement here
+   can be read as one about a critical exponent or window.
+2. *Relaxation time of the repair operator* — the number of accepted repair steps taken before
+   the state first locks. **This is the quantity addressed here**, as `FirstLock`.
+3. *Finite-size width of the ambiguous band*, and its scaling in a system size `L`.
+   **Not addressed here.** No size parameter appears.
+4. *Contraction factor of the repair map* — a per-step gap. **Not addressed here**, and for a
+   sharper reason than the other two: the construction below does *not* preserve it. See
+   `stutter_has_projection_fixing_step` and the conditionality discussion under it.
+
+A result about (2) says nothing about (1). The four are not interchangeable and no theorem
+in this file may be quoted across them.
+
+## What is proved
+
+For a finite deterministic repair operator `T`, locking is `IsFixedPt T`, so locked states are
+exactly the normal forms of the in-tree accepted repair relation
+`OPH.AbstractRewriting.stepRel T`. Given any positive stutter factor `s + 1`, the stutter
+extension `stutterStep T s` on the finite carrier `S × Fin (s + 1)`:
+
+* has exactly the same locked set, fibrewise, in both directions (`locked_stutter_iff`);
+* has the same projected accepted-repair reachability (`proj_reachable`, `lift_reachable`);
+* has the same projected basin (`basin_stutter_iff`);
+* multiplies the first-locking step count by `s + 1` (`firstLock_stutter`).
+
+Hence no function of the declared reading returns the first-locking count
+(`no_rate_functional`), while supplying the stutter factor separately makes it determinate
+(`rate_determined_by_clock`). The missing datum is exactly a clock or transition law.
+
+## The projection, stated
+
+The declared observable projection is `Prod.fst`: forget the counter. This is the honest
+projection because the corpus declines to declare the forgotten coordinate observable.
+`README.md` lines 292--295 (sentence at 294): "No theorem identifies phase locking with
+consensus confluence, modular flow, or an observer clock"; and lines 299--300: "Record order
+supplies a candidate history, not a clock".
+`physics-problems/compact_record_transients.md` line 73: "a repair eigenvalue is not a physical
+duration without a clock map". The theorem is exactly as strong as that claim and no stronger.
+
+## Why stuttering is admissible rather than smuggled in
+
+`extra/observable_normal_forms.tex` lines 633--665 requires that a kernel sampling rewrite
+schedules have support consisting of permitted rewrite steps *or stuttering moves*. The
+admissible class therefore already permits the moves used here.
+
+## Conditionality
+
+The no-go is conditional on no per-step contraction factor being declared observable; see
+`stutter_has_projection_fixing_step`. That condition is met by the corpus's own statement at
+`extra/observable_normal_forms.tex` lines 1486--1495, that the finite resampling checker
+supplies "neither a spectral gap nor a convergence rate".
+-/
+
+open Function Relation OPH.AbstractRewriting
+
+namespace OPH.RateNonidentifiability
+
+variable {S : Type*}
+
+/-! ## Locking, basins, and first-locking time -/
+
+/-- A state is locked when the repair operator no longer moves it. Locking is defined as
+fixed-point-ness so that it coincides with normal-form-ness of the in-tree accepted repair
+relation; see `locked_iff_normalForm`. -/
+def Locked (T : S → S) (x : S) : Prop := IsFixedPt T x
+
+theorem locked_iff (T : S → S) (x : S) : Locked T x ↔ T x = x := Iff.rfl
+
+/-- The bridge to the in-tree abstract rewriting layer: locked states are exactly the normal
+forms of `OPH.AbstractRewriting.stepRel`. -/
+theorem locked_iff_normalForm (T : S → S) (x : S) :
+    Locked T x ↔ IsNormalForm (stepRel T) x := by
+  constructor
+  · intro h y hy
+    exact hy.2 h
+  · intro h
+    exact Classical.not_not.1 fun hne => h (T x) ⟨rfl, hne⟩
+
+/-- The basin: states that eventually lock. -/
+def Basin (T : S → S) (x : S) : Prop := ∃ n, Locked T (T^[n] x)
+
+/-- **Sense (2) of "speed".** `FirstLock T n x` says the state `x` first locks after exactly `n`
+steps of the repair operator. It counts accepted repair steps. It is not a critical exponent,
+not a window width, and not a per-step contraction factor. -/
+def FirstLock (T : S → S) (n : ℕ) (x : S) : Prop :=
+  Locked T (T^[n] x) ∧ ∀ m < n, ¬ Locked T (T^[m] x)
+
+theorem firstLock_unique {T : S → S} {m n : ℕ} {x : S}
+    (hm : FirstLock T m x) (hn : FirstLock T n x) : m = n := by
+  by_contra hne
+  rcases Nat.lt_or_ge m n with h | h
+  · exact hn.2 m h hm.1
+  · exact hm.2 n (by omega) hn.1
+
+theorem basin_of_firstLock {T : S → S} {n : ℕ} {x : S} (h : FirstLock T n x) : Basin T x :=
+  ⟨n, h.1⟩
+
+theorem basin_of_iterate {α : Type*} {f : α → α} {x y : α} {m : ℕ}
+    (h : f^[m] x = y) (hy : Basin f y) : Basin f x := by
+  obtain ⟨n, hn⟩ := hy
+  exact ⟨n + m, by rw [Function.iterate_add_apply, h]; exact hn⟩
+
+/-- An iterated run whose every intermediate state actually moves is a run of the accepted
+repair relation. -/
+theorem reflTransGen_of_iterate {α : Type*} (f : α → α) (p : α) (n : ℕ)
+    (h : ∀ i < n, f (f^[i] p) ≠ f^[i] p) :
+    ReflTransGen (stepRel f) p (f^[n] p) := by
+  induction n with
+  | zero => exact ReflTransGen.refl
+  | succ n ih =>
+      refine (ih fun i hi => h i (by omega)).tail ?_
+      exact ⟨by rw [Function.iterate_succ_apply'], h n (Nat.lt_succ_self n)⟩
+
+/-! ## The stutter extension -/
+
+section Stutter
+
+variable [DecidableEq S]
+
+/-- The stutter extension with factor `s + 1`, an arbitrary positive natural. The carrier
+`S × Fin (s + 1)` is finite whenever `S` is. A locked state never stutters: the locked branch is
+tested first, which is what keeps the fixed-point set exactly preserved. -/
+def stutterStep (T : S → S) (s : ℕ) : S × Fin (s + 1) → S × Fin (s + 1) :=
+  fun p =>
+    if T p.1 = p.1 then p
+    else if p.2.val = 0 then (T p.1, Fin.last s)
+    else (p.1, ⟨p.2.val - 1, by have := p.2.isLt; omega⟩)
+
+/-- The declared observable projection: forget the counter coordinate. -/
+def proj (_T : S → S) (s : ℕ) : S × Fin (s + 1) → S := fun p => p.1
+
+/-! The three computation rules for `stutterStep`, stated once so that no downstream proof has
+to reason about the nesting of its branches. -/
+
+/-- A locked state does not move. -/
+theorem stutterStep_locked (T : S → S) (s : ℕ) (p : S × Fin (s + 1)) (h : Locked T p.1) :
+    stutterStep T s p = p := by
+  have h' : T p.1 = p.1 := h
+  simp only [stutterStep]
+  rw [if_pos h']
+
+/-- With the counter exhausted, one accepted repair step fires and the counter reloads. -/
+theorem stutterStep_reload (T : S → S) (s : ℕ) {x : S} (hx : ¬ Locked T x)
+    (c : Fin (s + 1)) (hc : c.val = 0) :
+    stutterStep T s (x, c) = (T x, Fin.last s) := by
+  have hx' : ¬ (T x = x) := hx
+  simp only [stutterStep]
+  rw [if_neg hx', if_pos hc]
+
+/-- Otherwise the extension takes a permitted stuttering move. -/
+theorem stutterStep_idle (T : S → S) (s : ℕ) {x : S} (hx : ¬ Locked T x)
+    (c : Fin (s + 1)) (hc : c.val ≠ 0) :
+    stutterStep T s (x, c) = (x, ⟨c.val - 1, by have := c.isLt; omega⟩) := by
+  have hx' : ¬ (T x = x) := hx
+  simp only [stutterStep]
+  rw [if_neg hx', if_neg hc]
+
+/-- **Failure mode 1, defeated.** The full fixed-point set of the extended system is pinned
+fibrewise and in both directions: the extension adds no locked state, removes none, and a fibre
+is locked exactly when its base state is. -/
+theorem locked_stutter_iff (T : S → S) (s : ℕ) (p : S × Fin (s + 1)) :
+    Locked (stutterStep T s) p ↔ Locked T p.1 := by
+  obtain ⟨x, c⟩ := p
+  constructor
+  · intro h
+    have h' : stutterStep T s (x, c) = (x, c) := h
+    by_contra hne
+    have hne' : ¬ Locked T x := hne
+    by_cases hc : c.val = 0
+    · rw [stutterStep_reload T s hne' c hc] at h'
+      exact hne (congrArg Prod.fst h')
+    · rw [stutterStep_idle T s hne' c hc] at h'
+      have h2 : c.val - 1 = c.val := congrArg (fun q => (Prod.snd q).val) h'
+      omega
+  · exact stutterStep_locked T s (x, c)
+
+/-- Every extended step projects either to nothing (a stuttering move) or to exactly one step of
+the base repair operator. -/
+theorem proj_step (T : S → S) (s : ℕ) (p : S × Fin (s + 1)) :
+    (stutterStep T s p).1 = p.1 ∨ (stutterStep T s p).1 = T p.1 := by
+  obtain ⟨x, c⟩ := p
+  by_cases hl : Locked T x
+  · left; rw [stutterStep_locked T s (x, c) hl]
+  · by_cases hc : c.val = 0
+    · right; rw [stutterStep_reload T s hl c hc]
+    · left; rw [stutterStep_idle T s hl c hc]
+
+/-- While the base state is unlocked the extension idles, decrementing the counter. -/
+theorem stutter_iterate_hold (T : S → S) (s : ℕ) {x : S} (hx : ¬ Locked T x)
+    (c : Fin (s + 1)) :
+    ∀ i, i ≤ c.val →
+      (stutterStep T s)^[i] (x, c) = (x, ⟨c.val - i, by have := c.isLt; omega⟩) := by
+  have hx' : ¬ (T x = x) := hx
+  intro i
+  induction i with
+  | zero => intro _; simp
+  | succ i ih =>
+      intro hi
+      have hne : (⟨c.val - i, by have := c.isLt; omega⟩ : Fin (s + 1)).val ≠ 0 := by
+        show c.val - i ≠ 0
+        omega
+      rw [Function.iterate_succ_apply', ih (by omega), stutterStep_idle T s hx _ hne]
+      congr 1
+
+/-- After exactly `c + 1` extended steps the base state has advanced by exactly one repair step
+and the counter has been reloaded. -/
+theorem stutter_step_next (T : S → S) (s : ℕ) {x : S} (hx : ¬ Locked T x)
+    (c : Fin (s + 1)) :
+    (stutterStep T s)^[c.val + 1] (x, c) = (T x, Fin.last s) := by
+  rw [Function.iterate_succ_apply', stutter_iterate_hold T s hx c c.val le_rfl]
+  exact stutterStep_reload T s hx _ (show c.val - c.val = 0 from Nat.sub_self c.val)
+
+/-- One block: `s + 1` extended steps realise one base repair step. -/
+theorem stutter_block (T : S → S) (s : ℕ) {x : S} (hx : ¬ Locked T x) :
+    (stutterStep T s)^[s + 1] (x, Fin.last s) = (T x, Fin.last s) :=
+  stutter_step_next T s hx (Fin.last s)
+
+/-- `k` base repair steps cost exactly `(s + 1) * k` extended steps. -/
+theorem stutter_iterate_mul (T : S → S) (s : ℕ) (x : S) :
+    ∀ k, (∀ j < k, ¬ Locked T (T^[j] x)) →
+      (stutterStep T s)^[(s + 1) * k] (x, Fin.last s) = (T^[k] x, Fin.last s) := by
+  intro k
+  induction k with
+  | zero => intro _; simp
+  | succ k ih =>
+      intro hpre
+      have hk : ¬ Locked T (T^[k] x) := hpre k (Nat.lt_succ_self k)
+      have hsplit : (s + 1) * (k + 1) = (s + 1) + (s + 1) * k := by ring
+      rw [hsplit, Function.iterate_add_apply, ih fun j hj => hpre j (by omega),
+        stutter_block T s hk, Function.iterate_succ_apply']
+
+/-- No extended state locks before the whole block schedule has run. -/
+theorem stutter_not_locked_before (T : S → S) (s n : ℕ) (x : S)
+    (hpre : ∀ j < n, ¬ Locked T (T^[j] x)) :
+    ∀ m < (s + 1) * n,
+      ¬ Locked (stutterStep T s) ((stutterStep T s)^[m] (x, Fin.last s)) := by
+  intro m hm
+  obtain ⟨q, r, hrs, hdm⟩ : ∃ q r, r < s + 1 ∧ m = (s + 1) * q + r :=
+    ⟨m / (s + 1), m % (s + 1), Nat.mod_lt _ (Nat.succ_pos s),
+      (Nat.div_add_mod m (s + 1)).symm⟩
+  have hqn : q < n := by
+    by_contra hcon
+    have hcon' : n ≤ q := Nat.le_of_not_lt hcon
+    have hmul : (s + 1) * n ≤ (s + 1) * q := Nat.mul_le_mul (Nat.le_refl (s + 1)) hcon'
+    omega
+  have hunlocked : ¬ Locked T (T^[q] x) := hpre _ hqn
+  have hidx : m = r + (s + 1) * q := by rw [hdm]; ring
+  have hrle : r ≤ (Fin.last s).val := by
+    simp only [Fin.val_last]
+    omega
+  rw [hidx, Function.iterate_add_apply,
+    stutter_iterate_mul T s x q fun j hj => hpre j (by omega),
+    stutter_iterate_hold T s hunlocked (Fin.last s) r hrle]
+  intro hcon
+  exact hunlocked ((locked_stutter_iff T s _).1 hcon)
+
+/-- **The rate multiplication.** First locking in `n` base repair steps becomes first locking in
+`(s + 1) * n` steps of the extension, for an arbitrary positive stutter factor `s + 1`. -/
+theorem firstLock_stutter (T : S → S) (s n : ℕ) (x : S) (h : FirstLock T n x) :
+    FirstLock (stutterStep T s) ((s + 1) * n) (x, Fin.last s) := by
+  refine ⟨?_, stutter_not_locked_before T s n x h.2⟩
+  rw [stutter_iterate_mul T s x n h.2]
+  exact (locked_stutter_iff T s _).2 h.1
+
+/-! ## Preservation of the projected reading -/
+
+/-- Every extended run projects to a run of the base accepted repair relation. -/
+theorem proj_reachable (T : S → S) (s : ℕ) {p q : S × Fin (s + 1)}
+    (h : ReflTransGen (stepRel (stutterStep T s)) p q) :
+    ReflTransGen (stepRel T) p.1 q.1 := by
+  induction h with
+  | refl => exact ReflTransGen.refl
+  | @tail b c _hpb hbc ih =>
+      have hb : ¬ Locked T b.1 := fun hlock =>
+        hbc.2 ((locked_stutter_iff T s b).2 hlock)
+      have hc : c.1 = (stutterStep T s b).1 := by rw [hbc.1]
+      rcases proj_step T s b with h1 | h1
+      · rw [hc, h1]
+        exact ih
+      · exact ih.tail ⟨by rw [hc, h1], hb⟩
+
+/-- Every base run is realised by an extended run. -/
+theorem lift_reachable (T : S → S) (s : ℕ) {x y : S}
+    (h : ReflTransGen (stepRel T) x y) :
+    ReflTransGen (stepRel (stutterStep T s)) (x, Fin.last s) (y, Fin.last s) := by
+  induction h with
+  | refl => exact ReflTransGen.refl
+  | @tail b c _hxb hbc ih =>
+      refine ih.trans ?_
+      have hb : ¬ Locked T b := hbc.2
+      have hmove : ∀ i < s + 1,
+          stutterStep T s ((stutterStep T s)^[i] (b, Fin.last s))
+            ≠ (stutterStep T s)^[i] (b, Fin.last s) := by
+        intro i hi
+        have hile : i ≤ (Fin.last s).val := by
+          simp only [Fin.val_last]
+          omega
+        rw [stutter_iterate_hold T s hb (Fin.last s) i hile]
+        intro hcon
+        exact hb ((locked_stutter_iff T s _).1 hcon)
+      have hpath := reflTransGen_of_iterate (stutterStep T s) (b, Fin.last s) (s + 1) hmove
+      rw [stutter_block T s hb] at hpath
+      rw [hbc.1]
+      exact hpath
+
+theorem proj_iterate_exists (T : S → S) (s : ℕ) (p : S × Fin (s + 1)) (n : ℕ) :
+    ∃ k, ((stutterStep T s)^[n] p).1 = T^[k] p.1 := by
+  induction n with
+  | zero => exact ⟨0, rfl⟩
+  | succ n ih =>
+      obtain ⟨k, hk⟩ := ih
+      rw [Function.iterate_succ_apply']
+      rcases proj_step T s ((stutterStep T s)^[n] p) with h | h
+      · exact ⟨k, by rw [h, hk]⟩
+      · exact ⟨k + 1, by rw [h, hk, Function.iterate_succ_apply']⟩
+
+theorem basin_stutter_of_base (T : S → S) (s : ℕ) :
+    ∀ (n : ℕ) (p : S × Fin (s + 1)), Locked T (T^[n] p.1) → Basin (stutterStep T s) p := by
+  intro n
+  induction n with
+  | zero => intro p hp; exact ⟨0, (locked_stutter_iff T s p).2 hp⟩
+  | succ n ih =>
+      intro p hp
+      by_cases hlk : Locked T p.1
+      · exact ⟨0, (locked_stutter_iff T s p).2 hlk⟩
+      · have hstep : (stutterStep T s)^[p.2.val + 1] p = (T p.1, Fin.last s) :=
+          stutter_step_next T s hlk p.2
+        have hnext : Locked T (T^[n] (T p.1)) := by
+          rw [← Function.iterate_succ_apply]
+          exact hp
+        exact basin_of_iterate hstep (ih (T p.1, Fin.last s) hnext)
+
+/-- The basin is preserved exactly, fibrewise and in both directions. -/
+theorem basin_stutter_iff (T : S → S) (s : ℕ) (p : S × Fin (s + 1)) :
+    Basin (stutterStep T s) p ↔ Basin T p.1 := by
+  constructor
+  · rintro ⟨n, hn⟩
+    obtain ⟨k, hk⟩ := proj_iterate_exists T s p n
+    refine ⟨k, ?_⟩
+    rw [← hk]
+    exact (locked_stutter_iff T s _).1 hn
+  · rintro ⟨n, hn⟩
+    exact basin_stutter_of_base T s n p hn
+
+/-! ## The declared reading and the no-go -/
+
+/-- The three pieces of declared data: the locked set, the accepted repair relation, and the
+basin. Nothing here is a clock and nothing here is a per-step contraction factor. -/
+structure DeclaredReading (S : Type*) where
+  LockedSet : S → Prop
+  Reach : S → S → Prop
+  BasinSet : S → Prop
+
+/-- The reading of the unextended system. -/
+def reading (T : S → S) : DeclaredReading S where
+  LockedSet := Locked T
+  Reach := ReflTransGen (stepRel T)
+  BasinSet := Basin T
+
+/-- **Failure mode 2, defeated by naming the projection.** The reading of the extended system as
+seen through `proj`, which forgets the counter. Everything an observer without a clock can read
+off the stuttered system. -/
+def projReading (T : S → S) (s : ℕ) : DeclaredReading S where
+  LockedSet := fun x => ∃ c : Fin (s + 1), Locked (stutterStep T s) (x, c)
+  Reach := fun x y => ∃ c d : Fin (s + 1),
+    ReflTransGen (stepRel (stutterStep T s)) (x, c) (y, d)
+  BasinSet := fun x => ∃ c : Fin (s + 1), Basin (stutterStep T s) (x, c)
+
+/-- Every stutter extension reads identically to the unextended system, for every factor. -/
+theorem projReading_eq (T : S → S) (s : ℕ) : projReading T s = reading T := by
+  have hL : (fun x => ∃ c : Fin (s + 1), Locked (stutterStep T s) (x, c)) = Locked T := by
+    funext x
+    apply propext
+    constructor
+    · rintro ⟨c, hc⟩
+      exact (locked_stutter_iff T s (x, c)).1 hc
+    · intro h
+      exact ⟨Fin.last s, (locked_stutter_iff T s (x, Fin.last s)).2 h⟩
+  have hR : (fun x y => ∃ c d : Fin (s + 1),
+      ReflTransGen (stepRel (stutterStep T s)) (x, c) (y, d)) = ReflTransGen (stepRel T) := by
+    funext x y
+    apply propext
+    constructor
+    · rintro ⟨c, d, h⟩
+      exact proj_reachable T s h
+    · intro h
+      exact ⟨Fin.last s, Fin.last s, lift_reachable T s h⟩
+  have hB : (fun x => ∃ c : Fin (s + 1), Basin (stutterStep T s) (x, c)) = Basin T := by
+    funext x
+    apply propext
+    constructor
+    · rintro ⟨c, hc⟩
+      exact (basin_stutter_iff T s (x, c)).1 hc
+    · intro h
+      exact ⟨Fin.last s, (basin_stutter_iff T s (x, Fin.last s)).2 h⟩
+  unfold projReading reading
+  simp only [DeclaredReading.mk.injEq]
+  exact ⟨hL, hR, hB⟩
+
+/-- Two stutter factors, one reading, two different first-locking counts. -/
+theorem sameReading_differentFirstLock (T : S → S) (x : S) (n : ℕ)
+    (hlock : FirstLock T n x) (hpos : 0 < n) (s₁ s₂ : ℕ) (hne : s₁ ≠ s₂) :
+    projReading T s₁ = projReading T s₂ ∧
+      FirstLock (stutterStep T s₁) ((s₁ + 1) * n) (x, Fin.last s₁) ∧
+      FirstLock (stutterStep T s₂) ((s₂ + 1) * n) (x, Fin.last s₂) ∧
+      (s₁ + 1) * n ≠ (s₂ + 1) * n := by
+  refine ⟨by rw [projReading_eq, projReading_eq], firstLock_stutter T s₁ n x hlock,
+    firstLock_stutter T s₂ n x hlock, ?_⟩
+  intro hcon
+  have hsucc : s₁ + 1 = s₂ + 1 := Nat.eq_of_mul_eq_mul_right hpos hcon
+  exact hne (by omega)
+
+/-- **The no-go, sense (2).** No function whatsoever from the declared reading — locked set,
+accepted repair relation, basin — returns the first-locking step count. The reading is constant
+across the stutter family while the count is not.
+
+In plain English: patch consistency together with endpoint and basin data forbids nothing about
+how many repair steps locking takes. Any number of steps is consistent with the same declared
+data. This is a statement about identifiability, not about physics. -/
+theorem no_rate_functional (T : S → S) (x : S) (n : ℕ)
+    (hlock : FirstLock T n x) (hpos : 0 < n)
+    (rate : DeclaredReading S → ℕ)
+    (hrate : ∀ s : ℕ, FirstLock (stutterStep T s) (rate (projReading T s)) (x, Fin.last s)) :
+    False := by
+  have e0 : rate (projReading T 0) = 1 * n :=
+    firstLock_unique (hrate 0) (firstLock_stutter T 0 n x hlock)
+  have e1 : rate (projReading T 1) = 2 * n :=
+    firstLock_unique (hrate 1) (firstLock_stutter T 1 n x hlock)
+  rw [projReading_eq] at e0 e1
+  omega
+
+/-- **The positive half.** Supply the stutter factor separately — a clock, or equivalently a
+transition law fixing the cost of a repair step — and the rate becomes determinate: it is
+exactly `(s + 1) * n`. The datum missing from the no-go is precisely this one. -/
+theorem rate_determined_by_clock (T : S → S) (x : S) (n s m : ℕ)
+    (hlock : FirstLock T n x)
+    (hm : FirstLock (stutterStep T s) m (x, Fin.last s)) :
+    m = (s + 1) * n :=
+  firstLock_unique hm (firstLock_stutter T s n x hlock)
+
+/-! ## What the construction does not preserve, and hence what the no-go is conditional on -/
+
+/-- **Conditionality of the no-go.** The extension has reachable steps that leave the projection
+fixed while the base state is unlocked. A declared per-step contraction factor or spectral gap
+would therefore distinguish the stutter family, and the no-go above would not apply to it.
+
+This is why nothing in this file may be read as a statement about sense (4). It is also why the
+no-go is conditional on no per-step gap being declared — a condition the corpus itself asserts
+at `extra/observable_normal_forms.tex` lines 1486--1495. -/
+theorem stutter_has_projection_fixing_step (T : S → S) (s : ℕ) (x : S)
+    (hx : ¬ Locked T x) (hs : 0 < s) :
+    ∃ p : S × Fin (s + 1),
+      ¬ Locked T p.1 ∧ ¬ Locked (stutterStep T s) p ∧ (stutterStep T s p).1 = p.1 := by
+  refine ⟨(x, Fin.last s), hx, fun hcon => hx ((locked_stutter_iff T s _).1 hcon), ?_⟩
+  have hc : (Fin.last s).val ≠ 0 := by
+    show s ≠ 0
+    omega
+  rw [stutterStep_idle T s hx (Fin.last s) hc]
+
+omit [DecidableEq S] in
+/-- By contrast the base system has no such step: an unlocked base state always moves. -/
+theorem base_has_no_projection_fixing_step (T : S → S) (x : S) (hx : ¬ Locked T x) :
+    T x ≠ x := hx
+
+/-- The stutter extension preserves termination, so it does not manufacture a basin. Stated
+through the in-tree descent lemma. -/
+theorem stutter_terminating_of_descent (T : S → S) (s : ℕ) (Φ : S → ℕ)
+    (hdesc : ∀ x, T x ≠ x → Φ (T x) < Φ x) :
+    Terminating (stepRel (stutterStep T s)) := by
+  refine descent_terminating (stutterStep T s) (fun p => (s + 1) * Φ p.1 + p.2.val) ?_
+  intro p hne
+  obtain ⟨x, c⟩ := p
+  have hbase : ¬ Locked T x := fun hlock => hne ((locked_stutter_iff T s (x, c)).2 hlock)
+  have hdrop : Φ (T x) + 1 ≤ Φ x := hdesc x hbase
+  have hmul : (s + 1) * (Φ (T x) + 1) ≤ (s + 1) * Φ x :=
+    Nat.mul_le_mul (Nat.le_refl _) hdrop
+  rw [Nat.mul_add, Nat.mul_one] at hmul
+  by_cases hc : c.val = 0
+  · rw [stutterStep_reload T s hbase c hc]
+    show (s + 1) * Φ (T x) + s < (s + 1) * Φ x + c.val
+    omega
+  · rw [stutterStep_idle T s hbase c hc]
+    show (s + 1) * Φ x + (c.val - 1) < (s + 1) * Φ x + c.val
+    omega
+
+end Stutter
+
+/-! ## An explicit finite witness
+
+Four states, a descent repair operator, one locked state, three unlocked states with distinct
+first-locking counts. Stutter factor seven gives a twenty-eight-state extension with an
+identical declared reading and a first-locking count of twenty-one instead of three. -/
+
+section Witness
+
+/-- The four-state descent witness: mismatch level three decays to the locked level zero. -/
+def wT : Fin 4 → Fin 4 := fun i => if i = 0 then 0 else i - 1
+
+instance decidableLocked {S : Type*} [DecidableEq S] (T : S → S) (x : S) :
+    Decidable (Locked T x) :=
+  inferInstanceAs (Decidable (T x = x))
+
+instance decidableFirstLock {S : Type*} [DecidableEq S] (T : S → S) (n : ℕ) (x : S) :
+    Decidable (FirstLock T n x) :=
+  inferInstanceAs (Decidable (Locked T (T^[n] x) ∧ ∀ m < n, ¬ Locked T (T^[m] x)))
+
+/-- The locked set of the witness is exactly `{0}`. -/
+theorem wT_locked_iff : ∀ i : Fin 4, Locked wT i ↔ i = 0 := by decide
+
+/-- Three unlocked states with three distinct first-locking counts. -/
+theorem wT_firstLock_zero : FirstLock wT 0 0 := by decide
+
+theorem wT_firstLock_one : FirstLock wT 1 1 := by decide
+
+theorem wT_firstLock_two : FirstLock wT 2 2 := by decide
+
+theorem wT_firstLock_three : FirstLock wT 3 3 := by decide
+
+/-- The witness terminates, through the in-tree descent lemma. -/
+theorem wT_terminating : Terminating (stepRel wT) :=
+  descent_terminating wT (fun i => i.val) (by decide)
+
+/-- Every stutter extension of the witness terminates too. -/
+theorem wT_stutter_terminating (s : ℕ) : Terminating (stepRel (stutterStep wT s)) :=
+  stutter_terminating_of_descent wT s (fun i => i.val) (by decide)
+
+/-- Stutter factor seven multiplies the first-locking count from three to twenty-one. -/
+theorem wT_stutter_firstLock : FirstLock (stutterStep wT 6) 21 (3, Fin.last 6) := by
+  have h := firstLock_stutter wT 6 3 3 wT_firstLock_three
+  have harith : (6 + 1) * 3 = 21 := by norm_num
+  rwa [harith] at h
+
+/-- Every stutter extension of the witness has the same declared reading. -/
+theorem wT_readings_agree (s₁ s₂ : ℕ) : projReading wT s₁ = projReading wT s₂ := by
+  rw [projReading_eq, projReading_eq]
+
+/-- The witness instance of the no-go. -/
+theorem wT_no_rate_functional (rate : DeclaredReading (Fin 4) → ℕ)
+    (hrate : ∀ s : ℕ,
+      FirstLock (stutterStep wT s) (rate (projReading wT s)) (3, Fin.last s)) :
+    False :=
+  no_rate_functional wT 3 3 wT_firstLock_three (by norm_num) rate hrate
+
+end Witness
+
+end OPH.RateNonidentifiability
+
+/- Axiom audit. -/
+
+#print axioms OPH.RateNonidentifiability.locked_iff_normalForm
+#print axioms OPH.RateNonidentifiability.locked_stutter_iff
+#print axioms OPH.RateNonidentifiability.proj_reachable
+#print axioms OPH.RateNonidentifiability.lift_reachable
+#print axioms OPH.RateNonidentifiability.basin_stutter_iff
+#print axioms OPH.RateNonidentifiability.firstLock_stutter
+#print axioms OPH.RateNonidentifiability.projReading_eq
+#print axioms OPH.RateNonidentifiability.sameReading_differentFirstLock
+#print axioms OPH.RateNonidentifiability.no_rate_functional
+#print axioms OPH.RateNonidentifiability.rate_determined_by_clock
+#print axioms OPH.RateNonidentifiability.stutter_has_projection_fixing_step
+#print axioms OPH.RateNonidentifiability.stutter_terminating_of_descent
+#print axioms OPH.RateNonidentifiability.wT_firstLock_three
+#print axioms OPH.RateNonidentifiability.wT_stutter_firstLock
+#print axioms OPH.RateNonidentifiability.wT_no_rate_functional


### PR DESCRIPTION

**Proven:** first-lock count is not identifiable from the stipulated abstract `DeclaredReading`; **not proven:** a rate no-go for OPH's `obsMap`/`acceptedStep` or any physical rate—the repository-facing OPH rate question remains open.

This adds an abstract finite-locking construction and, just as importantly, machine-checks the obstruction that prevents presenting it as an OPH result. A stutter extension preserves the abstract locked-set/reachability/basin reading while multiplying first-lock count. But the OPH relation admits no observably idle accepted step: every `acceptedStep` strictly changes `obsMap`. For the choice-canonical `stepOnce` scheduler, `obsMap` instead bounds and determines first-lock count.

The abstract receipts are:

- `OPH.RateNonidentifiability.firstLock_stutter` — `Lean/ObserverPatchHolography/RateNonidentifiability.lean:305`
- `OPH.RateNonidentifiability.projReading_eq` — `Lean/ObserverPatchHolography/RateNonidentifiability.lean:419`
- `OPH.RateNonidentifiability.sameReading_differentFirstLock` — `Lean/ObserverPatchHolography/RateNonidentifiability.lean:450`
- `OPH.RateNonidentifiability.no_rate_functional` — `Lean/ObserverPatchHolography/RateNonidentifiability.lean:475`
- `OPH.RateNonidentifiability.stutter_has_projection_fixing_step` — `Lean/ObserverPatchHolography/RateNonidentifiability.lean:512`

The OPH boundary receipts are:

- `OPH.RateBridgeObstruction.acceptedStep_changes_obs` — `Lean/ObserverPatchHolography/RateBridgeObstruction.lean:120`
- `OPH.RateBridgeObstruction.no_observably_idle_acceptedStep` — `Lean/ObserverPatchHolography/RateBridgeObstruction.lean:133`
- `OPH.RateBridgeObstruction.acceptedStepLR_changes_obs` — `Lean/ObserverPatchHolography/RateBridgeObstruction.lean:143`
- `OPH.RateBridgeObstruction.stepOnce_acceptedStep` — `Lean/ObserverPatchHolography/RateBridgeObstruction.lean:199`
- `OPH.RateBridgeObstruction.locked_stepOnce_iff_normalForm` — `Lean/ObserverPatchHolography/RateBridgeObstruction.lean:206`
- `OPH.RateBridgeObstruction.firstLock_le_mismatchCount` — `Lean/ObserverPatchHolography/RateBridgeObstruction.lean:253`
- `OPH.RateBridgeObstruction.firstLock_obs_determined` — `Lean/ObserverPatchHolography/RateBridgeObstruction.lean:319`
- `OPH.RateBridgeObstruction.firstLock_eq_of_obs_eq` — `Lean/ObserverPatchHolography/RateBridgeObstruction.lean:328`

Validation after rebasing onto `15db16e85a6bf6c946dad76e61c6fe8a450a6286`:

```text
/home/monkey/bin/leanbuild build ObserverPatchHolography.RateBridgeObstruction
Build completed successfully (8251 jobs).
```

The embedded axiom audits (`RateNonidentifiability.lean:610`–`:626`, `RateBridgeObstruction.lean:334`–`:345`) report the exact union `{propext, Classical.choice, Quot.sound}`. There are no `sorry` tokens in either theorem-bearing file.

**What to attack first:** please challenge the scope boundary, not just the abstract proof. In particular, attack whether `DeclaredReading` is being confused with `obsMap`, whether the impossibility of an observably idle `acceptedStep` really blocks the stutter bridge, and whether `stepOnce_acceptedStep` plus `locked_stepOnce_iff_normalForm` is sufficient faithfulness for the positive OPH-side statements. Any reading that turns this into a physical-rate result or a closed OPH rate question is a bug in the presentation.

No GitHub issue is claimed.
