### PR TITLE
Keep per-change Lean CI below 30 minutes

### DIFF
--- a/.github/workflows/lean-ci.yml
+++ b/.github/workflows/lean-ci.yml
@@ -3,6 +3,7 @@ name: Lean CI
 on:
   workflow_dispatch:
   push:
+    branches: [main]
     paths:
       - "Lean/**"
       - "claims/frozen_prediction_register.json"
@@ -33,17 +34,18 @@ on:
       - "tools/check_lean_native_decide_inventory.py"
       - ".github/workflows/lean-ci.yml"
 
+concurrency:
+  group: lean-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    # A cold build (Mathlib source fallback plus the OPH libraries) exceeds
-    # any single-job limit on a two-core runner, and a job cancelled by
-    # timeout-minutes skips cache post-steps, so no progress was ever saved
-    # and every run restarted from zero. The build therefore runs under an
-    # internal time budget, the Lake directories are saved explicitly even
-    # when the budget expires, and the next run resumes from the saved
-    # state until it completes.
-    timeout-minutes: 350
+    # Keep every per-change Lean job below the repository's 30-minute CI
+    # ceiling. Internal budgets leave time to save resumable build artifacts
+    # before this hard job timeout. The expensive frozen OphGap certificate is
+    # checked independently in the parallel, change-aware job below.
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -51,6 +53,9 @@ jobs:
           # FZ-11 resolves and hashes its original and repaired proof blobs at
           # their declared commits, then checks the repair is a direct child.
           fetch-depth: 0
+
+      - name: Verify Lean CI runtime ceiling
+        run: python3 tools/check_lean_ci_budget.py
 
       - name: Install elan
         run: |
@@ -69,10 +74,12 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: |
-            Lean/.lake
-            Lean/ObservableNormalForms/.lake
-          key: lake2-${{ runner.os }}-${{ hashFiles('Lean/lean-toolchain', 'Lean/lakefile.lean', 'Lean/lake-manifest.json', 'Lean/ObservableNormalForms/lean-toolchain', 'Lean/ObservableNormalForms/lakefile.lean', 'Lean/ObservableNormalForms/lake-manifest.json') }}
+            Lean/.lake/build
+            Lean/ObservableNormalForms/.lake/build
+          key: lean-core-v3-${{ runner.os }}-${{ hashFiles('Lean/lean-toolchain', 'Lean/lakefile.lean', 'Lean/lake-manifest.json', 'Lean/ObservableNormalForms/lean-toolchain', 'Lean/ObservableNormalForms/lakefile.lean', 'Lean/ObservableNormalForms/lake-manifest.json') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
+            lean-core-v3-${{ runner.os }}-${{ hashFiles('Lean/lean-toolchain', 'Lean/lakefile.lean', 'Lean/lake-manifest.json', 'Lean/ObservableNormalForms/lean-toolchain', 'Lean/ObservableNormalForms/lakefile.lean', 'Lean/ObservableNormalForms/lake-manifest.json') }}-
+            lean-core-v3-${{ runner.os }}-
             lake2-${{ runner.os }}-${{ hashFiles('Lean/lean-toolchain', 'Lean/lakefile.lean', 'Lean/lake-manifest.json', 'Lean/ObservableNormalForms/lean-toolchain', 'Lean/ObservableNormalForms/lakefile.lean', 'Lean/ObservableNormalForms/lake-manifest.json') }}
             lake2-${{ runner.os }}-
 
@@ -102,7 +109,7 @@ jobs:
         run: |
           set -euo pipefail
           status=0
-          timeout 300m lake build 2>&1 | tee lake-build.log || status=$?
+          timeout 18m lake build 2>&1 | tee lake-build.log || status=$?
           echo "status=$status" >> "$GITHUB_OUTPUT"
           if [ "$status" -ne 0 ]; then
             echo "::warning::lake build stopped with exit $status (124 = time budget reached); progress is cached for the next run"
@@ -129,7 +136,7 @@ jobs:
         run: |
           set -euo pipefail
           status=0
-          timeout 60m lake build 2>&1 | tee onf-build.log || status=$?
+          timeout 5m lake build 2>&1 | tee onf-build.log || status=$?
           echo "status=$status" >> "$GITHUB_OUTPUT"
           if [ "$status" -ne 0 ]; then
             echo "::warning::ObservableNormalForms build stopped with exit $status; progress is cached for the next run"
@@ -140,9 +147,9 @@ jobs:
         if: always()
         with:
           path: |
-            Lean/.lake
-            Lean/ObservableNormalForms/.lake
-          key: lake2-${{ runner.os }}-${{ hashFiles('Lean/lean-toolchain', 'Lean/lakefile.lean', 'Lean/lake-manifest.json', 'Lean/ObservableNormalForms/lean-toolchain', 'Lean/ObservableNormalForms/lakefile.lean', 'Lean/ObservableNormalForms/lake-manifest.json') }}-${{ github.run_id }}
+            Lean/.lake/build
+            Lean/ObservableNormalForms/.lake/build
+          key: lean-core-v3-${{ runner.os }}-${{ hashFiles('Lean/lean-toolchain', 'Lean/lakefile.lean', 'Lean/lake-manifest.json', 'Lean/ObservableNormalForms/lean-toolchain', 'Lean/ObservableNormalForms/lakefile.lean', 'Lean/ObservableNormalForms/lake-manifest.json') }}-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Fail when the time budget expired before completion
         if: steps.budget_build.outputs.status != '0'
@@ -230,3 +237,133 @@ jobs:
 
       - name: Verify manifest unchanged
         run: git diff --exit-code -- Lean/lean-toolchain Lean/lakefile.lean Lean/lake-manifest.json
+
+  ophgap:
+    name: OphGap certificate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Detect OphGap-relevant changes
+        id: changes
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "required=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            base="$PR_BASE_SHA"
+            head="$PR_HEAD_SHA"
+          else
+            base="$BEFORE_SHA"
+            head="$GITHUB_SHA"
+          fi
+
+          if [ -z "$base" ] || [[ "$base" =~ ^0+$ ]] || ! git cat-file -e "$base^{commit}"; then
+            echo "required=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git diff --quiet "$base" "$head" -- \
+              Lean/OphGap Lean/OphGap.lean \
+              Lean/lean-toolchain Lean/lakefile.lean Lean/lake-manifest.json \
+              .github/workflows/lean-ci.yml; then
+            echo "required=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "required=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install elan
+        if: steps.changes.outputs.required == 'true'
+        run: |
+          set -euo pipefail
+          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf \
+            | sh -s -- -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+
+      - name: Print toolchain
+        if: steps.changes.outputs.required == 'true'
+        working-directory: Lean
+        run: |
+          lean --version
+          lake --version
+
+      - name: Restore OphGap build cache
+        if: steps.changes.outputs.required == 'true'
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            Lean/.lake/build/lib/lean/OphGap
+            Lean/.lake/build/lib/lean/OphGap.*
+            Lean/.lake/build/ir/OphGap
+            Lean/.lake/build/ir/OphGap.*
+          key: ophgap-v1-${{ runner.os }}-${{ hashFiles('Lean/lean-toolchain', 'Lean/lakefile.lean', 'Lean/lake-manifest.json') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            ophgap-v1-${{ runner.os }}-${{ hashFiles('Lean/lean-toolchain', 'Lean/lakefile.lean', 'Lean/lake-manifest.json') }}-
+            ophgap-v1-${{ runner.os }}-
+            lake2-${{ runner.os }}-${{ hashFiles('Lean/lean-toolchain', 'Lean/lakefile.lean', 'Lean/lake-manifest.json', 'Lean/ObservableNormalForms/lean-toolchain', 'Lean/ObservableNormalForms/lakefile.lean', 'Lean/ObservableNormalForms/lake-manifest.json') }}
+            lake2-${{ runner.os }}-
+
+      - name: Fetch Mathlib olean cache
+        if: steps.changes.outputs.required == 'true'
+        working-directory: Lean
+        run: |
+          set -euo pipefail
+          status=0
+          lake exe cache get 2>&1 | tee cache-get-ophgap.log || status=$?
+          tail -n 5 cache-get-ophgap.log || true
+          if [ "$status" -ne 0 ]; then
+            echo "::warning::lake exe cache get exited with $status; continuing under the proof budget"
+          fi
+
+      - name: Build OphGap under time budget
+        id: ophgap_build
+        if: steps.changes.outputs.required == 'true'
+        working-directory: Lean
+        run: |
+          set -euo pipefail
+          status=0
+          timeout 23m lake build OphGap 2>&1 | tee ophgap-build.log || status=$?
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          if [ "$status" -ne 0 ]; then
+            echo "::warning::OphGap stopped with exit $status (124 = time budget reached); progress is cached for the next run"
+          fi
+
+      - name: Save OphGap build cache
+        if: always() && steps.changes.outputs.required == 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            Lean/.lake/build/lib/lean/OphGap
+            Lean/.lake/build/lib/lean/OphGap.*
+            Lean/.lake/build/ir/OphGap
+            Lean/.lake/build/ir/OphGap.*
+          key: ophgap-v1-${{ runner.os }}-${{ hashFiles('Lean/lean-toolchain', 'Lean/lakefile.lean', 'Lean/lake-manifest.json') }}-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Fail when the OphGap budget expired before completion
+        if: steps.changes.outputs.required == 'true' && steps.ophgap_build.outputs.status != '0'
+        run: |
+          echo "The OphGap certificate did not complete within its 23-minute build budget." >&2
+          echo "Progress was saved; re-run this workflow to resume from the cache." >&2
+          exit 1
+
+      - name: Check OphGap proof debt
+        if: steps.changes.outputs.required == 'true'
+        run: |
+          set -euo pipefail
+          if rg -n '^\s*(sorry|admit)\b|:=\s*(sorry|admit)\b|^\s*axiom\b|\bby\s+native_decide\b' \
+              Lean/OphGap.lean Lean/OphGap --glob '*.lean'; then
+            echo "Unexpected proof debt in OphGap." >&2
+            exit 1
+          fi

--- a/.github/workflows/mandatory-suite.yml
+++ b/.github/workflows/mandatory-suite.yml
@@ -44,6 +44,7 @@ jobs:
     if: github.event_name != 'schedule'
     name: mandatory collection (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -65,6 +66,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+
+      - name: Regression-test the Lean CI runtime ceiling
+        run: python -m pytest -q tools/test_check_lean_ci_budget.py
 
       # #507: the mandatory suite is one documented command, identical here and
       # in REPRODUCE.md. It validates the scientific claim registry (#512),
@@ -94,6 +98,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+
+      - name: Regression-test the Lean CI runtime ceiling
+        run: python -m pytest -q tools/test_check_lean_ci_budget.py
 
       - name: Run the full mandatory suite
         run: python tools/run_mandatory_suite.py --full

--- a/Lean/OphGap/README.md
+++ b/Lean/OphGap/README.md
@@ -21,8 +21,9 @@ The project uses the toolchain named in `Lean/lean-toolchain`
 cd Lean && lake build OphGap
 ```
 
-The repository's Lean CI builds the proof on every push and pull request that
-touches `Lean/**`.
+`OphGap` is intentionally not a default Lake target. A dedicated Lean CI job
+builds it when its sources, pinned Lean inputs, or CI wiring change; unrelated
+Lean edits do not re-evaluate the frozen certificate.
 
 `OphGap/SignedGap.lean` proves, with zero `sorry`:
 

--- a/Lean/lakefile.lean
+++ b/Lean/lakefile.lean
@@ -18,7 +18,9 @@ lean_lib «ObservableNormalForms» where
 lean_lib «ObserverPatchHolography» where
   srcDir := "."
 
-@[default_target]
+-- The frozen 8,662-carrier certificate is deliberately opt-in.  Lean CI
+-- builds it in a dedicated, change-aware job so unrelated default builds do
+-- not inherit its sequential kernel-evaluation cost.
 lean_lib «OphGap» where
   srcDir := "."
   -- The folded proof predates this repository's project-wide explicit-binder

--- a/tools/check_lean_ci_budget.py
+++ b/tools/check_lean_ci_budget.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Fail closed if per-change Lean CI can again exceed thirty minutes."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "lean-ci.yml"
+LAKEFILE = ROOT / "Lean" / "lakefile.lean"
+
+
+def _job_block(workflow: str, name: str) -> str:
+    marker = f"  {name}:\n"
+    start = workflow.find(marker)
+    if start < 0:
+        raise ValueError(f"Lean CI is missing the {name!r} job")
+    end_match = re.search(r"(?m)^  [A-Za-z0-9_-]+:\s*$", workflow[start + len(marker) :])
+    if end_match is None:
+        return workflow[start:]
+    return workflow[start : start + len(marker) + end_match.start()]
+
+
+def validate(workflow: str, lakefile: str) -> list[str]:
+    errors: list[str] = []
+
+    default_ophgap = re.search(
+        r"@\[default_target\]\s*(?:(?:--[^\n]*)?\n\s*)*lean_lib\s+«OphGap»",
+        lakefile,
+    )
+    if default_ophgap:
+        errors.append("OphGap must not be a Lake default target")
+    if "lean_lib «OphGap»" not in lakefile:
+        errors.append("the OphGap Lake library is missing")
+
+    push_header = re.search(r"(?ms)^  push:\n(?P<body>.*?)(?=^  pull_request:)", workflow)
+    if push_header is None or "    branches: [main]" not in push_header.group("body"):
+        errors.append("Lean CI branch pushes must be limited to main")
+    if "cancel-in-progress: true" not in workflow:
+        errors.append("Lean CI must cancel superseded runs")
+
+    try:
+        build = _job_block(workflow, "build")
+        ophgap = _job_block(workflow, "ophgap")
+    except ValueError as exc:
+        errors.append(str(exc))
+        return errors
+
+    for name, block in (("build", build), ("ophgap", ophgap)):
+        match = re.search(r"(?m)^    timeout-minutes:\s*(\d+)\s*$", block)
+        if match is None:
+            errors.append(f"Lean CI {name!r} job has no hard timeout")
+        elif int(match.group(1)) > 30:
+            errors.append(f"Lean CI {name!r} job exceeds the 30-minute ceiling")
+
+    if "timeout 18m lake build" not in build:
+        errors.append("the default Lean build must retain its 18-minute resumable budget")
+    if "timeout 23m lake build OphGap" not in ophgap:
+        errors.append("the OphGap build must retain its 23-minute resumable budget")
+    if "Detect OphGap-relevant changes" not in ophgap:
+        errors.append("the OphGap job must remain change-aware")
+    for name, block in (("build", build), ("ophgap", ophgap)):
+        if "${{ github.run_attempt }}" not in block:
+            errors.append(f"Lean CI {name!r} cache keys must support resumable re-runs")
+    for path in (
+        "Lean/OphGap Lean/OphGap.lean",
+        "Lean/lean-toolchain Lean/lakefile.lean Lean/lake-manifest.json",
+        ".github/workflows/lean-ci.yml",
+    ):
+        if path not in ophgap:
+            errors.append(f"the OphGap change detector is missing {path!r}")
+
+    full_lake_cache = re.compile(r"(?m)^\s+Lean/(?:ObservableNormalForms/)?\.lake\s*$")
+    if full_lake_cache.search(workflow):
+        errors.append("Lean CI must cache build artifacts, not the full Lake dependency tree")
+
+    return errors
+
+
+def main() -> None:
+    errors = validate(
+        WORKFLOW.read_text(encoding="utf-8"),
+        LAKEFILE.read_text(encoding="utf-8"),
+    )
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        raise SystemExit(1)
+    print("Lean CI budget wiring: OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_check_lean_ci_budget.py
+++ b/tools/test_check_lean_ci_budget.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from tools.check_lean_ci_budget import LAKEFILE, WORKFLOW, validate
+
+
+def _inputs() -> tuple[str, str]:
+    return (
+        WORKFLOW.read_text(encoding="utf-8"),
+        LAKEFILE.read_text(encoding="utf-8"),
+    )
+
+
+def test_current_wiring_passes() -> None:
+    workflow, lakefile = _inputs()
+    assert validate(workflow, lakefile) == []
+
+
+def test_default_ophgap_target_is_rejected() -> None:
+    workflow, lakefile = _inputs()
+    mutated = lakefile.replace(
+        "lean_lib «OphGap» where",
+        "@[default_target]\nlean_lib «OphGap» where",
+        1,
+    )
+    assert "OphGap must not be a Lake default target" in validate(workflow, mutated)
+
+
+def test_job_over_thirty_minutes_is_rejected() -> None:
+    workflow, lakefile = _inputs()
+    mutated = workflow.replace("    timeout-minutes: 30", "    timeout-minutes: 31", 1)
+    assert "Lean CI 'build' job exceeds the 30-minute ceiling" in validate(mutated, lakefile)
+
+
+def test_full_lake_cache_is_rejected() -> None:
+    workflow, lakefile = _inputs()
+    mutated = workflow.replace("            Lean/.lake/build", "            Lean/.lake", 1)
+    assert (
+        "Lean CI must cache build artifacts, not the full Lake dependency tree"
+        in validate(mutated, lakefile)
+    )
+
+
+def test_nonresumable_cache_key_is_rejected() -> None:
+    workflow, lakefile = _inputs()
+    mutated = workflow.replace("-${{ github.run_attempt }}", "")
+    errors = validate(mutated, lakefile)
+    assert "Lean CI 'build' cache keys must support resumable re-runs" in errors
+    assert "Lean CI 'ophgap' cache keys must support resumable re-runs" in errors
+
+
+def test_duplicate_branch_and_pr_runs_are_rejected() -> None:
+    workflow, lakefile = _inputs()
+    mutated = workflow.replace("    branches: [main]\n", "", 1)
+    assert "Lean CI branch pushes must be limited to main" in validate(mutated, lakefile)
+
+
+def test_missing_superseded_run_cancellation_is_rejected() -> None:
+    workflow, lakefile = _inputs()
+    mutated = workflow.replace("  cancel-in-progress: true", "  cancel-in-progress: false", 1)
+    assert "Lean CI must cancel superseded runs" in validate(mutated, lakefile)


### PR DESCRIPTION
Follow-up to #757. OphGap is no longer a global Lake default target; a dedicated change-aware job builds the frozen certificate in parallel when its sources or pinned Lean inputs change. Both per-change Lean jobs have hard 30-minute limits and shorter resumable build budgets. Cache scope is reduced from the full 17 GB Lake tree to project build artifacts, with run-attempt-aware keys. A fail-closed checker and mutation tests prevent the expensive target, timeout, or full-cache regression from returning. Local validation: default Lake build, explicit OphGap build, standard mandatory suite, claim/public-surface gates, theorem-count gate, and five CI-budget mutation tests.