### PR TITLE
feat(KoideCirculant): discharge the cosine hypotheses — the phase cancels unconditionally

### DIFF
--- a/Lean/ObserverPatchHolography/KoideCirculant.lean
+++ b/Lean/ObserverPatchHolography/KoideCirculant.lean
@@ -93,4 +93,80 @@ theorem koide_eq_two_thirds_iff
     rw [h]
     nlinarith
 
+/-! ## Phase cancellation: the cosine hypotheses hold for every δ
+
+`root_sum` and `root_square_sum` take the two cosine identities as HYPOTHESES on abstract
+coordinates `c₀ c₁ c₂`. Theorem 9.1 of the paper derives them for the actual cosines at angles
+separated by `2π/3`, which is what makes "the phase δ cancels from Q" a theorem rather than an
+assumption. The three results below discharge those hypotheses for EVERY `δ`, so the Koide
+quotient is phase-independent unconditionally.
+
+Scope unchanged: this adds no physical-mass claim, does not select the phase, and does not
+supply the source-to-charged-family attachment. It closes exactly the trigonometric step. -/
+
+/-- The three cosine coordinates at `2π/3` spacing sum to zero, for every phase `δ`. -/
+theorem cos_coords_sum_zero (δ : ℝ) :
+    Real.cos δ + Real.cos (δ + 2 * Real.pi / 3) + Real.cos (δ + 4 * Real.pi / 3) = 0 := by
+  have h2 : Real.cos (δ + 2 * Real.pi / 3)
+      = Real.cos δ * Real.cos (2 * Real.pi / 3) - Real.sin δ * Real.sin (2 * Real.pi / 3) :=
+    Real.cos_add _ _
+  have h4 : Real.cos (δ + 4 * Real.pi / 3)
+      = Real.cos δ * Real.cos (4 * Real.pi / 3) - Real.sin δ * Real.sin (4 * Real.pi / 3) :=
+    Real.cos_add _ _
+  have c2 : Real.cos (2 * Real.pi / 3) = -(1 / 2) := by
+    have h : (2 : ℝ) * Real.pi / 3 = Real.pi - Real.pi / 3 := by ring
+    rw [h, Real.cos_pi_sub, Real.cos_pi_div_three]
+  have c4 : Real.cos (4 * Real.pi / 3) = -(1 / 2) := by
+    have h : (4 : ℝ) * Real.pi / 3 = Real.pi / 3 + Real.pi := by ring
+    rw [h, Real.cos_add_pi, Real.cos_pi_div_three]
+  have s2 : Real.sin (2 * Real.pi / 3) = Real.sqrt 3 / 2 := by
+    have h : (2 : ℝ) * Real.pi / 3 = Real.pi - Real.pi / 3 := by ring
+    rw [h, Real.sin_pi_sub, Real.sin_pi_div_three]
+  have s4 : Real.sin (4 * Real.pi / 3) = -(Real.sqrt 3 / 2) := by
+    have h : (4 : ℝ) * Real.pi / 3 = Real.pi / 3 + Real.pi := by ring
+    rw [h, Real.sin_add_pi, Real.sin_pi_div_three]
+  rw [h2, h4, c2, c4, s2, s4]; ring
+
+/-- Their squares sum to `3/2`, for every phase `δ`. -/
+theorem cos_coords_sq_sum (δ : ℝ) :
+    Real.cos δ ^ 2 + Real.cos (δ + 2 * Real.pi / 3) ^ 2
+      + Real.cos (δ + 4 * Real.pi / 3) ^ 2 = 3 / 2 := by
+  have h2 : Real.cos (δ + 2 * Real.pi / 3)
+      = Real.cos δ * Real.cos (2 * Real.pi / 3) - Real.sin δ * Real.sin (2 * Real.pi / 3) :=
+    Real.cos_add _ _
+  have h4 : Real.cos (δ + 4 * Real.pi / 3)
+      = Real.cos δ * Real.cos (4 * Real.pi / 3) - Real.sin δ * Real.sin (4 * Real.pi / 3) :=
+    Real.cos_add _ _
+  have c2 : Real.cos (2 * Real.pi / 3) = -(1 / 2) := by
+    have h : (2 : ℝ) * Real.pi / 3 = Real.pi - Real.pi / 3 := by ring
+    rw [h, Real.cos_pi_sub, Real.cos_pi_div_three]
+  have c4 : Real.cos (4 * Real.pi / 3) = -(1 / 2) := by
+    have h : (4 : ℝ) * Real.pi / 3 = Real.pi / 3 + Real.pi := by ring
+    rw [h, Real.cos_add_pi, Real.cos_pi_div_three]
+  have s2 : Real.sin (2 * Real.pi / 3) = Real.sqrt 3 / 2 := by
+    have h : (2 : ℝ) * Real.pi / 3 = Real.pi - Real.pi / 3 := by ring
+    rw [h, Real.sin_pi_sub, Real.sin_pi_div_three]
+  have s4 : Real.sin (4 * Real.pi / 3) = -(Real.sqrt 3 / 2) := by
+    have h : (4 : ℝ) * Real.pi / 3 = Real.pi / 3 + Real.pi := by ring
+    rw [h, Real.sin_add_pi, Real.sin_pi_div_three]
+  have hsq3 : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  have pyth : Real.sin δ ^ 2 + Real.cos δ ^ 2 = 1 := Real.sin_sq_add_cos_sq δ
+  rw [h2, h4, c2, c4, s2, s4]
+  nlinarith [hsq3, pyth]
+
+/-- **The phase cancels.** For every `δ`, the signed Koide quotient of the circulant roots built
+from the actual cosine coordinates is `1/3 + (2/3)(b/a)^2` -- an expression in which `δ` does not
+appear. This is the unconditional form of `koide_formula`: no cosine hypothesis is assumed. -/
+theorem koide_quotient_phase_independent {a b : ℝ} (ha : a ≠ 0) (δ : ℝ) :
+    ((a + 2 * b * Real.cos δ) ^ 2
+        + (a + 2 * b * Real.cos (δ + 2 * Real.pi / 3)) ^ 2
+        + (a + 2 * b * Real.cos (δ + 4 * Real.pi / 3)) ^ 2)
+      / ((a + 2 * b * Real.cos δ)
+          + (a + 2 * b * Real.cos (δ + 2 * Real.pi / 3))
+          + (a + 2 * b * Real.cos (δ + 4 * Real.pi / 3))) ^ 2
+      = 1 / 3 + (2 / 3) * (b / a) ^ 2 := by
+  rw [root_sum (cos_coords_sum_zero δ),
+      root_square_sum (cos_coords_sum_zero δ) (cos_coords_sq_sum δ)]
+  exact koide_formula ha
+
 end OPH.KoideCirculant


### PR DESCRIPTION
`root_sum` and `root_square_sum` take the two cosine identities as **hypotheses** on abstract coordinates `c₀ c₁ c₂`:

```lean
theorem root_sum {a b c₀ c₁ c₂ : ℝ} (hcos : c₀ + c₁ + c₂ = 0) : ...
theorem root_square_sum ... (hcos : ...) (hcosSq : c₀^2 + c₁^2 + c₂^2 = 3/2) : ...
```

Theorem 9.1 of *Finite Observer Consensus as a Reconstruction Principle* **derives** them for the actual cosines at `2π/3` spacing, and that step is what makes "the phase δ cancels from Q" a theorem rather than an assumption:

> The three cosines at angles separated by 2π/3 sum to zero, and their squares sum to 3/2.

> The phase δ cancels from Q and jointly controls the two mass ratios, so the identity constrains one combination of the spectrum exactly while leaving two ratios free.

The module never instantiates those hypotheses at real cosines, so in Lean the phase-cancellation was assumed and derived only in prose. This PR closes exactly that step.

### Adds (module namespace; no existing result modified)

- `cos_coords_sum_zero (δ)` — `cos δ + cos (δ + 2π/3) + cos (δ + 4π/3) = 0`, for every `δ`
- `cos_coords_sq_sum (δ)` — the squares sum to `3/2`, for every `δ`
- `koide_quotient_phase_independent (ha : a ≠ 0) (δ)` — the signed Koide quotient of the roots `a + 2b·cos(δ + 2πk/3)` equals `1/3 + (2/3)(b/a)^2`, an expression in which `δ` does not appear

The corollary is proved by instantiating the module's own `root_sum`, `root_square_sum` and `koide_formula` at the real cosines, so it composes with the existing development and replaces nothing. `δ` appears on the left and is absent on the right: that is the cancellation.

### Scope deliberately unchanged

No physical-mass claim, no phase selection, no source-to-charged-family attachment; the nonnegative-eigenvalue chamber remains a premise. The module's existing scope docstring stays accurate. This is pure trigonometry making an algebraic identity unconditional — it adds no fitting and no physical attachment, so it is consistent with the `test_no_koide_import` guard on the charged-lepton lane (that guard scans `code/particles/leptons/*.py` and is untouched by this change).

### Verification

- `lake build ObserverPatchHolography.KoideCirculant` → **8248/8248 jobs, exit 0**
- `lake build ObserverPatchHolography` (the umbrella that imports it) → **8347/8347 jobs, exit 0**
- toolchain `leanprover/lean4:v4.29.1`, built against `main@e3918108`
- `#print axioms` on all three new results → `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no project axiom
- diff: 1 file, +76 / −0, additive only

### Reviewer note

The compiler confirms these statements are proved and axiom-clean. What it cannot confirm is that they are the *faithful* Lean reading of the paper's proof step — that judgement is worth a human check, and it is the only gate here a build cannot close.
