### PR TITLE
Add external Arithmon negative control for Koide balance

### DIFF
--- a/code/particles/data/arithmon_koide_cross_0.json
+++ b/code/particles/data/arithmon_koide_cross_0.json
@@ -1,0 +1,37 @@
+{
+  "schema": "oph.external_arithmon_koide_cross_fixture.v1",
+  "role": "external_framework_compare_only_version_pin",
+  "freeze": {
+    "arithmon_k7": {
+      "repository": "Arithmon/K7",
+      "commit": "af9224cf3bd0c7bb8a895b98d4d1146eb138b555",
+      "path": "docs/wiki/Observable-Reference.md",
+      "git_blob_sha": "646500c22e40fcd89d3584df7d64d5a9d452f754"
+    },
+    "arithmon_k7_lean": {
+      "repository": "Arithmon/K7-Lean",
+      "commit": "836296db191c49307f7df59aa0df989399a0b1bb",
+      "path": "GIFT/Relations/KoideAssembly.lean",
+      "git_blob_sha": "47ff66d563e50f64f73ad085490459f28ff0df85",
+      "theorem": "GIFT.Relations.KoideAssembly.koideQ_gift_lt_two_thirds",
+      "statement": "koideQ jordan_power_phi 3477 < 2 / 3"
+    }
+  },
+  "excluded_from_cross_input": {
+    "arithmon_own_koide_value": "2/3",
+    "reason": "KOIDE-CROSS-0 tests only the version-pinned Arithmon mass-pair formulas against OPH exact balance. Arithmon's own topological Koide value is context, not an input to the cross-check."
+  },
+  "experimental_data_consumed": false,
+  "version_pinned_arithmon_mass_pair": {
+    "normalization": "m_e = 1",
+    "m_mu_over_m_e": {
+      "formula": "27^phi",
+      "public_reference_status": "DERIVED"
+    },
+    "m_tau_over_m_e": {
+      "formula": "3477",
+      "public_reference_status": "DERIVED"
+    }
+  },
+  "prediction_freeze_claimed": false
+}

--- a/code/particles/leptons/koide_arithmon_cross_control.py
+++ b/code/particles/leptons/koide_arithmon_cross_control.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Pinned external Arithmon negative control for the exact OPH Koide balance.
+
+This is a compare-only same-quantity test, not a prediction freeze. OPH proves
+that its nonnegative balanced circulant has Q = 2/3 (with the positive chamber
+needed for the physical square-root-mass reading). Independently,
+Arithmon/K7-Lean proves Q(27^phi, 3477) < 2/3 for its public mass-pair formulas.
+The two receipts therefore cannot be realized simultaneously as one exact
+balanced positive-chamber charged-family spectrum.
+
+The exact theorems remain kernel-checked in separate repositories. Nothing in
+this file imports Arithmon as an OPH axiom, derives the charged-family
+attachment, or adjudicates either framework physically.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from decimal import Decimal, localcontext
+from pathlib import Path
+from typing import Any
+
+CODE_ROOT = Path(__file__).resolve().parents[2]
+REPO_ROOT = CODE_ROOT.parent
+FIXTURE = CODE_ROOT / "particles" / "data" / "arithmon_koide_cross_0.json"
+OUT = CODE_ROOT / "particles" / "runs" / "leptons" / "koide_arithmon_cross_0.json"
+OPH_KOIDE = REPO_ROOT / "Lean" / "ObserverPatchHolography" / "KoideCirculant.lean"
+
+PRECISION = 120
+EXPECTED = {
+    "fixture_schema": "oph.external_arithmon_koide_cross_fixture.v1",
+    "k7_commit": "af9224cf3bd0c7bb8a895b98d4d1146eb138b555",
+    "k7_blob": "646500c22e40fcd89d3584df7d64d5a9d452f754",
+    "lean_commit": "836296db191c49307f7df59aa0df989399a0b1bb",
+    "lean_blob": "47ff66d563e50f64f73ad085490459f28ff0df85",
+    "lean_theorem": "GIFT.Relations.KoideAssembly.koideQ_gift_lt_two_thirds",
+}
+
+ONE, TWO, THREE = Decimal(1), Decimal(2), Decimal(3)
+
+
+class CertificateError(ValueError):
+    pass
+
+
+def require(ok: bool, code: str) -> None:
+    if not ok:
+        raise CertificateError(code)
+
+
+def load_fixture() -> dict[str, Any]:
+    f = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    require(f.get("schema") == EXPECTED["fixture_schema"], "FIXTURE_SCHEMA")
+    k7, lean = f["freeze"]["arithmon_k7"], f["freeze"]["arithmon_k7_lean"]
+    require(
+        (k7["commit"], k7["git_blob_sha"])
+        == (EXPECTED["k7_commit"], EXPECTED["k7_blob"]),
+        "K7_SOURCE_PIN",
+    )
+    require(
+        (lean["commit"], lean["git_blob_sha"], lean["theorem"])
+        == (EXPECTED["lean_commit"], EXPECTED["lean_blob"], EXPECTED["lean_theorem"]),
+        "K7_LEAN_SOURCE_PIN",
+    )
+    pair = f["version_pinned_arithmon_mass_pair"]
+    require(pair["m_mu_over_m_e"]["formula"] == "27^phi", "MUON_FORMULA")
+    require(pair["m_tau_over_m_e"]["formula"] == "3477", "TAU_FORMULA")
+    require(f.get("experimental_data_consumed") is False, "EXPERIMENTAL_INPUT")
+    require(f.get("prediction_freeze_claimed") is False, "PREDICTION_FREEZE_SCOPE")
+    oph = OPH_KOIDE.read_text(encoding="utf-8")
+    require(
+        "theorem koide_eq_two_thirds_iff" in oph
+        and "ratio = 1 / Real.sqrt 2" in oph,
+        "OPH_KOIDE_THEOREM",
+    )
+    return f
+
+
+def koide_q(m_e: Decimal, m_mu: Decimal, m_tau: Decimal) -> Decimal:
+    roots = m_e.sqrt() + m_mu.sqrt() + m_tau.sqrt()
+    return (m_e + m_mu + m_tau) / roots**2
+
+
+def balance_roots(m1: Decimal, m2: Decimal) -> tuple[Decimal, Decimal]:
+    p, s = m1.sqrt() + m2.sqrt(), m1 + m2
+    d = Decimal(6) * p**2 - THREE * s
+    require(d > 0, "BALANCE_DISCRIMINANT")
+    r = d.sqrt()
+    return (TWO * p + r) ** 2, (TWO * p - r) ** 2
+
+
+def build_payload() -> dict[str, Any]:
+    fixture = load_fixture()
+    with localcontext() as ctx:
+        ctx.prec = PRECISION
+        phi = (ONE + Decimal(5).sqrt()) / TWO
+        mu = (phi * Decimal(27).ln()).exp()
+        tau = Decimal(3477)
+        target = TWO / THREE
+        q = koide_q(ONE, mu, tau)
+
+        tau_plus, tau_minus = balance_roots(ONE, mu)
+        mu_plus, mu_minus = balance_roots(ONE, tau)
+        require(q < target, "LOCAL_SIGN_MISMATCH")
+        require(tau_plus > mu > ONE and tau_minus < mu, "TAU_ROOT_ORDER")
+        require(ONE < mu_minus < tau and mu_plus > tau, "MU_ROOT_ORDER")
+
+        q_tau = koide_q(ONE, mu, tau_plus)
+        q_mu = koide_q(ONE, mu_minus, tau)
+        require(abs(q_tau - target) < Decimal("1e-110"), "TAU_REPAIR_CONTROL")
+        require(abs(q_mu - target) < Decimal("1e-110"), "MU_REPAIR_CONTROL")
+
+        txt = lambda x: format(+x, "f")
+        return {
+            "artifact": "oph_arithmon_koide_cross_0",
+            "schema": "oph.koide_arithmon_cross_0.v1",
+            "status": "EXTERNAL_NEGATIVE_CONTROL__ARITHMON_MASS_PAIR_INCOMPATIBLE_WITH_EXACT_OPH_BALANCE",
+            "claim_class": "external_negative_control",
+            "issue_context": [546, 736],
+            "source_only_physical_prediction": False,
+            "prospective_prediction_freeze": False,
+            "public_physical_promotion_allowed": False,
+            "formal_composition_in_one_kernel": False,
+            "experimental_data_consumed": False,
+            "claim_boundary": (
+                "Compare-only same-quantity compatibility test. OPH and Arithmon exact receipts "
+                "are kernel-checked in separate repositories and version-pinned here, but not "
+                "composed in one Lean environment. No Arithmon statement is imported as an OPH "
+                "premise; no charged-family attachment or physical adjudication is claimed."
+            ),
+            "same_quantity_bridge": {
+                "quantity": "Q = (m_e + m_mu + m_tau) / (sqrt(m_e) + sqrt(m_mu) + sqrt(m_tau))^2",
+                "normalization": "m_e = 1 (scale invariance)",
+                "oph_scope": "positive-chamber exact balanced circulant implies Q = 2/3",
+            },
+            "pinned_receipts": {
+                "oph": {
+                    "path": "Lean/ObserverPatchHolography/KoideCirculant.lean",
+                    "theorem": "OPH.KoideCirculant.koide_eq_two_thirds_iff",
+                },
+                "arithmon": fixture["freeze"],
+            },
+            "version_pinned_arithmon_inputs": fixture["version_pinned_arithmon_mass_pair"],
+            "local_recompute": {
+                "decimal_precision": PRECISION,
+                "m_mu_over_m_e": txt(mu),
+                "m_tau_over_m_e": txt(tau),
+                "Q": txt(q),
+                "Q_minus_two_thirds": txt(q - target),
+                "strictly_below_two_thirds": True,
+            },
+            "logical_verdict": {
+                "oph_exact_balance_requires": "Q = 2/3",
+                "arithmon_exact_external_receipt": "Q(27^phi, 3477) < 2/3",
+                "joint_exact_realization_possible": False,
+                "scope": "version-pinned Arithmon mass pair versus exact balanced positive-chamber OPH spectrum",
+            },
+            "controls": {
+                "replace_tau_by_balance_root": {
+                    "replacement_m_tau_over_m_e": txt(tau_plus),
+                    "delta": txt(tau_plus - tau),
+                    "abs_Q_minus_two_thirds_after_replacement": txt(abs(q_tau - target)),
+                    "restores_exact_balance_numerically": True,
+                },
+                "replace_muon_by_balance_root": {
+                    "replacement_m_mu_over_m_e": txt(mu_minus),
+                    "delta": txt(mu_minus - mu),
+                    "abs_Q_minus_two_thirds_after_replacement": txt(abs(q_mu - target)),
+                    "restores_exact_balance_numerically": True,
+                },
+            },
+            "checks": {
+                "external_source_pins_match_fixture": True,
+                "current_oph_koide_theorem_surface_present": True,
+                "no_experimental_mass_input": True,
+                "local_sign_matches_external_exact_receipt": True,
+                "balance_root_controls_close": True,
+            },
+            "checks_pass": True,
+        }
+
+
+def canonical(payload: dict[str, Any]) -> bytes:
+    return (json.dumps(payload, indent=2, ensure_ascii=False) + "\n").encode()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--output", type=Path, default=OUT)
+    ap.add_argument("--check", action="store_true")
+    args = ap.parse_args()
+    expected = canonical(build_payload())
+    if args.check:
+        require(args.output.is_file(), "OUTPUT_MISSING")
+        require(args.output.read_bytes() == expected, "OUTPUT_STALE")
+    else:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_bytes(expected)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/particles/leptons/test_koide_balance_comparison_certificate.py
+++ b/code/particles/leptons/test_koide_balance_comparison_certificate.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Regression and adversarial tests for the Koide balance certificate."""
+"""Regression and adversarial tests for the Koide balance certificates."""
 
 from __future__ import annotations
 
@@ -12,6 +12,7 @@ from pathlib import Path
 MODULE_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(MODULE_DIR))
 
+import koide_arithmon_cross_control as cross  # noqa: E402
 import koide_balance_comparison_certificate as cert  # noqa: E402
 
 
@@ -62,6 +63,63 @@ class KoideBalanceTests(unittest.TestCase):
         boundary = self.payload["claim_boundary"]
         self.assertIn("measured-target ancestry", boundary)
         self.assertIn("neither lane is a prospective prediction", boundary.lower())
+
+
+class KoideArithmonCrossTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.payload = cross.build_payload()
+
+    def test_stored_cross_certificate_matches_rebuild(self) -> None:
+        stored = json.loads(cross.OUT.read_text(encoding="utf-8"))
+        self.assertEqual(stored, self.payload)
+
+    def test_cross_fixture_is_version_pinned_and_target_free(self) -> None:
+        fixture = cross.load_fixture()
+        self.assertFalse(fixture["experimental_data_consumed"])
+        self.assertFalse(fixture["prediction_freeze_claimed"])
+        self.assertEqual(
+            fixture["freeze"]["arithmon_k7_lean"]["theorem"],
+            cross.EXPECTED["lean_theorem"],
+        )
+        self.assertEqual(
+            fixture["version_pinned_arithmon_mass_pair"]["m_mu_over_m_e"]["formula"],
+            "27^phi",
+        )
+        self.assertEqual(
+            fixture["version_pinned_arithmon_mass_pair"]["m_tau_over_m_e"]["formula"],
+            "3477",
+        )
+
+    def test_local_recompute_has_the_pinned_strict_sign(self) -> None:
+        row = self.payload["local_recompute"]
+        self.assertTrue(row["strictly_below_two_thirds"])
+        self.assertLess(Decimal(row["Q_minus_two_thirds"]), Decimal(0))
+        self.assertLess(Decimal(row["Q"]), Decimal(2) / Decimal(3))
+
+    def test_joint_exact_realization_is_excluded_only_at_declared_scope(self) -> None:
+        verdict = self.payload["logical_verdict"]
+        self.assertFalse(verdict["joint_exact_realization_possible"])
+        self.assertIn("balanced positive-chamber", verdict["scope"])
+        self.assertFalse(self.payload["formal_composition_in_one_kernel"])
+        self.assertFalse(self.payload["public_physical_promotion_allowed"])
+        self.assertFalse(self.payload["prospective_prediction_freeze"])
+
+    def test_balance_root_mutations_close_the_gap(self) -> None:
+        for name, control in self.payload["controls"].items():
+            self.assertTrue(control["restores_exact_balance_numerically"], name)
+            self.assertLess(
+                Decimal(control["abs_Q_minus_two_thirds_after_replacement"]),
+                Decimal("1e-110"),
+                name,
+            )
+
+    def test_cross_boundary_does_not_adjudicate_physics(self) -> None:
+        boundary = self.payload["claim_boundary"].lower()
+        self.assertIn("compare-only", boundary)
+        self.assertIn("not composed in one lean environment", boundary)
+        self.assertIn("physical adjudication", boundary)
+        self.assertFalse(self.payload["experimental_data_consumed"])
 
 
 if __name__ == "__main__":

--- a/code/particles/runs/leptons/koide_arithmon_cross_0.json
+++ b/code/particles/runs/leptons/koide_arithmon_cross_0.json
@@ -1,0 +1,90 @@
+{
+  "artifact": "oph_arithmon_koide_cross_0",
+  "schema": "oph.koide_arithmon_cross_0.v1",
+  "status": "EXTERNAL_NEGATIVE_CONTROL__ARITHMON_MASS_PAIR_INCOMPATIBLE_WITH_EXACT_OPH_BALANCE",
+  "claim_class": "external_negative_control",
+  "issue_context": [
+    546,
+    736
+  ],
+  "source_only_physical_prediction": false,
+  "prospective_prediction_freeze": false,
+  "public_physical_promotion_allowed": false,
+  "formal_composition_in_one_kernel": false,
+  "experimental_data_consumed": false,
+  "claim_boundary": "Compare-only same-quantity compatibility test. OPH and Arithmon exact receipts are kernel-checked in separate repositories and version-pinned here, but not composed in one Lean environment. No Arithmon statement is imported as an OPH premise; no charged-family attachment or physical adjudication is claimed.",
+  "same_quantity_bridge": {
+    "quantity": "Q = (m_e + m_mu + m_tau) / (sqrt(m_e) + sqrt(m_mu) + sqrt(m_tau))^2",
+    "normalization": "m_e = 1 (scale invariance)",
+    "oph_scope": "positive-chamber exact balanced circulant implies Q = 2/3"
+  },
+  "pinned_receipts": {
+    "oph": {
+      "path": "Lean/ObserverPatchHolography/KoideCirculant.lean",
+      "theorem": "OPH.KoideCirculant.koide_eq_two_thirds_iff"
+    },
+    "arithmon": {
+      "arithmon_k7": {
+        "repository": "Arithmon/K7",
+        "commit": "af9224cf3bd0c7bb8a895b98d4d1146eb138b555",
+        "path": "docs/wiki/Observable-Reference.md",
+        "git_blob_sha": "646500c22e40fcd89d3584df7d64d5a9d452f754"
+      },
+      "arithmon_k7_lean": {
+        "repository": "Arithmon/K7-Lean",
+        "commit": "836296db191c49307f7df59aa0df989399a0b1bb",
+        "path": "GIFT/Relations/KoideAssembly.lean",
+        "git_blob_sha": "47ff66d563e50f64f73ad085490459f28ff0df85",
+        "theorem": "GIFT.Relations.KoideAssembly.koideQ_gift_lt_two_thirds",
+        "statement": "koideQ jordan_power_phi 3477 < 2 / 3"
+      }
+    }
+  },
+  "version_pinned_arithmon_inputs": {
+    "normalization": "m_e = 1",
+    "m_mu_over_m_e": {
+      "formula": "27^phi",
+      "public_reference_status": "DERIVED"
+    },
+    "m_tau_over_m_e": {
+      "formula": "3477",
+      "public_reference_status": "DERIVED"
+    }
+  },
+  "local_recompute": {
+    "decimal_precision": 120,
+    "m_mu_over_m_e": "207.011856741603477932023309743594823644725221283538880551381359828877756318984959895950624333364622307025208080359545420",
+    "m_tau_over_m_e": "3477",
+    "Q": "0.666546162072081219458353176639518748624547259848002503084853069410638338349083512162447343137410477312783795195609372091",
+    "Q_minus_two_thirds": "-0.000120504594585447208313490027147918042119406818664163581813597256028328317583154504219323529256189353882871471057294576",
+    "strictly_below_two_thirds": true
+  },
+  "logical_verdict": {
+    "oph_exact_balance_requires": "Q = 2/3",
+    "arithmon_exact_external_receipt": "Q(27^phi, 3477) < 2/3",
+    "joint_exact_realization_possible": false,
+    "scope": "version-pinned Arithmon mass pair versus exact balanced positive-chamber OPH spectrum"
+  },
+  "controls": {
+    "replace_tau_by_balance_root": {
+      "replacement_m_tau_over_m_e": "3481.17920940240697424020209590644711858652270668296616323378298594524614866324965534731436991096270534404812629144221203",
+      "delta": "4.17920940240697424020209590644711858652270668296616323378298594524614866324965534731436991096270534404812629144221203",
+      "abs_Q_minus_two_thirds_after_replacement": "0.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+      "restores_exact_balance_numerically": true
+    },
+    "replace_muon_by_balance_root": {
+      "replacement_m_mu_over_m_e": "206.739502561980981002197866144983268634334750230174505012663559557095241483016436643098359330789714327479903831751282112",
+      "delta": "-0.272354179622496929825443598611555010390471053364375538717800271782514835968523252852265002574907979545304248608263308",
+      "abs_Q_minus_two_thirds_after_replacement": "0.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+      "restores_exact_balance_numerically": true
+    }
+  },
+  "checks": {
+    "external_source_pins_match_fixture": true,
+    "current_oph_koide_theorem_surface_present": true,
+    "no_experimental_mass_input": true,
+    "local_sign_matches_external_exact_receipt": true,
+    "balance_root_controls_close": true
+  },
+  "checks_pass": true
+}


### PR DESCRIPTION
## Summary

This PR adds a pinned external negative control for the exact OPH Koide balance.

OPH proves that the balanced nonnegative circulant has \(Q=2/3\), with the positive chamber required for the physical square-root-mass reading. Independently, public Arithmon receipts provide the version-pinned mass pair
`m_mu/m_e = 27^phi`, `m_tau/m_e = 3477`, and `Arithmon/K7-Lean` proves the strict result
`Q(27^phi, 3477) < 2/3`.

KOIDE-CROSS-0 pins those external sources and recomputes the same scale-invariant Koide quantity locally. No experimental lepton masses are consumed.

Two mutation controls replace either the tau or muon ratio by the corresponding exact-balance root and recover \(Q=2/3\), checking that the incompatibility detector is load-bearing.

## Boundary

This is a compare-only external-framework control, not a prospective prediction freeze.

The OPH and Arithmon results are kernel-checked in their respective repositories but are **not composed in one Lean kernel** here. No Arithmon statement is imported as an OPH axiom, no charged-family physical attachment is derived, and the result does not adjudicate which framework is physically correct.

The conclusion is only that the version-pinned Arithmon mass pair cannot simultaneously be an exact balanced positive-chamber OPH charged-family spectrum.

## Checks

* deterministic artifact regeneration / stale-output check
* exact external source pins
* zero experimental-mass input
* local sign agrees with the pinned Arithmon theorem
* balance-root mutation controls
* regression coverage through the existing Koide test surface